### PR TITLE
point to docs at rubydoc.info

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ gem 'oj'
 
 ## Documentation
 
-*Documentation*: http://www.ohler.com/oj
+*Documentation*: http://www.ohler.com/oj, http://rubydoc.info/gems/oj
 
 ## Source
 


### PR DESCRIPTION
http://www.ohler.com/oj is displaying docs for 2.9.8, but current release is 2.9.9. This PR changes the Documentation link in the README to point to http://rubydoc.info/gems/oj, which is published automatically whenever you push a new gem version.
