### PR TITLE
Use `rb_scan_args` to check args

### DIFF
--- a/ext/oj/mimic_json.c
+++ b/ext/oj/mimic_json.c
@@ -485,9 +485,10 @@ oj_mimic_pretty_generate(int argc, VALUE *argv, VALUE self) {
 static VALUE
 mimic_parse_core(int argc, VALUE *argv, VALUE self, bool bang) {
     struct _ParseInfo	pi;
+    VALUE		ropts;
     VALUE		args[1];
 
-    rb_scan_args(argc, argv, "11", NULL, NULL);
+    rb_scan_args(argc, argv, "11", NULL, &ropts);
     parse_info_init(&pi);
     oj_set_compat_callbacks(&pi);
     // TBD
@@ -506,8 +507,7 @@ mimic_parse_core(int argc, VALUE *argv, VALUE self, bool bang) {
     pi.options.mode = CompatMode;
     pi.max_depth = 100;
 
-    if (2 <= argc && Qnil != argv[1]) {
-	VALUE	ropts = argv[1];
+    if (2 <= argc && Qnil != ropts) {
 	VALUE	v;
 
 	if (T_HASH != rb_type(ropts)) {

--- a/ext/oj/mimic_json.c
+++ b/ext/oj/mimic_json.c
@@ -507,7 +507,7 @@ mimic_parse_core(int argc, VALUE *argv, VALUE self, bool bang) {
     pi.options.mode = CompatMode;
     pi.max_depth = 100;
 
-    if (2 <= argc && Qnil != ropts) {
+    if (Qnil != ropts) {
 	VALUE	v;
 
 	if (T_HASH != rb_type(ropts)) {

--- a/ext/oj/mimic_json.c
+++ b/ext/oj/mimic_json.c
@@ -487,9 +487,7 @@ mimic_parse_core(int argc, VALUE *argv, VALUE self, bool bang) {
     struct _ParseInfo	pi;
     VALUE		args[1];
 
-    if (argc < 1) {
-	rb_raise(rb_eArgError, "Wrong number of arguments to parse.");
-    }
+    rb_scan_args(argc, argv, "11", NULL, NULL);
     parse_info_init(&pi);
     oj_set_compat_callbacks(&pi);
     // TBD


### PR DESCRIPTION
If we pass `"11"` to 3rd argument of `rb_scan_args`,
`rb_scan_args` raises `ArgumentError` when `argc` is not
1 nor 2.
This commit changes to raise `ArgumentError` if `argc > 2`.