### PR TITLE
Relax a version constraint on rake-compiler

### DIFF
--- a/oj.gemspec
+++ b/oj.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = 'oj'
 
-  s.add_development_dependency 'rake-compiler', '~> 0.9'
+  s.add_development_dependency 'rake-compiler', '>= 0.9'
   s.add_development_dependency 'minitest', '~> 5'
   s.add_development_dependency 'wwtd', '~> 0'
 end


### PR DESCRIPTION
rake-compiler v1.0 was released on June 20, 2016.
This commit will allow developers to use rake-compiler v1.0.