### PR TITLE
constify RStruct access

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -1788,6 +1788,9 @@ dump_struct_obj(VALUE obj, int depth, Out out) {
     {
 	const VALUE	*vp;
 
+#ifndef RSTRUCT_CONST_PTR
+# define RSTRUCT_CONST_PTR(st) (const VALUE *)RSTRUCT_PTR(st)
+#endif
 	for (i = (int)RSTRUCT_LEN(obj), vp = RSTRUCT_CONST_PTR(obj); 0 < i; i--, vp++) {
 	    if (out->end - out->cur <= (long)size) {
 		grow(out, size);

--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -1786,9 +1786,9 @@ dump_struct_obj(VALUE obj, int depth, Out out) {
     size = d3 * out->indent + 2;
 #ifdef RSTRUCT_LEN
     {
-	VALUE	*vp;
+	const VALUE	*vp;
 
-	for (i = (int)RSTRUCT_LEN(obj), vp = RSTRUCT_PTR(obj); 0 < i; i--, vp++) {
+	for (i = (int)RSTRUCT_LEN(obj), vp = RSTRUCT_CONST_PTR(obj); 0 < i; i--, vp++) {
 	    if (out->end - out->cur <= (long)size) {
 		grow(out, size);
 	    }


### PR DESCRIPTION
`RSTRUCT_PTR()` makes the struct WB-unprotected, and causes GC penalty.