### PR TITLE
Remove RUBY_VERSION check for ruby 1.8 and 1.9

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,7 +8,6 @@ $VERBOSE = true
   $LOAD_PATH.unshift File.expand_path("../../#{dir}", __FILE__)
 end
 
-require 'rubygems' if RUBY_VERSION.start_with?('1.8.')
 require 'minitest'
 require 'minitest/autorun'
 require 'stringio'

--- a/test/isolated/shared.rb
+++ b/test/isolated/shared.rb
@@ -273,7 +273,7 @@ class SharedMimicTest < Minitest::Test
     children = []
     JSON.recurse_proc({ 'a' => 1, 'b' => [true, false]}) { |x| children << x }
     # JRuby 1.7.0 rb_yield() is broken and converts the [true, false] array into true
-    unless 'jruby' == $ruby && '1.9.3' == RUBY_VERSION
+    unless 'jruby' == $ruby
       assert([1, true, false, [true, false], { 'a' => 1, 'b' => [true, false]}] == children ||
              [true, false, [true, false], 1, { 'b' => [true, false], 'a' => 1}] == children)
     end

--- a/test/isolated/shared.rb
+++ b/test/isolated/shared.rb
@@ -36,8 +36,6 @@ class SharedMimicTest < Minitest::Test
     @expected_time_string =
       if defined?(Rails)
         %{"2014-05-13T16:53:20.000Z"}
-      elsif RUBY_VERSION.start_with?('1.8')
-        %{"Tue May 13 16:53:20 UTC 2014"}
       else
         %{"2014-05-13 16:53:20 UTC"}
       end
@@ -145,7 +143,7 @@ class SharedMimicTest < Minitest::Test
     Oj.mimic_JSON
     children = []
     json = %{{"a":1,"b":[true,false]}}
-    if 'rubinius' == $ruby || '1.8.7' == RUBY_VERSION
+    if 'rubinius' == $ruby
       obj = JSON.load(json) {|x| children << x }
     else
       p = Proc.new {|x| children << x }

--- a/test/json_gem/json_encoding_test.rb
+++ b/test/json_gem/json_encoding_test.rb
@@ -88,9 +88,7 @@ class JSONEncodingTest < Test::Unit::TestCase
   def test_chars
     (0..0x7f).each do |i|
       json = '["\u%04x"]' % i
-      if RUBY_VERSION >= "1.9."
-        i = i.chr
-      end
+      i = i.chr
       assert_equal i, JSON.parse(json).first[0]
       if i == ?\b
         generated = JSON.generate(["" << i])

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -160,20 +160,18 @@ class FileJuice < Minitest::Test
 
   # Range
   def test_range_object
-    unless RUBY_VERSION.start_with?('1.8')
-      Oj.default_options = { :mode => :object }
-      json = Oj.dump(1..7, :mode => :object, :indent => 0)
-      if 'rubinius' == $ruby
-        assert(%{{"^O":"Range","begin":1,"end":7,"exclude_end?":false}} == json)
-      elsif 'jruby' == $ruby
-        assert(%{{"^O":"Range","begin":1,"end":7,"exclude_end?":false}} == json)
-      else
-        assert_equal(%{{"^u":["Range",1,7,false]}}, json)
-      end
-      dump_and_load(1..7, false)
-      dump_and_load(1..1, false)
-      dump_and_load(1...7, false)
+    Oj.default_options = { :mode => :object }
+    json = Oj.dump(1..7, :mode => :object, :indent => 0)
+    if 'rubinius' == $ruby
+      assert(%{{"^O":"Range","begin":1,"end":7,"exclude_end?":false}} == json)
+    elsif 'jruby' == $ruby
+      assert(%{{"^O":"Range","begin":1,"end":7,"exclude_end?":false}} == json)
+    else
+      assert_equal(%{{"^u":["Range",1,7,false]}}, json)
     end
+    dump_and_load(1..7, false)
+    dump_and_load(1..1, false)
+    dump_and_load(1...7, false)
   end
 
   # BigNum

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -458,11 +458,7 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_xml_time
-    if RUBY_VERSION.start_with?('1.8')
-      t = Time.parse('2015-01-05T21:37:07.123456789-08:00')
-    else
-      t = Time.new(2015, 1, 5, 21, 37, 7.123456789, -8 * 3600)
-    end
+    t = Time.new(2015, 1, 5, 21, 37, 7.123456789, -8 * 3600)
     # The fractional seconds are not always recreated exactly which causes a
     # mismatch so instead the seconds, nsecs, and gmt_offset are checked
     # separately along with utc.
@@ -480,11 +476,7 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_xml_time_utc
-    if RUBY_VERSION.start_with?('1.8')
-      t = Time.parse('2015-01-05T21:37:07.123456789Z')
-    else
-      t = Time.utc(2015, 1, 5, 21, 37, 7.123456789)
-    end
+    t = Time.utc(2015, 1, 5, 21, 37, 7.123456789)
     # The fractional seconds are not always recreated exactly which causes a
     # mismatch so instead the seconds, nsecs, and gmt_offset are checked
     # separately along with utc.
@@ -501,11 +493,7 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_ruby_time
-    if RUBY_VERSION.start_with?('1.8')
-      t = Time.parse('2015-01-05T21:37:07.123456789-08:00')
-    else
-      t = Time.new(2015, 1, 5, 21, 37, 7.123456789, -8 * 3600)
-    end
+    t = Time.new(2015, 1, 5, 21, 37, 7.123456789, -8 * 3600)
     # The fractional seconds are not always recreated exactly which causes a
     # mismatch so instead the seconds, nsecs, and gmt_offset are checked
     # separately along with utc.
@@ -523,11 +511,7 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_ruby_time_12345
-    if RUBY_VERSION.start_with?('1.8')
-      t = Time.parse('2015-01-05T21:37:07.123456789+03:25')
-    else
-      t = Time.new(2015, 1, 5, 21, 37, 7.123456789, 12345/60*60)
-    end
+    t = Time.new(2015, 1, 5, 21, 37, 7.123456789, 12345/60*60)
     # The fractional seconds are not always recreated exactly which causes a
     # mismatch so instead the seconds, nsecs, and gmt_offset are checked
     # separately along with utc.
@@ -546,11 +530,7 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_ruby_time_utc
-    if RUBY_VERSION.start_with?('1.8')
-      t = Time.parse('2015-01-05T21:37:07.123456789Z')
-    else
-      t = Time.utc(2015, 1, 5, 21, 37, 7.123456789)
-    end
+    t = Time.utc(2015, 1, 5, 21, 37, 7.123456789)
     # The fractional seconds are not always recreated exactly which causes a
     # mismatch so instead the seconds, nsecs, and gmt_offset are checked
     # separately along with utc.
@@ -606,32 +586,26 @@ class ObjectJuice < Minitest::Test
     assert_equal(t.utc_offset, loaded.utc_offset)
   end
 
-  unless RUBY_VERSION.start_with?('1.8')
-    def test_time_unix_zone_12345
-      t = Time.new(2015, 1, 5, 21, 37, 7.123456789, 12345)
-      # The fractional seconds are not always recreated exactly which causes a
-      # mismatch so instead the seconds, nsecs, and gmt_offset are checked
-      # separately along with utc.
-      json = Oj.dump(t, :mode => :object, :time_format => :unix_zone)
-      #puts json
-      loaded = Oj.object_load(json);
-      assert_equal(t.tv_sec, loaded.tv_sec)
-      if t.respond_to?(:tv_nsec)
-        assert_equal(t.tv_nsec, loaded.tv_nsec)
-      else
-        assert_equal(t.tv_usec, loaded.tv_usec)
-      end
-      assert_equal(t.utc?, loaded.utc?)
-      assert_equal(t.utc_offset, loaded.utc_offset)
+  def test_time_unix_zone_12345
+    t = Time.new(2015, 1, 5, 21, 37, 7.123456789, 12345)
+    # The fractional seconds are not always recreated exactly which causes a
+    # mismatch so instead the seconds, nsecs, and gmt_offset are checked
+    # separately along with utc.
+    json = Oj.dump(t, :mode => :object, :time_format => :unix_zone)
+    #puts json
+    loaded = Oj.object_load(json);
+    assert_equal(t.tv_sec, loaded.tv_sec)
+    if t.respond_to?(:tv_nsec)
+      assert_equal(t.tv_nsec, loaded.tv_nsec)
+    else
+      assert_equal(t.tv_usec, loaded.tv_usec)
     end
+    assert_equal(t.utc?, loaded.utc?)
+    assert_equal(t.utc_offset, loaded.utc_offset)
   end
 
   def test_time_unix_zone_utc
-    if RUBY_VERSION.start_with?('1.8')
-      t = Time.parse('2015-01-05T21:37:07.123456789Z')
-    else
-      t = Time.utc(2015, 1, 5, 21, 37, 7.123456789)
-    end
+    t = Time.utc(2015, 1, 5, 21, 37, 7.123456789)
     # The fractional seconds are not always recreated exactly which causes a
     # mismatch so instead the seconds, nsecs, and gmt_offset are checked
     # separately along with utc.
@@ -801,7 +775,7 @@ class ObjectJuice < Minitest::Test
     assert_equal(err.message, e2['~mesg'])
     assert_equal(err.backtrace, e2['~bt'])
     e2 = Oj.load(json, :mode => :object)
-    if RUBY_VERSION.start_with?('1.8') || 'rubinius' == $ruby
+    if 'rubinius' == $ruby
       assert_equal(e.class, e2.class);
       assert_equal(e.message, e2.message);
       assert_equal(e.backtrace, e2.backtrace);
@@ -811,18 +785,16 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_range_object
-    unless RUBY_VERSION.start_with?('1.8')
-      Oj.default_options = { :mode => :object }
-      json = Oj.dump(1..7, :mode => :object, :indent => 0)
-      if 'rubinius' == $ruby
-        assert(%{{"^O":"Range","begin":1,"end":7,"exclude_end?":false}} == json)
-      else
-        assert_equal(%{{"^u":["Range",1,7,false]}}, json)
-      end
-      dump_and_load(1..7, false)
-      dump_and_load(1..1, false)
-      dump_and_load(1...7, false)
+    Oj.default_options = { :mode => :object }
+    json = Oj.dump(1..7, :mode => :object, :indent => 0)
+    if 'rubinius' == $ruby
+      assert(%{{"^O":"Range","begin":1,"end":7,"exclude_end?":false}} == json)
+    else
+      assert_equal(%{{"^u":["Range",1,7,false]}}, json)
     end
+    dump_and_load(1..7, false)
+    dump_and_load(1..1, false)
+    dump_and_load(1...7, false)
   end
 
   def test_circular_hash

--- a/test/test_various.rb
+++ b/test/test_various.rb
@@ -214,11 +214,7 @@ class Juice < Minitest::Test
     Oj.default_options = { :float_precision => 5 }
     assert_equal('1.4055', Oj.dump(1.405460727))
     Oj.default_options = { :float_precision => 0 }
-    if RUBY_VERSION.start_with?('1.8')
-      assert_equal('1405460727.72387', Oj.dump(1405460727.723866))
-    else
-      assert_equal('1405460727.723866', Oj.dump(1405460727.723866))
-    end
+    assert_equal('1405460727.723866', Oj.dump(1405460727.723866))
     Oj.default_options = { :float_precision => 15 }
     assert_equal('0.56', Oj.dump(0.56))
     assert_equal('0.5773', Oj.dump(0.5773))


### PR DESCRIPTION
Currently we do not support these ruby versions and do not
run tests against them.
So we do not need to check RUBY_VERSION for ruby 1.8 and 1.9.