### PR TITLE
Update oj.gemspec to include a minimum ruby version

### DIFF
--- a/oj.gemspec
+++ b/oj.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
   s.summary = "A fast JSON parser and serializer."
   s.description = %{The fastest JSON parser and object serializer. }
   s.licenses = ['MIT']
+  spec.required_ruby_version = ">= 2.0"
 
   s.files = Dir["{lib,ext,test}/**/*.{rb,h,c}"] + ['LICENSE', 'README.md'] + Dir["pages/*.md"]
   s.test_files = Dir["test/**/*.rb"]


### PR DESCRIPTION
Add minimum ruby version to gemspec, so it can be reported by rubygems.