### PR TITLE
Support to Integer unification for Ruby 2.4. 

### DIFF
--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -1281,7 +1281,11 @@ doc_type(int argc, VALUE *argv, VALUE self) {
 	case T_TRUE:	type = rb_cTrueClass;	break;
 	case T_FALSE:	type = rb_cFalseClass;	break;
 	case T_STRING:	type = rb_cString;	break;
+#ifdef RUBY_INTEGER_UNIFICATION
+  case T_FIXNUM:	type = rb_cInteger;	break;
+#else
 	case T_FIXNUM:	type = rb_cFixnum;	break;
+#endif
 	case T_FLOAT:	type = rb_cFloat;	break;
 	case T_ARRAY:	type = rb_cArray;	break;
 	case T_HASH:	type = rb_cHash;	break;

--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -1282,7 +1282,7 @@ doc_type(int argc, VALUE *argv, VALUE self) {
 	case T_FALSE:	type = rb_cFalseClass;	break;
 	case T_STRING:	type = rb_cString;	break;
 #ifdef RUBY_INTEGER_UNIFICATION
-  case T_FIXNUM:	type = rb_cInteger;	break;
+	case T_FIXNUM:	type = rb_cInteger;	break;
 #else
 	case T_FIXNUM:	type = rb_cFixnum;	break;
 #endif

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -402,9 +402,15 @@ oj_parse_options(VALUE ropts, Options copts) {
     if (Qnil != (v = rb_hash_lookup(ropts, float_prec_sym))) {
 	int	n;
 
+#ifdef RUBY_INTEGER_UNIFICATION
+	if (rb_cInteger != rb_obj_class(v)) {
+	    rb_raise(rb_eArgError, ":float_precision must be a Integer.");
+	}
+#else
 	if (rb_cFixnum != rb_obj_class(v)) {
 	    rb_raise(rb_eArgError, ":float_precision must be a Fixnum.");
 	}
+#endif
 	Check_Type(v, T_FIXNUM);
 	n = FIX2INT(v);
 	if (0 >= n) {
@@ -421,9 +427,15 @@ oj_parse_options(VALUE ropts, Options copts) {
     if (Qnil != (v = rb_hash_lookup(ropts, sec_prec_sym))) {
 	int	n;
 
+#ifdef RUBY_INTEGER_UNIFICATION
+	if (rb_cInteger != rb_obj_class(v)) {
+	    rb_raise(rb_eArgError, ":second_precision must be a Integer.");
+	}
+#else
 	if (rb_cFixnum != rb_obj_class(v)) {
 	    rb_raise(rb_eArgError, ":second_precision must be a Fixnum.");
 	}
+#endif
 	n = NUM2INT(v);
 	if (0 > n) {
 	    n = 0;


### PR DESCRIPTION
Ruby 2.4 will unify Bignum and Fixnum to Integer. ref. https://bugs.ruby-lang.org/issues/12005

I couldn't build oj-2.16.0 on ruby 2.4 with folloing error.

```
compiling ../../../../ext/oj/fast.c
../../../../ext/oj/fast.c:1284:24: error: use of undeclared identifier 'rb_cFixnum'
        case T_FIXNUM:  type = rb_cFixnum;      break;
                               ^
1 error generated.
gmake: *** [Makefile:241: fast.o] Error 1
```

I fixed this to use `RUBY_INTEGER_UNIFICATION` provided from Ruby 2.4.

