### PR TITLE
fix Twitter link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ See [{file:CHANGELOG.md}](CHANGELOG.md)
 
 - *RubyGems* *repo*: https://rubygems.org/gems/oj
 
-Follow [@peterohler on Twitter](http://twitter.com/#!/peterohler) for announcements and news about the Oj gem.
+Follow [@peterohler on Twitter](http://twitter.com/peterohler) for announcements and news about the Oj gem.
 
 #### Performance Comparisons
 


### PR DESCRIPTION
Twitter broke their JS-style links.