### PR TITLE
Fix memory usage for strings

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -157,30 +157,30 @@ static char	xss_friendly_chars[256] = "\
 33333333333333333333333333333333";
 
 inline static size_t
-newline_friendly_size(const uint8_t *str, size_t len) {
-    size_t	size = 0;
+newline_friendly_size(const uint8_t *str, const size_t len) {
+    size_t	size = 0, counter = len;
 
-    for (; 0 < len; str++, len--) {
+    for (; 0 < counter; str++, counter--) {
 	size += newline_friendly_chars[*str];
     }
     return size - len * (size_t)'0';
 }
 
 inline static size_t
-hibit_friendly_size(const uint8_t *str, size_t len) {
-    size_t	size = 0;
+hibit_friendly_size(const uint8_t *str, const size_t len) {
+    size_t	size = 0, counter = len;
 
-    for (; 0 < len; str++, len--) {
+    for (; 0 < counter; str++, counter--) {
 	size += hibit_friendly_chars[*str];
     }
     return size - len * (size_t)'0';
 }
 
 inline static size_t
-ascii_friendly_size(const uint8_t *str, size_t len) {
-    size_t	size = 0;
+ascii_friendly_size(const uint8_t *str, const size_t len) {
+    size_t	size = 0, counter = len;
 
-    for (; 0 < len; str++, len--) {
+    for (; 0 < counter; str++, counter--) {
 	size += ascii_friendly_chars[*str];
     }
     return size - len * (size_t)'0';
@@ -188,9 +188,9 @@ ascii_friendly_size(const uint8_t *str, size_t len) {
 
 inline static size_t
 xss_friendly_size(const uint8_t *str, size_t len) {
-    size_t	size = 0;
+    size_t	size = 0, counter = len;
 
-    for (; 0 < len; str++, len--) {
+    for (; 0 < counter; str++, counter--) {
 	size += xss_friendly_chars[*str];
     }
     return size - len * (size_t)'0';


### PR DESCRIPTION
Hi!

Could you please have a look at this fix rather soon?

It fixed a nasty bug where memory usage for string conversions was 49ish times bigger than it should've been. It's because ```*_friendly_size``` methods were modifying input parameter value of ```len``` and final return value calculation always subtracted zero which lead to a huge over-allocation for ```Out``` string.

Here is the comparison of the memory usage before and after fix for ```{body: body}``` hash object where body value is a ```2097152``` characters long ```String```:

Before: https://www.dropbox.com/s/i9p07edj2m61ex6/Memory_usage_before.png?dl=0
After: https://www.dropbox.com/s/mpggchzwldsjma5/Memory_usage_after.png?dl=0

Values above are in kilobytes.

I also took the liberty of removing trailing whitespaces (in a separate commit), let me know if you don't like it and I should remove it.

Thanks!