### PR TITLE
gemspec: add metadata URLs, drop rubyforge_project

### DIFF
--- a/oj.gemspec
+++ b/oj.gemspec
@@ -9,6 +9,14 @@ Gem::Specification.new do |s|
   s.date = Date.today.to_s
   s.email = "peter@ohler.com"
   s.homepage = "http://www.ohler.com/oj"
+  s.metadata = {
+    "bug_tracker_uri" => "https://github.com/ohler55/oj/issues",
+    "changelog_uri" => "https://github.com/ohler55/oj/blob/master/CHANGELOG.md",
+    "documentation_uri" => "http://www.ohler.com/oj/doc/index.html",
+    "homepage_uri" => "http://www.ohler.com/oj/",
+    "source_code_uri" => "https://github.com/ohler55/oj",
+    "wiki_uri" => "https://github.com/ohler55/oj/wiki"
+  }
   s.summary = "A fast JSON parser and serializer."
   s.description = "The fastest JSON parser and object serializer."
   s.licenses = ['MIT']
@@ -21,8 +29,6 @@ Gem::Specification.new do |s|
   s.has_rdoc = true
   s.extra_rdoc_files = ['README.md'] + Dir["pages/*.md"]
   s.rdoc_options = ['--title', 'Oj', '--main', 'README.md']
-
-  s.rubyforge_project = 'oj'
 
   s.add_development_dependency 'rake-compiler', '>= 0.9', '< 2.0'
   s.add_development_dependency 'minitest', '~> 5'


### PR DESCRIPTION
Hi, and thanks for `oj` for all this time.

I looked at the [metadata](http://guides.rubygems.org/specification-reference/#metadata), and added a few links. These would show up in the RubyGems website interface, and also be neat metadata. 