### PR TITLE
Remove calls to `dump_cstr` and `obj_dump_comp_val`

### DIFF
--- a/ext/oj/dump.h
+++ b/ext/oj/dump.h
@@ -47,10 +47,6 @@ extern void	oj_dump_custom_val(VALUE obj, int depth, Out out, bool as_ok);
 extern VALUE	oj_add_to_json(int argc, VALUE *argv, VALUE self);
 extern VALUE	oj_remove_to_json(int argc, VALUE *argv, VALUE self);
 
-// TBD remove when refactor complete
-extern void	oj_dump_comp_val(VALUE obj, int depth, Out out, int argc, VALUE *argv, bool as_ok);
-
-
 inline static void
 assure_size(Out out, size_t len) {
     if (out->end - out->cur <= (long)len) {

--- a/ext/oj/dump_leaf.c
+++ b/ext/oj/dump_leaf.c
@@ -10,8 +10,6 @@
 
 static void	dump_leaf(Leaf leaf, int depth, Out out);
 
-extern void	dump_cstr(const char *str, size_t cnt, int is_sym, int escape1, Out out);
-
 static void
 grow(Out out, size_t len) {
     size_t  size = out->end - out->buf;
@@ -52,10 +50,10 @@ static void
 dump_leaf_str(Leaf leaf, Out out) {
     switch (leaf->value_type) {
     case STR_VAL:
-	dump_cstr(leaf->str, strlen(leaf->str), 0, 0, out);
+	oj_dump_cstr(leaf->str, strlen(leaf->str), 0, 0, out);
 	break;
     case RUBY_VAL:
-	dump_cstr(rb_string_value_cstr(&leaf->value), RSTRING_LEN(leaf->value), 0, 0, out);
+	oj_dump_cstr(rb_string_value_cstr(&leaf->value), RSTRING_LEN(leaf->value), 0, 0, out);
 	break;
     case COL_VAL:
     default:
@@ -160,7 +158,7 @@ dump_leaf_hash(Leaf leaf, int depth, Out out) {
 		grow(out, size);
 	    }
 	    fill_indent(out, d2);
-	    dump_cstr(e->key, strlen(e->key), 0, 0, out);
+	    oj_dump_cstr(e->key, strlen(e->key), 0, 0, out);
 	    *out->cur++ = ':';
 	    dump_leaf(e, d2, out);
 	    if (e->next != first) {

--- a/ext/oj/string_writer.c
+++ b/ext/oj/string_writer.c
@@ -157,7 +157,6 @@ oj_str_writer_push_value(StrWriter sw, VALUE val, const char *key) {
 	    *sw->out.cur++ = ':';
 	}
     }
-    oj_dump_comp_val(val, sw->depth, &sw->out, 0, 0, true);
 }
 
 void


### PR DESCRIPTION
I was not able to `gem install oj` inside of a docker container because of the error:

```
Error relocating /usr/local/bundle/gems/oj-3.0.0/lib/oj/oj.so: dump_cstr: symbol not found - /usr/local/bundle/gems/oj-3.0.0/lib/oj/oj.so
```

After some digging i noticed the functions `dump_cstr` and `obj_dump_comp_val` were externed but not defined anywhere. I guess these were optimized away at link time?

This is just a quick fix and honestly I'm suprised it fixed my problem. Maybe I broke something but the tests seem to work.

