### PR TITLE
the second parameter of gettimeofday() should be NULL

### DIFF
--- a/ext/oj/hash_test.c
+++ b/ext/oj/hash_test.c
@@ -445,9 +445,8 @@ static struct _StrLen data[] = {
 static uint64_t
 micro_time() {
     struct timeval	tv;
-    struct timezone	tz;
 
-    gettimeofday(&tv, &tz);
+    gettimeofday(&tv, NULL);
 
     return (uint64_t)tv.tv_sec * 1000000ULL + (uint64_t)tv.tv_usec;
 }


### PR DESCRIPTION
Oj's native extension doesn't compile on Solaris and Ruby 2.3.0.
This is because as of r52703, `-D_XOPEN_SOURCE=xxx` may be specified on Solaris.
