### PR TITLE
Can not push onto an Object without a key

### DIFF
--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -1530,7 +1530,7 @@ stream_writer_push_value(int argc, VALUE *argv, VALUE self) {
 	oj_str_writer_push_value((StrWriter)DATA_PTR(self), *argv, 0);
 	break;
     case 2:
-	if (Qnil == argv[0]) {
+	if (Qnil == argv[1]) {
 	    oj_str_writer_push_value((StrWriter)DATA_PTR(self), *argv, 0);
 	} else {
 	    rb_check_type(argv[1], T_STRING);

--- a/test/test_writer.rb
+++ b/test/test_writer.rb
@@ -44,6 +44,14 @@ class OjWriter < Minitest::Test
     assert_equal("{}\n", w.to_s)
   end
 
+  def test_string_writer_push_null_value_with_key
+    w = Oj::StringWriter.new(:indent => 0, :mode => :compat)
+    w.push_object()
+    w.push_value(nil, 'nothing')
+    w.pop()
+    assert_equal(%|{"nothing":null}\n|, w.to_s)
+  end
+
   def test_string_writer_nested_object
     w = Oj::StringWriter.new(:indent => 0)
     w.push_object()
@@ -289,4 +297,12 @@ class OjWriter < Minitest::Test
     assert_equal(%|{"a1":{},"a2":{"b":{}},"a3":{"a4":37}}\n|, output.string())
   end
 
+  def test_stream_writer_push_null_value_with_key
+    output = StringIO.open("", "w+")
+    w = Oj::StreamWriter.new(output, :indent => 0)
+    w.push_object()
+    w.push_value(nil, 'nothing')
+    w.pop()
+    assert_equal(%|{"nothing":null}\n|, output.string())
+  end
 end # OjWriter


### PR DESCRIPTION
```ruby
w = Oj::StringWriter.new
w.push_object()
w.push_value(nil, 'nothing')
```
=> `Can not push onto an Object without a key. (StandardError)`