### PR TITLE
Drop `DATETIME_1_8` macro

### DIFF
--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -32,7 +32,6 @@ dflags = {
   'IS_WINDOWS' => is_windows ? 1 : 0,
   'USE_PTHREAD_MUTEX' => is_windows ? 0 : 1,
   'USE_RB_MUTEX' => (is_windows && !('1' == version[0] && '8' == version[1])) ? 1 : 0,
-  'DATETIME_1_8' => ('ruby' == type && ('1' == version[0] && '8' == version[1])) ? 1 : 0,
   'NO_TIME_ROUND_PAD' => ('rubinius' == type) ? 1 : 0,
   'HAS_DATA_OBJECT_WRAP' => ('ruby' == type && '2' == version[0] && '3' <= version[1]) ? 1 : 0,
   'HAS_METHOD_ARITY' =>  ('rubinius' == type) ? 0 : 1,

--- a/ext/oj/odd.c
+++ b/ext/oj/odd.c
@@ -44,9 +44,6 @@ get_datetime_secs(VALUE obj) {
     long long	num = rb_num2ll(rb_funcall(rfrac, numerator_id, 0));
     long long	den = rb_num2ll(rb_funcall(rfrac, denominator_id, 0));
 
-#if DATETIME_1_8
-    num *= 86400;
-#endif
     num += sec * den;
 
     return rb_funcall(rb_cObject, rational_id, 2, rb_ll2inum(num), rb_ll2inum(den));


### PR DESCRIPTION
We do not support Ruby 1.8, so we can remove this macro.