### PR TITLE
Drop ruby 1.9.3 from test targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
 
 language: ruby
 rvm:
-  - 1.9.3
   - 2.1.10
   - 2.2.6
   - 2.3.3
@@ -25,19 +24,12 @@ gemfile:
 matrix:
   fast_finish: true
   allow_failures:
-    - rvm: 1.9.3
     - rvm: 2.1.10
     - rvm: 2.2.6
 
   exclude:
     - gemfile: gemfiles/rails_5.gemfile
       rvm: 2.1.10
-    - gemfile: gemfiles/rails_4.1.gemfile
-      rvm: 1.9.3
-    - gemfile: gemfiles/rails_4.2.gemfile
-      rvm: 1.9.3
-    - gemfile: gemfiles/rails_5.gemfile
-      rvm: 1.9.3
     - gemfile: gemfiles/no_rails.gemfile
       rvm: 2.1.10
     - gemfile: gemfiles/no_rails.gemfile


### PR DESCRIPTION
We can not build current version oj gem on ruby 1.9.3.
When we try build it, these error has occurred.

> ruby: symbol lookup error: /path/to/oj.so: undefined symbol: RSTRUCT_GET

`RSTRUCT_GET` macro was introduced on ruby 2.1.0.

ref: https://github.com/ruby/ruby/commit/6a1101f23ea403a8825c2f361508eeb85878b011

So drop ruby 1.9.3 from test targets.