### PR TITLE
Yet another compile error regarding INFINITY

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -43,6 +43,12 @@
 #define rb_eEncodingError	rb_eException
 #endif
 
+//Workaround:
+#ifndef INFINITY
+#define INFINITY (1.0/0.0)
+#endif
+      
+
 typedef unsigned long	ulong;
 
 typedef struct _Out {


### PR DESCRIPTION
```
dump.c: In function ‘dump_float’:
dump.c:423: error: ‘INFINITY’ undeclared (first use in this function)
dump.c:423: error: (Each undeclared identifier is reported only once
dump.c:423: error: for each function it appears in.
```

I had the result shown above trying to gem install oj on a Lenny-Box while on rvm-1.8.7-p352. I tried (as for now successfully) to apply the workaround in load.c to dump.c aswell. Maybe it'll help, as long as the tests (which I can't seem to run in a timely fashion due to the lack of rbenv on my system) didn't crash.

Cheers,
Sebastian
