### PR TITLE
Add quirks_mode option for JSON compatibility

### DIFF
--- a/ext/oj/oj.h
+++ b/ext/oj/oj.h
@@ -141,6 +141,7 @@ typedef struct _Options {
     size_t	create_id_len;	// length of create_id
     int		sec_prec;	// second precision when dumping time
     char	allow_gc;	// allow GC during parse
+    char    quirks_mode; // allow single JSON values instead of documents
     DumpOpts	dump_opts;
 } *Options;
 

--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -873,5 +873,23 @@ oj_pi_parse(int argc, VALUE *argv, ParseInfo pi, char *json, size_t len, int yie
     if (err_has(&pi->err)) {
 	oj_err_raise(&pi->err);
     }
+
+    if (pi->options.quirks_mode == No) {
+	switch (rb_type(result)) {
+            case T_NIL:
+	    case T_TRUE:
+	    case T_FALSE:
+	    case T_FIXNUM:
+	    case T_FLOAT:
+	    case T_CLASS:
+	    case T_SYMBOL:
+		rb_raise(oj_parse_error_class, "unexpected non-document value");
+		break;
+	    default:
+		// okay
+		break;
+	}
+    }
+
     return result;
 }

--- a/test/isolated/shared.rb
+++ b/test/isolated/shared.rb
@@ -98,6 +98,13 @@ class SharedMimicTest < Minitest::Test
            "children don't match")
   end
 
+  def test_parse_with_quirks_mode
+    json = %{null}
+    assert_equal(nil, JSON.parse(json, quirks_mode: true))
+    assert_raises(JSON::ParserError) { JSON.parse(json, quirks_mode: false) }
+    assert_raises(JSON::ParserError) { JSON.parse(json) }
+  end
+
 # []
   def test_bracket_load
     json = %{{"a":1,"b":[true,false]}}

--- a/test/test_various.rb
+++ b/test/test_various.rb
@@ -1116,6 +1116,11 @@ class Juice < Minitest::Test
     assert_equal(nil, obj)
   end
 
+  def test_quirks_mode
+    assert_raises(Oj::ParseError) { Oj.load("null", :quirks_mode => false) }
+    assert_equal nil, Oj.load("null", :quirks_mode => true)
+  end
+
   def dump_and_load(obj, trace=false)
     json = Oj.dump(obj, :indent => 2)
     puts json if trace


### PR DESCRIPTION
JSON.parse allows single JSON values for JSON.parse when quirks_mode option is given. Allow the same quirks_mode option to be given to Oj as an argument. The default value for this option is true.

``` ruby
Oj.load("null", quirks_mode: false)
# => Oj::ParseError
Oj.load("null")
# => nil

JSON.parse("null", quirks_mode: true)
# => nil
JSON.parse("null")
# => Oj::ParseError
```
