### PR TITLE
Do not use a before_sep in pretty_generate

### DIFF
--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -1805,7 +1805,7 @@ mimic_pretty_generate(int argc, VALUE *argv, VALUE self) {
 
     strcpy(copts.dump_opts.indent_str, "  ");
     copts.dump_opts.indent_size = (uint8_t)strlen(copts.dump_opts.indent_str);
-    strcpy(copts.dump_opts.before_sep, " ");
+    strcpy(copts.dump_opts.before_sep, "");
     copts.dump_opts.before_size = (uint8_t)strlen(copts.dump_opts.before_sep);
     strcpy(copts.dump_opts.after_sep, " ");
     copts.dump_opts.after_size = (uint8_t)strlen(copts.dump_opts.after_sep);

--- a/test/isolated/shared.rb
+++ b/test/isolated/shared.rb
@@ -217,18 +217,18 @@ class SharedMimicTest < Minitest::Test
   def test_pretty_generate
     json = JSON.pretty_generate({ 'a' => 1, 'b' => [true, false]})
     assert(%{{
-  "a" : 1,
-  "b" : [
+  "a": 1,
+  "b": [
     true,
     false
   ]
 }} == json ||
 %{{
-  "b" : [
+  "b": [
     true,
     false
   ],
-  "a" : 1
+  "a": 1
 }} == json)
   end
 


### PR DESCRIPTION
The JSON module does not use any before separator when pretty generating JSON. This can be shown with this command:

```
$ ruby -rjson -e "puts JSON.pretty_generate(test: true, hello: 'world')"
{
  "test": true,
  "hello": "world"
}
```

This patch ensures that no `before_sep` is used when calling `pretty_generate`. Although the change is trivial, I think it is important for users who wish to transition to `Oj`. They will not have to deal with breaking any assertions they may have about the output of JSON in their test suites. I noticed this while working on https://github.com/ianks/yagni_json_encoder, which currently passes the entire Rails test suite minus this spec.