### PR TITLE
Add option to raise Exception on empty strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,10 @@ Oj.default_options = {:mode => :compat }
  * `:nilnil` [Boolean] if true a nil input to load will return nil and
    not raise an Exception
    
+ * `:empty_string` [Boolean] if true an empty input will not raise an
+   Exception, default is true (allow). When Oj.mimic_JSON is used,
+   default is false (raise exception when empty string is encountered)
+
  * `:allow_gc` [Boolean] allow or prohibit GC during parsing, default is
    true (allow).
    

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -130,6 +130,7 @@ static VALUE	mode_sym;
 static VALUE	nan_sym;
 static VALUE	newline_sym;
 static VALUE	nilnil_sym;
+static VALUE	empty_string_sym;
 static VALUE	null_sym;
 static VALUE	object_sym;
 static VALUE	omit_nil_sym;
@@ -184,6 +185,7 @@ struct _Options	oj_default_options = {
     No,		// to_json
     No,		// as_json
     No,		// nilnil
+    Yes,	// empty_string
     Yes,	// allow_gc
     Yes,	// quirks_mode
     No,		// allow_invalid    
@@ -231,6 +233,7 @@ static VALUE	define_mimic_json(int argc, VALUE *argv, VALUE self);
  * - use_to_json: [true|false|nil] call to_json() methods on dump, default is false
  * - use_as_json: [true|false|nil] call as_json() methods on dump, default is false
  * - nilnil: [true|false|nil] if true a nil input to load will return nil and not raise an Exception
+ * - empty_string: [true|false|nil] if true an empty input will not raise an Exception
  * - allow_gc: [true|false|nil] allow or prohibit GC during parsing, default is true (allow)
  * - quirks_mode: [true,|false|nil] Allow single JSON values instead of documents, default is true (allow)
  * - allow_invalid_unicode: [true,|false|nil] Allow invalid unicode, default is false (don't allow)
@@ -262,6 +265,7 @@ get_def_opts(VALUE self) {
     rb_hash_aset(opts, use_to_json_sym, (Yes == oj_default_options.to_json) ? Qtrue : ((No == oj_default_options.to_json) ? Qfalse : Qnil));
     rb_hash_aset(opts, use_as_json_sym, (Yes == oj_default_options.as_json) ? Qtrue : ((No == oj_default_options.as_json) ? Qfalse : Qnil));
     rb_hash_aset(opts, nilnil_sym, (Yes == oj_default_options.nilnil) ? Qtrue : ((No == oj_default_options.nilnil) ? Qfalse : Qnil));
+    rb_hash_aset(opts, empty_string_sym, (Yes == oj_default_options.empty_string) ? Qtrue : ((No == oj_default_options.empty_string) ? Qfalse : Qnil));
     rb_hash_aset(opts, allow_gc_sym, (Yes == oj_default_options.allow_gc) ? Qtrue : ((No == oj_default_options.allow_gc) ? Qfalse : Qnil));
     rb_hash_aset(opts, quirks_mode_sym, (Yes == oj_default_options.quirks_mode) ? Qtrue : ((No == oj_default_options.quirks_mode) ? Qfalse : Qnil));
     rb_hash_aset(opts, allow_invalid_unicode_sym, (Yes == oj_default_options.allow_invalid) ? Qtrue : ((No == oj_default_options.allow_invalid) ? Qfalse : Qnil));
@@ -378,6 +382,7 @@ oj_parse_options(VALUE ropts, Options copts) {
 	{ use_to_json_sym, &copts->to_json },
 	{ use_as_json_sym, &copts->as_json },
 	{ nilnil_sym, &copts->nilnil },
+	{ empty_string_sym, &copts->empty_string },
 	{ allow_gc_sym, &copts->allow_gc },
 	{ quirks_mode_sym, &copts->quirks_mode },
 	{ allow_invalid_unicode_sym, &copts->allow_invalid },
@@ -1832,6 +1837,7 @@ mimic_parse(int argc, VALUE *argv, VALUE self) {
     pi.options.auto_define = No;
     pi.options.quirks_mode = No;
     pi.options.allow_invalid = No;
+    pi.options.empty_string = No;
 
     if (2 <= argc) {
 	VALUE	ropts = argv[1];
@@ -1919,6 +1925,7 @@ static struct _Options	mimic_object_to_json_options = {
     No,		// to_json
     Yes,	// as_json
     Yes,	// nilnil
+    Yes,	// empty_string
     Yes,	// allow_gc
     Yes,	// quirks_mode
     No,		// allow_invalid
@@ -2258,6 +2265,7 @@ void Init_oj() {
     nan_sym = ID2SYM(rb_intern("nan"));			rb_gc_register_address(&nan_sym);
     newline_sym = ID2SYM(rb_intern("newline"));		rb_gc_register_address(&newline_sym);
     nilnil_sym = ID2SYM(rb_intern("nilnil"));		rb_gc_register_address(&nilnil_sym);
+    empty_string_sym = ID2SYM(rb_intern("empty_string"));rb_gc_register_address(&empty_string_sym);
     null_sym = ID2SYM(rb_intern("null"));		rb_gc_register_address(&null_sym);
     object_nl_sym = ID2SYM(rb_intern("object_nl"));	rb_gc_register_address(&object_nl_sym);
     object_sym = ID2SYM(rb_intern("object"));		rb_gc_register_address(&object_sym);

--- a/ext/oj/oj.h
+++ b/ext/oj/oj.h
@@ -156,6 +156,7 @@ typedef struct _Options {
     char		to_json;	// YesNo
     char		as_json;	// YesNo
     char		nilnil;		// YesNo
+    char		empty_string;	// YesNo
     char		allow_gc;	// allow GC during parse
     char		quirks_mode;	// allow single JSON values instead of documents
     char		allow_invalid;	// YesNo - allow invalid unicode

--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -598,6 +598,13 @@ oj_parse2(ParseInfo pi) {
 	if (!first && '\0' != *pi->cur) {
 	    oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "unexpected characters after the JSON document");
 	}
+
+	// if no tokens are consumed (i.e. empty string), throw a parse error
+	// this is the behavior of JSON.parse in both Ruby and JS
+	if (No == pi->options.empty_string && 1 == first && '\0' == *pi->cur) {
+	    oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "unexpected character");
+	}
+
 	switch (*pi->cur++) {
 	case '{':
 	    hash_start(pi);

--- a/test/isolated/shared.rb
+++ b/test/isolated/shared.rb
@@ -164,6 +164,12 @@ class SharedMimicTest < Minitest::Test
     assert_raises(JSON::ParserError) { JSON.parse(json) }
   end
 
+  def test_parse_with_empty_string
+    Oj.mimic_JSON
+    assert_raises(JSON::ParserError) { JSON.parse(' ') }
+    assert_raises(JSON::ParserError) { JSON.parse("\t\t\n   ") }
+  end
+
 # []
   def test_bracket_load
     json = %{{"a":1,"b":[true,false]}}

--- a/test/test_various.rb
+++ b/test/test_various.rb
@@ -6,6 +6,12 @@ $: << File.dirname(__FILE__)
 require 'helper'
 
 class Juice < Minitest::Test
+  def gen_whitespaced_string(length = Random.new.rand(100))
+    whitespace_chars = [" ", "\t", "\f", "\n", "\r"]
+    result = ""
+    length.times { result << whitespace_chars.sample }
+    result
+  end
 
   module TestModule
   end
@@ -1298,6 +1304,21 @@ class Juice < Minitest::Test
   def test_nilnil_true
     obj = Oj.load(nil, :nilnil => true)
     assert_equal(nil, obj)
+  end
+
+  def test_empty_string_true
+    10.times do
+      result = Oj.load(gen_whitespaced_string, :empty_string => true)
+      assert_nil(result)
+    end
+  end
+
+  def test_empty_string_false
+    10.times do
+      assert_raises(Oj::ParseError) do
+        Oj.load(gen_whitespaced_string, :empty_string => false)
+      end
+    end
   end
 
   def test_quirks_null_mode

--- a/test/test_various.rb
+++ b/test/test_various.rb
@@ -128,6 +128,7 @@ class Juice < Minitest::Test
       :use_to_json=>false,
       :use_as_json=>false,
       :nilnil=>true,
+      :empty_string=>true,
       :allow_gc=>false,
       :quirks_mode=>false,
       :allow_invalid_unicode=>true,


### PR DESCRIPTION
Many JSON parsers (including Ruby's JSON module and Javascripts `JSON.parse`),
raise exceptions when only whitespace is given as an input string. This patch
adds an optional configuration parameter to raise an exception when an empty
string is given as an input.

This change also updates the Mimic configuration to use this by default, which
corresponds to the behavior of `JSON.parse`. This can be illustrated by running:

```
$ ruby -rjson -e "JSON.parse('   ')"
/home/ianks/.gem/ruby/2.3.1/gems/json-2.0.3/lib/json/common.rb:156:in `parse': 743: unexpected token at '' (JSON::ParserError)
	from /home/ianks/.gem/ruby/2.3.1/gems/json-2.0.3/lib/json/common.rb:156:in `parse'
	from -e:1:in `<main>'
```

Oj now raises a similar exception:

```
$ ruby -roj -e "Oj.mimic_JSON; JSON.parse('   ')"
-e:1:in `parse': unexpected character at line 1, column 3 [parse.c:606] (JSON::ParserError)
	from -e:1:in `<main>'
```

This was the only difference I witnessed when attempting to pass all of the `ActiveSupport::JSON.decode` specs.