### PR TITLE
Guard usage where callbacks into Ruby land can cause crashes

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -585,6 +585,8 @@ dump_array(VALUE a, int depth, Out out) {
     if (id < 0) {
 	return;
     }
+
+    RB_GC_GUARD(a);
     np = RARRAY_PTR(a);
     cnt = (int)RARRAY_LEN(a);
     *out->cur++ = '[';
@@ -1199,6 +1201,7 @@ dump_data_obj(VALUE obj, int depth, Out out) {
 
 static void
 dump_obj_comp(VALUE obj, int depth, Out out) {
+    RB_GC_GUARD(obj);
     if (rb_respond_to(obj, oj_to_hash_id)) {
 	VALUE	h = rb_funcall(obj, oj_to_hash_id, 0);
  


### PR DESCRIPTION
Also check http://timetobleed.com/the-broken-promises-of-mrireeyarv/ for
more explanation on this problem. If you call back into Ruby, it can
easily lead to a new object allocation somewhere.

This fixes a crash we experienced when benchmarking an application using
Oj on Ruby 2.0.0p247.
