### PR TITLE
Fix stack limits with unlimited stacks

### DIFF
--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -839,7 +839,7 @@ parse_json(VALUE clas, char *json, bool given, bool allocated) {
     {
 	struct rlimit	lim;
 
-	if (0 == getrlimit(RLIMIT_STACK, &lim)) {
+	if (0 == getrlimit(RLIMIT_STACK, &lim) && RLIM_INFINITY != lim.rlim_cur) {
 	    pi.stack_min = (void*)((char*)&lim - (lim.rlim_cur / 4 * 3)); // let 3/4ths of the stack be used only
 	} else {
 	    pi.stack_min = 0; // indicates not to check stack limit

--- a/ext/oj/saj.c
+++ b/ext/oj/saj.c
@@ -626,7 +626,7 @@ saj_parse(VALUE handler, char *json) {
     {
 	struct rlimit	lim;
 
-	if (0 == getrlimit(RLIMIT_STACK, &lim)) {
+	if (0 == getrlimit(RLIMIT_STACK, &lim) && RLIM_INFINITY != lim.rlim_cur) {
 	    pi.stack_min = (void*)((char*)&obj - (lim.rlim_cur / 4 * 3)); /* let 3/4ths of the stack be used only */
 	} else {
 	    pi.stack_min = 0; /* indicates not to check stack limit */


### PR DESCRIPTION
The maximum size of the stack of a process can be set to be unlimited; in this case, the calculated stack limit in oj itself basically allows no extra stack for nested JSONs, which are not parsed.

As solution, do not set a limit in case the resource limit result is `RLIM_INFINITY` (i.e. not set).

This can be reproduced on Linux by wrapping the test run with prlimit(1), e.g.
  `prlimit --stack=-1:-1 ruby etc...`