### PR TITLE
Fix description in gemspec

### DIFF
--- a/oj.gemspec
+++ b/oj.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.email = "peter@ohler.com"
   s.homepage = "http://www.ohler.com/oj"
   s.summary = "A fast JSON parser and serializer."
-  s.description = %{The fastest JSON parser and object serializer. }
+  s.description = "The fastest JSON parser and object serializer."
   s.licenses = ['MIT']
   s.required_ruby_version = ">= 2.0"
 


### PR DESCRIPTION
- remove trailing whitespace
- percent literal not required for simple strings