### PR TITLE
Doc cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,7 +271,7 @@
 
 ## 2.14.1 - 2015-12-15
 
-- Fixed bug that reverted to BigDecimal when a decimal had preceeding zeros after the decimal point.
+- Fixed bug that reverted to BigDecimal when a decimal had preceding zeros after the decimal point.
 
 ## 2.14.0 - 2015-12-04
 
@@ -826,7 +826,7 @@
 ## 1.1.0 - 2012-03-27
 
 - Errors are not longer raised when comments are encountered in JSON documents.
-- Oj can now mimic JSON. With some expections calling JSON.mimic_JSON will allow all JSON calls to use OJ instead of JSON. This gives a speedup of more than 2x on parsing and 5x for generating over the JSON::Ext module.
+- Oj can now mimic JSON. With some exceptions calling JSON.mimic_JSON will allow all JSON calls to use OJ instead of JSON. This gives a speedup of more than 2x on parsing and 5x for generating over the JSON::Ext module.
 - Oj::Doc now allows a document to be left open and then closed with the Oj::Doc.close() class.
 - Changed the default encoding to UTF-8 instead of the Ruby default String encoding.
 

--- a/ext/oj/custom.c
+++ b/ext/oj/custom.c
@@ -1001,7 +1001,7 @@ hash_set_num(struct _ParseInfo *pi, Val kval, NumInfo ni) {
 	    if (86400 == ni->exp) { // UTC time
 		parent->val = rb_time_nano_new(ni->i, (long)nsec);
 		// Since the ruby C routines alway create local time, the
-		// offset and then a convertion to UTC keeps makes the time
+		// offset and then a conversion to UTC keeps makes the time
 		// match the expected value.
 		parent->val = rb_funcall2(parent->val, oj_utc_id, 0, 0);
 	    } else if (ni->hasExp) {

--- a/ext/oj/design.txt
+++ b/ext/oj/design.txt
@@ -8,7 +8,7 @@ The parser in sparse.c is represented by the ParseInfo struct in parser.h. Key e
 
 The options are simply flags and parameters that modify the parse output or behavior. They are constructed from the default options and the arguments to the Ruby calls.
 
-The Reader is defined in reader.h and is struct that represented an object that is able to read bytes from some source and provide those bytes to the parser. The single method on the Reader is the 'read_func' which is a pointer to a function. The function pointed to by this member is selected based on the input type. The psuedo subclasses of the Reader are readers for files, general IO, IO that supports partial reads, and strings. A mentioned earlier the string version does not perform as well as direct string access so the original parser is used instead.
+The Reader is defined in reader.h and is struct that represented an object that is able to read bytes from some source and provide those bytes to the parser. The single method on the Reader is the 'read_func' which is a pointer to a function. The function pointed to by this member is selected based on the input type. The pseudo subclasses of the Reader are readers for files, general IO, IO that supports partial reads, and strings. A mentioned earlier the string version does not perform as well as direct string access so the original parser is used instead.
 
 On the output side the callback functions such as 'start_hash' represent the method of the parser. By assigning different functions to those members the parser is effectively subclassed to be either the object, compat, strict, or SCP parsers. In a future release those callbacks and the specifics of each parser may be pulled out to become the handlers.
 

--- a/ext/oj/mimic_json.c
+++ b/ext/oj/mimic_json.c
@@ -44,13 +44,13 @@ static VALUE	state_class;
 /* Document-method: parser=
  * call-seq: parser=(parser)
  * 
- * Does nothing other than provide compatibiltiy.
+ * Does nothing other than provide compatibility.
  * - *parser* [_Object_] ignored
  */
 /* Document-method: generator=
  * call-seq: generator=(generator)
  * 
- * Does nothing other than provide compatibiltiy.
+ * Does nothing other than provide compatibility.
  * - *generator* [_Object_] ignored
  */
 
@@ -606,7 +606,7 @@ mimic_parse_bang(int argc, VALUE *argv, VALUE self) {
 /* Document-method: recurse_proc
  * call-seq: recurse_proc(obj, &proc)
  * 
- * Yields to the proc for every element in the obj recursivly.
+ * Yields to the proc for every element in the obj recursively.
  * 
  * - *obj* [_Hash_|Array] object to walk
  * - *proc* [_Proc_] to yield to on each element

--- a/ext/oj/object.c
+++ b/ext/oj/object.c
@@ -286,7 +286,7 @@ hat_num(ParseInfo pi, Val parent, Val kval, NumInfo ni) {
 		if (86400 == ni->exp) { // UTC time
 		    parent->val = rb_time_nano_new(ni->i, (long)nsec);
 		    // Since the ruby C routines alway create local time, the
-		    // offset and then a convertion to UTC keeps makes the time
+		    // offset and then a conversion to UTC keeps makes the time
 		    // match the expected value.
 		    parent->val = rb_funcall2(parent->val, oj_utc_id, 0, 0);
 		} else if (ni->hasExp) {

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -1271,7 +1271,7 @@ static DumpFunc	rails_funcs[] = {
     dump_obj,		// RUBY_T_DATA     = 0x0c,
     NULL, 		// RUBY_T_MATCH    = 0x0d,
     // Rails raises a stack error on Complex and Rational. It also corrupts
-    // something whic causes a segfault on the next call. Oj will not mimic
+    // something which causes a segfault on the next call. Oj will not mimic
     // that behavior.
     dump_as_string, 	// RUBY_T_COMPLEX  = 0x0e,
     dump_as_string, 	// RUBY_T_RATIONAL = 0x0f,

--- a/ext/oj/saj.c
+++ b/ext/oj/saj.c
@@ -52,7 +52,7 @@ static void	skip_comment(ParseInfo pi);
  * a SAX parser because it uses callback when document elements are
  * encountered.
  *
- * Parsing is very tolerant. Lack of headers and even mispelled element
+ * Parsing is very tolerant. Lack of headers and even misspelled element
  * endings are passed over without raising an error. A best attempt is made in
  * all cases to parse the string.
  */

--- a/pages/Encoding.md
+++ b/pages/Encoding.md
@@ -10,7 +10,7 @@ in a JSON document. The formatting follows these rules.
  * JSON native types, true, false, nil, String, Hash, Array, and Number are
    encoded normally.
 
- * A Symbol is encoded as a JSON string with a preceeding `':'` character.
+ * A Symbol is encoded as a JSON string with a preceding `':'` character.
 
  * The `'^'` character denotes a special key value when in a JSON Object sequence.
 
@@ -28,7 +28,7 @@ in a JSON document. The formatting follows these rules.
  * A `"^o"` JSON Object key indicates the value should be converted to a Ruby
    Object. The first entry in the JSON Object must be a class with the `"^o"`
    key. After that each entry is treated as a variable of the Object where the
-   key is the variable name without the preceeding `'@'`. An example is
+   key is the variable name without the preceding `'@'`. An example is
    `{"^o":"Oj::Bag","x":58,"y":"marbles"}`. `"^O"`is the same except that it
    is for built in or odd classes that don't obey the normal Ruby
    rules. Examples are Rational, Date, and DateTime.
@@ -40,7 +40,7 @@ in a JSON document. The formatting follows these rules.
    `{"^u":["Range",1,7,false]}`.
 
  * When encoding an Object, if the variable name does not begin with an
-   `'@'`character then the name preceeded by a `'~'` character. This occurs in
+   `'@'`character then the name preceded by a `'~'` character. This occurs in
    the Exception class. An example is `{"^o":"StandardError","~mesg":"A
    Message","~bt":[".\/tests.rb:345:in 'test_exception'"]}`.
 

--- a/pages/Options.md
+++ b/pages/Options.md
@@ -80,7 +80,7 @@ dynamically modifying classes or reloading classes then don't use this.
 
 ### :create_additions
 
-A flag indicating the :create_id key when encounterd during parsing should
+A flag indicating the :create_id key when encountered during parsing should
 creating an Object mactching the class name specified in the value associated
 with the key.
 

--- a/pages/Rails.md
+++ b/pages/Rails.md
@@ -78,7 +78,7 @@ Oj::Rails.optimize is called with no arguments are:
  * any other class where all attributes should be dumped
 
 The ActiveSupport decoder is the JSON.parse() method. Calling the
-Oj::Rails.set_decoder() method replaces that method with the Oj equivelant.
+Oj::Rails.set_decoder() method replaces that method with the Oj equivalent.
 
 ### Notes:
 

--- a/pages/Rails.md
+++ b/pages/Rails.md
@@ -93,6 +93,22 @@ Oj::Rails.set_decoder() method replaces that method with the Oj equivalent.
    are used as keys or if a other non-String objects such as Numerics are mixed
    with numbers as Strings.
 
-3. To verify Oj is being used turn on trace and then set the
-   `Tracer.display_c_call = true` to see calls to C extensions.
-   
+3. To verify Oj is being used, turn on C extension tracing.
+   Set `tracer = TracePoint.new(:c_call) do |tp| p [tp.lineno, tp.event, tp.defined_class, tp.method_id] end`
+   or, in older Rubies, set `Tracer.display_c_call = true`.
+
+   For example:
+
+     ```
+     require 'active_support/core_ext'
+     require 'active_support/json'
+     require 'oj'
+     Oj.optimize_rails
+     tracer.enable { Time.now.to_json }
+     # prints output including
+     ....
+     [20, :c_call, #<Class:Oj::Rails::Encoder>, :new]
+     [20, :c_call, Oj::Rails::Encoder, :encode]
+     ....
+     => "\"2018-02-23T12:13:42.493-06:00\""
+     ```

--- a/test/json_gem/README.md
+++ b/test/json_gem/README.md
@@ -2,4 +2,4 @@
 
 Ported from [ruby/test/json](https://github.com/ruby/ruby/tree/trunk/test/json).
 
-Omited - tests which Oj will not support.
+Omitted - tests which Oj will not support.


### PR DESCRIPTION
- Update Rails docs to describe TracePoint usage

- Fix some typos

```bash
misspell  -w -error -source=text -i "clas,class" .
```

I'm not sure if the `clas/class` is important. I didn't look too hard.

There's also an interesting false positive matching 'alse' for false, though I don't
know why the 'f' is missing offhand.

```
+++ b/ext/oj/sparse.c
@@ -161,7 +161,7 @@ read_true(ParseInfo pi) {

 static void
 read_false(ParseInfo pi) {
-    if (0 == reader_expect(&pi->rd, "alse")) {
+    if (0 == reader_expect(&pi->rd, "else")) {
```