### PR TITLE
cleanup generated oj.so in build_test script, add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ Makefile
 doc
 .yardoc
 Gemfile.lock
+*.so


### PR DESCRIPTION
Since I made a mistake and committed oj.so in my last pull request, it seems like it should be added to .gitignore as well as cleaned up after the build_test script runs.