### PR TITLE
Suppress an open-ended dependency warning

### DIFF
--- a/oj.gemspec
+++ b/oj.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = 'oj'
 
-  s.add_development_dependency 'rake-compiler', '>= 0.9'
+  s.add_development_dependency 'rake-compiler', '>= 0.9', '< 2.0'
   s.add_development_dependency 'minitest', '~> 5'
   s.add_development_dependency 'wwtd', '~> 0'
 end


### PR DESCRIPTION
This commit will suppress an open-ended dependency warning
when `gem build oj.gemspec` is executed.