### PR TITLE
BigDecimal encoded differently in compat mode

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -1194,8 +1194,7 @@ dump_obj_comp(VALUE obj, int depth, Out out) {
 	if (oj_bigdecimal_class == clas) {
 	    VALUE	rstr = rb_funcall(obj, oj_to_s_id, 0);
 
-	    //dump_raw(StringValuePtr(rstr), RSTRING_LEN(rstr), out);
-	    dump_cstr(StringValuePtr(rstr), RSTRING_LEN(rstr), 0, 0, out);
+	    dump_raw(StringValuePtr(rstr), RSTRING_LEN(rstr), out);
 	} else {
 	    Odd	odd = oj_get_odd(clas);
 


### PR DESCRIPTION
In compat mode, BigDecimals are encoded as strings. In other modes, they are numbers. This is probably a mistake, because the correct code appears to be accidenatlly commented out in 7a573f2810dbd33ed163bde91b00bff333a328bb.

This PR reverts it and fixes the problem.

```
Oj.dump(BigDecimal.new("7"), mode: :strict)
=> 0.7E1
Oj.dump(BigDecimal.new("7"), mode: :object)
=> 0.7E1
Oj.dump(BigDecimal.new("7"), mode: :compat)
=> "0.7E1"
```
