### PR TITLE
 Fix loading array into struct in hat_value() 

### DIFF
--- a/ext/oj/object.c
+++ b/ext/oj/object.c
@@ -341,7 +341,7 @@ hat_value(ParseInfo pi, Val parent, const char *key, size_t klen, volatile VALUE
             volatile VALUE	sc;
 	    volatile VALUE	e1;
 	    int			slen;
-	    
+
 	    if (0 == len) {
 		oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "Invalid struct data");
 		return 1;
@@ -380,14 +380,14 @@ hat_value(ParseInfo pi, Val parent, const char *key, size_t klen, volatile VALUE
             } else {
 		int	i;
 
-		for (i = 0; i < slen; i++) {
+		for (i = 0; i < len - 1; i++) {
 		    rb_struct_aset(parent->val, INT2FIX(i), RARRAY_PTR(value)[i + 1]);
 		}
             }
 	    return 1;
 	} else if (3 <= klen && '#' == key[1]) {
 	    volatile VALUE	*a;
-	
+
 	    if (2 != len) {
 		oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "invalid hash pair");
 		return 1;
@@ -602,7 +602,7 @@ hash_set_value(ParseInfo pi, Val kval, VALUE value) {
 	    if (3 <= klen && '^' == *key && '#' == key[1] && T_ARRAY == rb_type(value)) {
 		long		len = RARRAY_LEN(value);
 		volatile VALUE	*a = RARRAY_PTR(value);
-	
+
 		if (2 != len) {
 		    oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "invalid hash pair");
 		    return;
@@ -683,7 +683,7 @@ array_append_cstr(ParseInfo pi, const char *str, size_t len, const char *orig) {
 		rb_ary_push(stack_peek(&pi->stack)->val, oj_circ_array_get(pi->circ_array, i));
 		return;
 	    }
-	    
+
 	}
     }
     rb_ary_push(stack_peek(&pi->stack)->val, str_to_value(pi, str, len, orig));

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -805,6 +805,14 @@ class ObjectJuice < Minitest::Test
     assert_equal(h2['b'].__id__, h2.__id__)
   end
 
+
+  def test_json_object_missing_fields
+    json = %{{ "^u": [ "ObjectJuice::Stuck",1]}}
+
+    obj = Oj.load(json, mode: :object)
+    assert_nil(obj['b'])
+  end
+
   def test_circular_array
     a = [7]
     a << a
@@ -895,11 +903,11 @@ class ObjectJuice < Minitest::Test
     json = Oj.dump(jam, :omit_nil => true, :mode => :object)
     assert_equal(%|{"^o":"ObjectJuice::Jam","x":{"a":1}}|, json)
   end
-  
+
   def test_odd_date
     dump_and_load(Date.new(2012, 6, 19), false)
   end
-  
+
   def test_odd_datetime
     dump_and_load(DateTime.new(2012, 6, 19, 13, 5, Rational(4, 3)), false)
     dump_and_load(DateTime.new(2012, 6, 19, 13, 5, Rational(7123456789, 1000000000)), false)


### PR DESCRIPTION
Hi

When loading an array into a new `Struct` with `hat_value()`, `oj` checks if there are more items than `Struct` fields and raises an error if that's the case. It doesn't verify if the number of items is lower than the number of fields. The problem is that when this happens, inexistent values are loaded into the fields which leads to corrupt data and unexpected Ruby crashes.

This PR changes this behavior by only setting the fields for which we have a value in the array. Fields that don't have a defined value will remain `nil`. I also added a test for it but I believe it could lead to Ruby crashes under certain circumstances.

---

After having added a new field on an existing struct, we started experiencing Ruby crashes during garbage collection and weird values in the extra-field, making some data unloadable again. The crashes stopped when finally we removed the newly added field. 

This example illustrates the issue.

```ruby
Sample = Struct.new(
  :id,
  :created_at,
  :content,
  :deleted
)

partial_json_object  = '{ "^u": [ "Sample",2504600553]}'
full_json_object  = '{ "^u": [ "Sample",2504600553,"2017-12-20T15:43:51Z","Test sample",false]}'

puts Oj.load(partial_json_object, mode: :object)
puts Oj.load(full_json_object, mode: :object)


### Without fix, if Ruby doesn't crash
#<struct Sample id=2504600553, created_at=false, content=2737202, deleted=String>
#<struct Sample id=2504600553, created_at="2017-12-20T15:43:51Z", content="Test sample", deleted=false>

### With fix
#<struct Sample id=2504600553, created_at=nil, content=nil, deleted=nil>
#<struct Sample id=2504600553, created_at="2017-12-20T15:43:51Z", content="Test sample", deleted=false>
```

This was tested on OSx and Linux with Ruby 2.4.2 and Oj 3.3.9. I only did a quick run with older gem and Ruby version, but the tests were also crashing or raising weird errors: 
```ruby
test2.rb:13:in `inspect': undefined method `inspect' for #<Enumerable:0x0000000000653f10> (NoMethodError)
	from test2.rb:13:in `puts'
	from test2.rb:13:in `puts'
	from test2.rb:13:in `<main>'
```

/cc @skaes @boosty