### PR TITLE
Rename `UNIFY_FIXNUM_AND_BIGNUM` macro

### DIFF
--- a/ext/oj/custom.c
+++ b/ext/oj/custom.c
@@ -771,11 +771,11 @@ dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
 #endif
 
 #ifdef RSTRUCT_LEN
-#if UNIFY_FIXNUM_AND_BIGNUM
+#if RSTRUCT_LEN_RETURNS_INTEGER_OBJECT
 	cnt = (int)NUM2LONG(RSTRUCT_LEN(obj));
-#else // UNIFY_FIXNUM_AND_BIGNUM
+#else // RSTRUCT_LEN_RETURNS_INTEGER_OBJECT
 	cnt = (int)RSTRUCT_LEN(obj);
-#endif // UNIFY_FIXNUM_AND_BIGNUM
+#endif // RSTRUCT_LEN_RETURNS_INTEGER_OBJECT
 #else
 	// This is a bit risky as a struct in C ruby is not the same as a Struct
 	// class in interpreted Ruby so length() may not be defined.

--- a/ext/oj/dump_compat.c
+++ b/ext/oj/dump_compat.c
@@ -793,11 +793,11 @@ dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
 	    raise_json_err("Only named structs are supported.", "JSONError");
 	}
 #ifdef RSTRUCT_LEN
-#if UNIFY_FIXNUM_AND_BIGNUM
+#if RSTRUCT_LEN_RETURNS_INTEGER_OBJECT
 	cnt = (int)NUM2LONG(RSTRUCT_LEN(obj));
-#else // UNIFY_FIXNUM_AND_BIGNUM
+#else // RSTRUCT_LEN_RETURNS_INTEGER_OBJECT
 	cnt = (int)RSTRUCT_LEN(obj);
-#endif // UNIFY_FIXNUM_AND_BIGNUM
+#endif // RSTRUCT_LEN_RETURNS_INTEGER_OBJECT
 #else
 	// This is a bit risky as a struct in C ruby is not the same as a Struct
 	// class in interpreted Ruby so length() may not be defined.

--- a/ext/oj/dump_object.c
+++ b/ext/oj/dump_object.c
@@ -727,11 +727,11 @@ dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
     {
 	VALUE	v;
 	int	cnt;
-#if UNIFY_FIXNUM_AND_BIGNUM
+#if RSTRUCT_LEN_RETURNS_INTEGER_OBJECT
 	cnt = (int)NUM2LONG(RSTRUCT_LEN(obj));
-#else // UNIFY_FIXNUM_AND_BIGNUM
+#else // RSTRUCT_LEN_RETURNS_INTEGER_OBJECT
 	cnt = (int)RSTRUCT_LEN(obj);
-#endif // UNIFY_FIXNUM_AND_BIGNUM
+#endif // RSTRUCT_LEN_RETURNS_INTEGER_OBJECT
 	
 	for (i = 0; i < cnt; i++) {
 	    v = RSTRUCT_GET(obj, i);

--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -37,7 +37,7 @@ dflags = {
   'HAS_DATA_OBJECT_WRAP' => ('ruby' == type && '2' == version[0] && '3' <= version[1]) ? 1 : 0,
   'HAS_METHOD_ARITY' =>  ('rubinius' == type) ? 0 : 1,
   'HAS_STRUCT_MEMBERS' =>  ('rubinius' == type) ? 0 : 1,
-  'UNIFY_FIXNUM_AND_BIGNUM' => ('ruby' == type && '2' == version[0] && '4' == version[1] && '1' >= version[2]) ? 1 : 0,
+  'RSTRUCT_LEN_RETURNS_INTEGER_OBJECT' => ('ruby' == type && '2' == version[0] && '4' == version[1] && '1' >= version[2]) ? 1 : 0,
 }
 # This is a monster hack to get around issues with 1.9.3-p0 on CentOS 5.4. SO
 # some reason math.h and string.h contents are not processed. Might be a

--- a/ext/oj/object.c
+++ b/ext/oj/object.c
@@ -366,11 +366,11 @@ hat_value(ParseInfo pi, Val parent, const char *key, size_t klen, volatile VALUE
             parent->val = rb_obj_alloc(sc);
             // If the JSON array has more entries than the struct class allows, we record an error.
 #ifdef RSTRUCT_LEN
-#if UNIFY_FIXNUM_AND_BIGNUM
+#if RSTRUCT_LEN_RETURNS_INTEGER_OBJECT
 	    slen = (int)NUM2LONG(RSTRUCT_LEN(parent->val));
-#else // UNIFY_FIXNUM_AND_BIGNUM
+#else // RSTRUCT_LEN_RETURNS_INTEGER_OBJECT
 	    slen = (int)RSTRUCT_LEN(parent->val);
-#endif // UNIFY_FIXNUM_AND_BIGNUM
+#endif // RSTRUCT_LEN_RETURNS_INTEGER_OBJECT
 #else
 	    slen = FIX2INT(rb_funcall2(parent->val, oj_length_id, 0, 0));
 #endif

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -149,11 +149,11 @@ dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
     const char		*name;
 
 #ifdef RSTRUCT_LEN
-#if UNIFY_FIXNUM_AND_BIGNUM
+#if RSTRUCT_LEN_RETURNS_INTEGER_OBJECT
     cnt = (int)NUM2LONG(RSTRUCT_LEN(obj));
-#else // UNIFY_FIXNUM_AND_BIGNUM
+#else // RSTRUCT_LEN_RETURNS_INTEGER_OBJECT
     cnt = (int)RSTRUCT_LEN(obj);
-#endif // UNIFY_FIXNUM_AND_BIGNUM
+#endif // RSTRUCT_LEN_RETURNS_INTEGER_OBJECT
 #else
     // This is a bit risky as a struct in C ruby is not the same as a Struct
     // class in interpreted Ruby so length() may not be defined.


### PR DESCRIPTION
We use this macro only to check we should cast returned value of
`RSTRUCT_LEN` to `long`. So `RSTRUCT_LEN_RETURNS_INTEGER_OBJECT`
is better.
By the way, we can use `RUBY_INTEGER_UNIFICATION` macro to detect
Integer is unified or not.