### PR TITLE
BigDecimal should dump to a String, at least in compat mode

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -1074,14 +1074,8 @@ dump_data_comp(VALUE obj, Out out) {
     } else {
 	VALUE	rstr;
 
-	if (oj_bigdecimal_class == clas) {
-	    //rstr = rb_funcall(obj, oj_to_s_id, 1, rb_intern("E"));
-	    rstr = rb_funcall(obj, oj_to_s_id, 0);
-	    dump_raw(StringValuePtr(rstr), RSTRING_LEN(rstr), out);
-	} else {
-	    rstr = rb_funcall(obj, oj_to_s_id, 0);
-	    dump_cstr(StringValuePtr(rstr), RSTRING_LEN(rstr), 0, 0, out);
-	}
+	rstr = rb_funcall(obj, oj_to_s_id, 0);
+	dump_cstr(StringValuePtr(rstr), RSTRING_LEN(rstr), 0, 0, out);
     }
 }
 

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -666,10 +666,10 @@ class Juice < ::Test::Unit::TestCase
     Oj.default_options = {:mode => mode}
   end
   def test_bigdecimal_compat
-    orig = BigDecimal.new('3.14159265358979323846')
+    orig = BigDecimal.new('80.51')
     json = Oj.dump(orig, :mode => :compat)
     bg = Oj.load(json, :mode => :compat)
-    assert_equal(orig, bg)
+    assert_equal(orig.to_s, bg)
   end
   def test_bigdecimal_object
     mode = Oj.default_options[:mode]


### PR DESCRIPTION
The vast majority of JSON libraries across various languages load JSON numeric data types in using floating point numbers. The only safe way to maintain the precision of BigDecimal languages with 3rd party clients is to encode the data in JSON as a String and allow client code downstream from the JSON decoder use the correct language data type. This behavior is mirrored in the JSON gem, Yajl gem, and ActiveSupport.

I left the other modes alone because I'm not sure what the loss of precision means for people who use these modes. 80.51 is one such number that, at least in Ruby 1.9, won't be equal between a Float and a BigDecimal.

``` ruby
gem 'json'
require 'json'
require 'bigdecimal'
JSON.dump(BigDecimal.new("1.01")) #=> "\"0.101E1\"" 
```

``` ruby
require 'bigdecimal'
require 'yajl'
Yajl::Encoder.encode(BigDecimal.new("1.01")) #=> "\"0.101E1\""
```

``` ruby
require 'active_support/json'
BigDecimal.new("1.01").as_json #=> "1.01" 
BigDecimal.new("1.01").to_json #=> "\"1.01\""
```
