### PR TITLE
fix parsing big numbers with trailing zeros

### DIFF
--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -441,7 +441,7 @@ read_num(ParseInfo pi) {
 		}
 		// TBD move size check here
 		ni.i = ni.i * 10 + d;
-		if (LONG_MAX <= ni.i || DEC_MAX < ni.dec_cnt - zero_cnt) {
+		if (LONG_MAX <= ni.i || DEC_MAX < ni.dec_cnt) {
 		    ni.big = 1;
 		}
 	    }

--- a/test/test_various.rb
+++ b/test/test_various.rb
@@ -901,8 +901,10 @@ class Juice < Minitest::Test
     b = Oj.load(json, :mode => :strict)
     assert_equal(30226801971775055948247051683954096612865741943, b)
   end
+
   def test_bignum_object
     dump_and_load(7 ** 55, false)
+    dump_and_load(10 ** 19, false)
   end
 
   # BigDecimal


### PR DESCRIPTION
Hi,

I stumbled upon this:

    >> Oj.load '[10000000000000000000]'
    => [-8446744073709551616]

And I think I managed to find and fix it (substracting <tt>zero_cnt</tt> seems to only make sense for the decimal part, and <tt>LONG_MAX</tt> check doesn't catch it because one iteration it's below and the next one it's already overflowed).

Couldn't calculating the actual number <tt>ni.i</tt> be removed completely here?

Also, there is the same code part in sparse.c which I did not change. I'm assuming it's for strict parsing? But when playing a bit it seemed that parse.c was also used for strict. So since I didn't know how to test it, I left it alone even though probably it needs the same fix.

PS. Awesome work with the lib, I've had an amazing performance improvement after switching to it some time ago.

