### PR TITLE
Stop removing `::Parser` top-level constant

### DIFF
--- a/lib/oj/json.rb
+++ b/lib/oj/json.rb
@@ -95,7 +95,7 @@ module JSON
   State = ::JSON::Ext::Generator::State unless defined?(::JSON::State)
 
   begin
-    Object.send(:remove_const, :Parser)
+    send(:remove_const, :Parser)
   rescue
   end
   Parser = ::JSON::Ext::Parser unless defined?(::JSON::Parser)


### PR DESCRIPTION
This library, as it stands, is removing the top-level `::Parser` constant when the `json.rb` file is required. That breaks the require of other libraries that depend on the `::Parser` constant being available (for example, from https://github.com/whitequark/parser):

```ruby
$ bundle exec pry
[1] pry(main)> require 'parser'
=> true
[2] pry(main)> require 'oj/json'
=> true
[3] pry(main)> require 'rubocop'
NameError: uninitialized constant RuboCop::AST::Parser
Did you mean?  ParseError
from /Users/ufuk/.gem/ruby/2.5.5/gems/rubocop-0.72.0/lib/rubocop/ast/node.rb:21:in `<module:AST>'
```

Instead, the intent here seems to be to just remove the `Parser` constant in the current namespace, which can achieved by doing a simple `remove_const :Parser`.