### PR TITLE
Avoid implicit loss of precision in odd.c

### DIFF
--- a/ext/oj/odd.c
+++ b/ext/oj/odd.c
@@ -34,7 +34,7 @@
 
 static struct _Odd	_odds[4]; // bump up if new initial Odd classes are added
 static struct _Odd	*odds = _odds;
-static int		odd_cnt = 0;
+static long		odd_cnt = 0;
 
 static void
 set_class(Odd odd, const char *classname) {


### PR DESCRIPTION
What's being written to `odd_cnt` is the result of pointer arithmetics, which don't fit `int` values on 64bit machines.

This silences the following warning:

```
../../../../ext/oj/odd.c:104:26: warning: implicit conversion loses integer precision: 'long' to 'int' [-Wshorten-64-to-32]
    odd_cnt = odd - odds + 1l;
```

on platform:

```
Apple LLVM version 6.0 (clang-600.0.54) (based on LLVM 3.5svn)
Target: x86_64-apple-darwin14.0.0
```
