### PR TITLE
Update YARD comment to avoid warning

### DIFF
--- a/lib/oj/mimic.rb
+++ b/lib/oj/mimic.rb
@@ -31,7 +31,7 @@ module Oj
   end
 
   # Loads mimic-ed JSON paths. Used by Oj.mimic_JSON().
-  # @param mimic_path [Array] additional paths to add to the Ruby loaded features.
+  # @param mimic_paths [Array] additional paths to add to the Ruby loaded features.
   def self.mimic_loaded(mimic_paths=[])
     $LOAD_PATH.each do |d|
       next unless File.exist?(d)


### PR DESCRIPTION
This PR fixes a YARD comment warning:

```
lib/oj/mimic.rb:34: [UnknownParam] @param tag has unknown parameter name: mimic_path. Did you mean `mimic_paths`?
```