### PR TITLE
Build makefile in oj/oj as per example in rubygems

### DIFF
--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -56,6 +56,6 @@ dflags.each do |k,v|
 end
 $CPPFLAGS += ' -Wall'
 #puts "*** $CPPFLAGS: #{$CPPFLAGS}"
-create_makefile(extension_name)
+create_makefile("#{extension_name}/#{extension_name}")
 
 %x{make clean}

--- a/oj.gemspec
+++ b/oj.gemspec
@@ -14,10 +14,8 @@ Gem::Specification.new do |s|
   s.licenses = ['MIT']
 
   s.files = Dir["{lib,ext,test}/**/*.{rb,h,c}"] + ['LICENSE', 'README.md']
-
+  s.test_files = Dir["test/**/*.rb"]
   s.extensions = ["ext/oj/extconf.rb"]
-
-  s.require_paths = ["lib", "ext"]
 
   s.has_rdoc = true
   s.extra_rdoc_files = ['README.md']


### PR DESCRIPTION
Fix for issue #255 

Build makefile in oj/oj as per example in rubygems: http://guides.rubygems.org/gems-with-extensions/