### PR TITLE
Yield next offset when parsing multiple objects

### DIFF
--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -676,14 +676,16 @@ oj_parse2(ParseInfo pi) {
 	}
 	if (stack_empty(&pi->stack)) {
 	    if (Qundef != pi->proc) {
+		long pos = pi->cur - pi->json;
 		if (Qnil == pi->proc) {
-		    rb_yield(stack_head_val(&pi->stack));
+		    rb_yield_values(2, stack_head_val(&pi->stack), INT2NUM(pos));
 		} else {
 #if HAS_PROC_WITH_BLOCK
-		    VALUE	args[1];
+		    VALUE	args[2];
 
-		    *args = stack_head_val(&pi->stack);
-		    rb_proc_call_with_block(pi->proc, 1, args, Qnil);
+		    args[0] = stack_head_val(&pi->stack);
+		    args[1] = INT2NUM(pos);
+		    rb_proc_call_with_block(pi->proc, 2, args, Qnil);
 #else
 		    rb_raise(rb_eNotImpError,
 			     "Calling a Proc with a block not supported in this version. Use func() {|x| } syntax instead.");

--- a/ext/oj/sparse.c
+++ b/ext/oj/sparse.c
@@ -719,14 +719,16 @@ oj_sparse2(ParseInfo pi) {
 	}
 	if (stack_empty(&pi->stack)) {
 	    if (Qundef != pi->proc) {
+		long pos = pi->rd.tail - pi->rd.head;
 		if (Qnil == pi->proc) {
-		    rb_yield(stack_head_val(&pi->stack));
+		    rb_yield_values(2, stack_head_val(&pi->stack), INT2NUM(pos));
 		} else {
 #if HAS_PROC_WITH_BLOCK
-		    VALUE	args[1];
+		    VALUE	args[2];
 
-		    *args = stack_head_val(&pi->stack);
-		    rb_proc_call_with_block(pi->proc, 1, args, Qnil);
+		    args[0] = stack_head_val(&pi->stack);
+		    args[1] = INT2NUM(pos);
+		    rb_proc_call_with_block(pi->proc, 2, args, Qnil);
 #else
 		    oj_set_error_at(pi, rb_eNotImpError, __FILE__, __LINE__,
 				    "Calling a Proc with a block not supported in this version. Use func() {|x| } syntax instead.");


### PR DESCRIPTION
Pass the next offset as a second block argument when a block is passed
to `Oj.load`.

This allows an end-user to know what had been successfully parsed if an
error occurs after some objects have been parsed successfully, which is
useful if the stream being parsed may be incomplete (i.e. it's being
read from somewhere else that doesn't buffer on a per-object basis).

---

A couple notes though...:

- First, Oj ignores the offset when a `StringIO` is provided, so this API isn't entirely trivial to use: you  need to either pass in a *new* StringIO that starts at the right offset, or `read` the remaining contents of the StringIO. If Oj looked at the `StringIO`'s offset, then a user could just `seek` to the last offset that was successfully parsed, then resume parsing, which would probably be easier to use. I suspect this would be a breaking change though 😢, so let me know what you think!
- I'm not sure how to enter the branch that calls `rb_proc_call_with_block`, so the changes I've made there are completely untested. I'd be happy to actually add test coverage for those if you could let me know in which case this gets used 😄 

Thanks for your time, and thanks for Oj!