### PR TITLE
restore old struct loading behavior while still avoiding segfaults

### DIFF
--- a/ext/oj/object.c
+++ b/ext/oj/object.c
@@ -196,11 +196,28 @@ hat_value(ParseInfo pi, Val parent, const char *key, size_t klen, volatile VALUE
             // Create a properly initialized struct instance without calling the initialize method.
             parent->val = rb_obj_alloc(sc);
             // If the JSON array has more entries than the struct class allows, we record an error.
+#if HAVE_RSTRUCT
+            // MRI >= 1.9
             if (len-1 > RSTRUCT_LEN(parent->val)) {
 		oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "Invalid struct data");
             } else {
                 MEMCPY(RSTRUCT_PTR(parent->val), RARRAY_PTR(value)+1, VALUE, len-1);
             }
+#else
+            {
+              // MRI < 1.9 or Rubinius
+              VALUE sz = rb_funcall2(parent->val, oj_length_id, 0, 0);
+              int length = FIX2INT(sz);
+              int i;
+              if (len-1 > length) {
+		oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "Invalid struct data");
+              } else {
+                for (i=0; i<length; i++) {
+                  rb_struct_aset(parent->val, INT2FIX(i), RARRAY_PTR(value)[i+1]);
+                }
+              }
+            } while(0);
+#endif
 	    return 1;
 	} else if (3 <= klen && '#' == key[1]) {
 	    volatile VALUE	*a;

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -64,6 +64,7 @@ ID	oj_hash_start_id;
 ID	oj_iconv_id;
 ID	oj_instance_variables_id;
 ID	oj_json_create_id;
+ID	oj_length_id;
 ID	oj_new_id;
 ID	oj_read_id;
 ID	oj_string_id;
@@ -1248,6 +1249,7 @@ void Init_oj() {
     oj_iconv_id = rb_intern("iconv");
     oj_instance_variables_id = rb_intern("instance_variables");
     oj_json_create_id = rb_intern("json_create");
+    oj_length_id = rb_intern("length");
     oj_new_id = rb_intern("new");
     oj_read_id = rb_intern("read");
     oj_string_id = rb_intern("string");

--- a/ext/oj/oj.h
+++ b/ext/oj/oj.h
@@ -217,6 +217,7 @@ extern ID	oj_hash_start_id;
 extern ID	oj_iconv_id;
 extern ID	oj_instance_variables_id;
 extern ID	oj_json_create_id;
+extern ID	oj_length_id;
 extern ID	oj_new_id;
 extern ID	oj_read_id;
 extern ID	oj_string_id;


### PR DESCRIPTION
rb_obj_alloc() safely creates a properly initialized struct instance, without calling the initialize method of the struct.

This restores pre 2.2.3 behavior. In the future, one could think of make struct loading behavior configurable.

 If so, the code for creating the instance would be:

``` c
    parent->val = rb_class_new_instance(len - 1, RARRAY_PTR(value)+1, sc);
```
