### PR TITLE
Correctly print double numbers like 1.0

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -437,8 +437,8 @@ dump_float(VALUE obj, Out out) {
 	strcpy(buf, "-Infinity");
 	cnt = 9;
     } else {
-	cnt = sprintf(buf, "%0.16g", d); // used sprintf due to bug in snprintf
-    }	
+	cnt = sprintf(buf, (d - ((long)d)) ? "%0.16g" : "%.1f", d); // used sprintf due to bug in snprintf
+    }
     if (out->end - out->cur <= (long)cnt) {
 	grow(out, cnt);
     }


### PR DESCRIPTION
Right now when a double number e.g. `1.0` is dumped, Oj converts it to just `1` (integer) instead of `1.0` (float). This commit fixes it and now Oj handles the kind of numbers as expected.

I don't believe this change would make Oj slow. I tested it by looping it 10 million times and the difference(about 10 - 20ms) isn't significant. Here is the code I used to measure the performance:

``` c
#include <stdio.h>

int main(){
  char buf[64];
  double d = -3.14; // or something like 1.0 or -3.0
  int i;

  for(i = 0; i < 10000000; i++) {
    sprintf(buf, (d - (long)d) ? "%0.16g" : "%.1f", d);
    // or use the next line to make a comparison.
    // sprintf(buf, "%0.16g", d);
  }

  return 0;
}
```

(compiled with `-O0` option, measured using `time` cmd)

Surprisingly, when the value is e.g. `1.0`, it is actually faster than the current implementation. I guess this is because `"%.1f"` is faster than `"%0.16g"`.

As you can see, all the tests pass on travis. Also feel free to change the conditional operator to `if ... else ...` if you don't like it.
