### PR TITLE
Null bytes in strings

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -426,7 +426,7 @@ dump_bignum(VALUE obj, Out out) {
     if (out->end - out->cur <= (long)cnt) {
 	grow(out, cnt);
     }
-    memcpy(out->cur, rb_string_value_cstr((VALUE*)&rs), cnt);
+    memcpy(out->cur, rb_string_value_ptr((VALUE*)&rs), cnt);
     out->cur += cnt;
     *out->cur = '\0';
 }
@@ -554,12 +554,12 @@ dump_cstr(const char *str, size_t cnt, int is_sym, int escape1, Out out) {
 
 static void
 dump_str_comp(VALUE obj, Out out) {
-    dump_cstr(rb_string_value_cstr((VALUE*)&obj), RSTRING_LEN(obj), 0, 0, out);
+    dump_cstr(rb_string_value_ptr((VALUE*)&obj), RSTRING_LEN(obj), 0, 0, out);
 }
 
 static void
 dump_str_obj(VALUE obj, Out out) {
-    const char	*s = rb_string_value_cstr((VALUE*)&obj);
+    const char	*s = rb_string_value_ptr((VALUE*)&obj);
     size_t	len = RSTRING_LEN(obj);
     char	s1 = s[1];
 
@@ -1023,7 +1023,7 @@ static void
 dump_ruby_time(VALUE obj, Out out) {
     volatile VALUE	rstr = rb_funcall(obj, oj_to_s_id, 0);
 
-    dump_cstr(rb_string_value_cstr((VALUE*)&rstr), RSTRING_LEN(rstr), 0, 0, out);
+    dump_cstr(rb_string_value_ptr((VALUE*)&rstr), RSTRING_LEN(rstr), 0, 0, out);
 }
 
 static void
@@ -1121,7 +1121,7 @@ dump_data_strict(VALUE obj, Out out) {
     if (oj_bigdecimal_class == clas) {
 	volatile VALUE	rstr = rb_funcall(obj, oj_to_s_id, 0);
 
-	dump_raw(rb_string_value_cstr((VALUE*)&rstr), RSTRING_LEN(rstr), out);
+	dump_raw(rb_string_value_ptr((VALUE*)&rstr), RSTRING_LEN(rstr), out);
     } else {
 	raise_strict(obj);
     }
@@ -1134,7 +1134,7 @@ dump_data_null(VALUE obj, Out out) {
     if (oj_bigdecimal_class == clas) {
 	volatile VALUE	rstr = rb_funcall(obj, oj_to_s_id, 0);
 
-	dump_raw(rb_string_value_cstr((VALUE*)&rstr), RSTRING_LEN(rstr), out);
+	dump_raw(rb_string_value_ptr((VALUE*)&rstr), RSTRING_LEN(rstr), out);
     } else {
 	dump_nil(out);
     }
@@ -1161,7 +1161,7 @@ dump_data_comp(VALUE obj, int depth, Out out) {
 	last_obj = obj;
 	rs = rb_funcall(obj, oj_to_json_id, 0);
 	last_obj = Qundef;
-	s = rb_string_value_cstr((VALUE*)&rs);
+	s = rb_string_value_ptr((VALUE*)&rs);
 	len = (int)RSTRING_LEN(rs);
 
 	if (out->end - out->cur <= len + 1) {
@@ -1184,14 +1184,14 @@ dump_data_comp(VALUE obj, int depth, Out out) {
 	    volatile VALUE	rstr = rb_funcall(obj, oj_to_s_id, 0);
 
 	    if (Yes == out->opts->bigdec_as_num) {
-		dump_raw(rb_string_value_cstr((VALUE*)&rstr), RSTRING_LEN(rstr), out);
+		dump_raw(rb_string_value_ptr((VALUE*)&rstr), RSTRING_LEN(rstr), out);
 	    } else {
-		dump_cstr(rb_string_value_cstr((VALUE*)&rstr), RSTRING_LEN(rstr), 0, 0, out);
+		dump_cstr(rb_string_value_ptr((VALUE*)&rstr), RSTRING_LEN(rstr), 0, 0, out);
 	    }
 	} else {
 	    volatile VALUE	rstr = rb_funcall(obj, oj_to_s_id, 0);
 
-	    dump_cstr(rb_string_value_cstr((VALUE*)&rstr), RSTRING_LEN(rstr), 0, 0, out);
+	    dump_cstr(rb_string_value_ptr((VALUE*)&rstr), RSTRING_LEN(rstr), 0, 0, out);
 	}
     }
 }
@@ -1221,9 +1221,9 @@ dump_data_obj(VALUE obj, int depth, Out out) {
 		volatile VALUE	rstr = rb_funcall(obj, oj_to_s_id, 0);
 		
 		if (Yes == out->opts->bigdec_as_num) {
-		    dump_raw(rb_string_value_cstr((VALUE*)&rstr), RSTRING_LEN(rstr), out);
+		    dump_raw(rb_string_value_ptr((VALUE*)&rstr), RSTRING_LEN(rstr), out);
 		} else {
-		    dump_cstr(rb_string_value_cstr((VALUE*)&rstr), RSTRING_LEN(rstr), 0, 0, out);
+		    dump_cstr(rb_string_value_ptr((VALUE*)&rstr), RSTRING_LEN(rstr), 0, 0, out);
 		}
 	    } else {
 		dump_nil(out);
@@ -1255,7 +1255,7 @@ dump_obj_comp(VALUE obj, int depth, Out out) {
 	last_obj = obj;
 	rs = rb_funcall(obj, oj_to_json_id, 0);
 	last_obj = Qundef;
-	s = rb_string_value_cstr((VALUE*)&rs);
+	s = rb_string_value_ptr((VALUE*)&rs);
 	len = (int)RSTRING_LEN(rs);
 
 	if (out->end - out->cur <= len + 1) {
@@ -1271,14 +1271,14 @@ dump_obj_comp(VALUE obj, int depth, Out out) {
 	    volatile VALUE	rstr = rb_funcall(obj, oj_to_s_id, 0);
 
 	    if (Yes == out->opts->bigdec_as_num) {
-		dump_raw(rb_string_value_cstr((VALUE*)&rstr), RSTRING_LEN(rstr), out);
+		dump_raw(rb_string_value_ptr((VALUE*)&rstr), RSTRING_LEN(rstr), out);
 	    } else {
-		dump_cstr(rb_string_value_cstr((VALUE*)&rstr), RSTRING_LEN(rstr), 0, 0, out);
+		dump_cstr(rb_string_value_ptr((VALUE*)&rstr), RSTRING_LEN(rstr), 0, 0, out);
 	    }
 	} else if (oj_datetime_class == clas || oj_date_class == clas) {
 	    volatile VALUE	rstr = rb_funcall(obj, oj_to_s_id, 0);
 
-	    dump_cstr(rb_string_value_cstr((VALUE*)&rstr), RSTRING_LEN(rstr), 0, 0, out);
+	    dump_cstr(rb_string_value_ptr((VALUE*)&rstr), RSTRING_LEN(rstr), 0, 0, out);
 	} else {
 	    Odd	odd = oj_get_odd(clas);
 
@@ -1304,7 +1304,7 @@ dump_obj_obj(VALUE obj, int depth, Out out) {
 	    if (oj_bigdecimal_class == clas) {
 		volatile VALUE	rstr = rb_funcall(obj, oj_to_s_id, 0);
 
-		dump_raw(rb_string_value_cstr((VALUE*)&rstr), RSTRING_LEN(rstr), out);
+		dump_raw(rb_string_value_ptr((VALUE*)&rstr), RSTRING_LEN(rstr), out);
 	    } else {
 		dump_obj_attrs(obj, clas, id, depth, out);
 	    }
@@ -1496,7 +1496,7 @@ dump_struct_comp(VALUE obj, int depth, Out out) {
 	const char	*s;
 	int		len;
 
-	s = rb_string_value_cstr((VALUE*)&rs);
+	s = rb_string_value_ptr((VALUE*)&rs);
 	len = (int)RSTRING_LEN(rs);
 	if (out->end - out->cur <= len) {
 	    grow(out, len);

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -215,6 +215,7 @@ class Juice < ::Test::Unit::TestCase
     dump_and_load('abc', false)
     dump_and_load("abc\ndef", false)
     dump_and_load("a\u0041", false)
+    assert_equal("a\u0000a", dump_and_load("a\u0000a", false))
   end
 
   def test_string_object


### PR DESCRIPTION
Starting from 2.2.0, dumping strings that contain null bytes have failed. This is caused by the change to use `rb_string_value_cstr` instead of `StringValuePtr`. Reverting back to StringValuePtr fixes this issue as StringValuePtr only returns the pointer to the buffer without scanning the string for nulls.
