### PR TITLE
Fix tests which are failed on Ruby trunk

### DIFF
--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -37,7 +37,7 @@ dflags = {
   'HAS_DATA_OBJECT_WRAP' => ('ruby' == type && '2' == version[0] && '3' <= version[1]) ? 1 : 0,
   'HAS_METHOD_ARITY' =>  ('rubinius' == type) ? 0 : 1,
   'HAS_STRUCT_MEMBERS' =>  ('rubinius' == type) ? 0 : 1,
-  'UNIFY_FIXNUM_AND_BIGNUM' => ('ruby' == type && '2' == version[0] && '4' <= version[1]) ? 1 : 0,
+  'UNIFY_FIXNUM_AND_BIGNUM' => ('ruby' == type && '2' == version[0] && '4' == version[1] && '1' >= version[2]) ? 1 : 0,
 }
 # This is a monster hack to get around issues with 1.9.3-p0 on CentOS 5.4. SO
 # some reason math.h and string.h contents are not processed. Might be a


### PR DESCRIPTION
`RSTRUCT_LEN` on Ruby 2.4.0 and 2.4.1 returns an
Integer VALUE. But other versions return `long`.
So we should check patch version of Ruby when
defining `UNIFY_FIXNUM_AND_BIGNUM` macro.

ref:

* Ruby r55788 changed the type of `RSTRUCT_LEN` from
  `long` to an Integer VALUE.
  https://github.com/ruby/ruby/commit/26f59b09fe3a1c2ec50145f7c3d5b425f48a7a32

* Ruby r58359 fixed these incompatibility issue.
  https://github.com/ruby/ruby/commit/8e64799c9614cf18541b04c66a46e0d081d39f57

* Ruby r58636 backported r58359 to 2_4 branch.
  https://svn.ruby-lang.org/cgi-bin/viewvc.cgi?view=revision&revision=58636