### PR TITLE
Fix float padding issues on certain decimal values

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -450,11 +450,7 @@ dump_float(VALUE obj, Out out) {
     int		cnt;
 
     if (0.0 == d) {
-	b = buf;
-	*b++ = '0';
-	*b++ = '.';
-	*b++ = '0';
-	*b++ = '\0';
+	strcpy(buf, "0.0");
 	cnt = 3;
     } else if (OJ_INFINITY == d) {
 	if (StrictMode == out->opts->mode) {
@@ -475,9 +471,9 @@ dump_float(VALUE obj, Out out) {
 	strcpy(buf, "NaN");
 	cnt = 3;
     } else if (d == (double)(long long int)d) {
-	cnt = sprintf(buf, "%.1f", d); // used sprintf due to bug in snprintf
+	cnt = sprintf(buf, "%.1f", d);
     } else {
-	cnt = sprintf(buf, "%0.16g", d); // used sprintf due to bug in snprintf
+	cnt = sprintf(buf, "%0.15g", d);
     }
     if (out->end - out->cur <= (long)cnt) {
 	grow(out, cnt);

--- a/test/test_various.rb
+++ b/test/test_various.rb
@@ -190,6 +190,22 @@ class Juice < Minitest::Test
     Oj.default_options = {:mode => mode}
   end
 
+  def test_float_dump
+    assert_equal('0.56', Oj.dump(0.56))
+    assert_equal('0.5773', Oj.dump(0.5773))
+    assert_equal('0.6768', Oj.dump(0.6768))
+    assert_equal('0.685', Oj.dump(0.685))
+    assert_equal('0.7032', Oj.dump(0.7032))
+    assert_equal('0.7051', Oj.dump(0.7051))
+    assert_equal('0.8274', Oj.dump(0.8274))
+    assert_equal('0.9149', Oj.dump(0.9149))
+    assert_equal('64.4', Oj.dump(64.4))
+    assert_equal('71.6', Oj.dump(71.6))
+    assert_equal('73.4', Oj.dump(73.4))
+    assert_equal('80.6', Oj.dump(80.6))
+    assert_equal('-95.640172', Oj.dump(-95.640172))
+  end
+
   def test_string
     dump_and_load('', false)
     dump_and_load('abc', false)


### PR DESCRIPTION
We were seeing things like this:
  Oj.dump(-95.640172) => "-95.64017200000001"
  Oj.dump(73.4) => "73.40000000000001"
  Oj.dump(0.7032) => "0.7031999999999999"

This is obviously not right and not ideal. The precision specifier in
the sprintf() call in the dump routine was changed from 15 to 16 in
commit a7a4d73991fc, but not much verification to correctness was given
there. In any case, as the test cases clearly show, we are not "doing
the right thing".

This small change fixes the newly provided test cases, and breaks no
existing ones.

Finally, clean up some of the special float casing of '0.0' and use
strcpy("0.0") similar to what we do in the other branches.

---
If this change from 15 to 16 was made for a reason, I failed to see it, given the lack of test cases showing benefit, and nothing failed when we went back to the old value. This addresses issue #193, and the example case from there has been included as a test case.