### PR TITLE
Be more exact when parsing doubles to floating point

### DIFF
--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -702,7 +702,7 @@ oj_num_as_value(NumInfo ni) {
 		rnum = rb_funcall(rnum, rb_intern("to_f"), 0);
 	    }
 	} else {
-	    double	d = (double)ni->i + (double)ni->num / (double)ni->div;
+	    double	d = (double)ni->i + (double)ni->num * (1.0 / ni->div);
 
 	    if (ni->neg) {
 		d = -d;

--- a/test/test_compat.rb
+++ b/test/test_compat.rb
@@ -90,6 +90,8 @@ class CompatJuice < Minitest::Test
     dump_and_load(12345.6789, false)
     dump_and_load(70.35, false)
     dump_and_load(-54321.012, false)
+    dump_and_load(1.7775, false)
+    dump_and_load(2.5024, false)
     dump_and_load(2.48e16, false)
     dump_and_load(2.48e100 * 1.0e10, false)
     dump_and_load(-2.48e100 * 1.0e10, false)

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -85,6 +85,8 @@ class FileJuice < Minitest::Test
     dump_and_load(12345.6789, false)
     dump_and_load(70.35, false)
     dump_and_load(-54321.012, false)
+    dump_and_load(1.7775, false)
+    dump_and_load(2.5024, false)
     dump_and_load(2.48e16, false)
     dump_and_load(2.48e100 * 1.0e10, false)
     dump_and_load(-2.48e100 * 1.0e10, false)

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -163,6 +163,8 @@ class ObjectJuice < Minitest::Test
     dump_and_load(12345.6789, false)
     dump_and_load(70.35, false)
     dump_and_load(-54321.012, false)
+    dump_and_load(1.7775, false)
+    dump_and_load(2.5024, false)
     dump_and_load(2.48e16, false)
     dump_and_load(2.48e100 * 1.0e10, false)
     dump_and_load(-2.48e100 * 1.0e10, false)

--- a/test/test_strict.rb
+++ b/test/test_strict.rb
@@ -39,6 +39,8 @@ class StrictJuice < Minitest::Test
     dump_and_load(12345.6789, false)
     dump_and_load(70.35, false)
     dump_and_load(-54321.012, false)
+    dump_and_load(1.7775, false)
+    dump_and_load(2.5024, false)
     dump_and_load(2.48e16, false)
     dump_and_load(2.48e100 * 1.0e10, false)
     dump_and_load(-2.48e100 * 1.0e10, false)

--- a/test/test_various.rb
+++ b/test/test_various.rb
@@ -173,6 +173,8 @@ class Juice < Minitest::Test
     dump_and_load(12345.6789, false)
     dump_and_load(70.35, false)
     dump_and_load(-54321.012, false)
+    dump_and_load(1.7775, false)
+    dump_and_load(2.5024, false)
     dump_and_load(2.48e16, false)
     dump_and_load(2.48e100 * 1.0e10, false)
     dump_and_load(-2.48e100 * 1.0e10, false)


### PR DESCRIPTION
The math was constructed in such a way that IEEE rules on floating point
were hurting us and not helping us. This meant we were seeing things
like the following when doing a round trip conversion:

Expected: 1.7775
Actual:   1.7774999999999999

Expected: 2.5024
Actual:   2.5023999999999997

Fix this by first computing the reciprocal of the denominator when
doing the integer parts to floating point conversion. This allows the
above two numbers (and many others) to be properly parsed and converted
into ruby floating point objects without needing to switch to using
BigDecimal objects.

The two test cases are pulled from issue #99 (which this solves) and a number we came across when using the library and noticing parse differences from standard ruby.
