### PR TITLE
Read initial escape_html from active_support in rails mode

### DIFF
--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -1071,6 +1071,8 @@ rails_set_encoder(VALUE self) {
     rb_undef_method(encoding, "use_standard_json_time_format=");
     rb_define_module_function(encoding, "use_standard_json_time_format=", rails_use_standard_json_time_format, 1);
 
+    pv = rb_iv_get(encoding, "@escape_html_entities_in_json");
+    escape_html = Qtrue == pv;
     rb_undef_method(encoding, "escape_html_entities_in_json=");
     rb_define_module_function(encoding, "escape_html_entities_in_json=", rails_escape_html_entities_in_json, 1);
 


### PR DESCRIPTION
ActiveSupport configuration usually happens in environment files via app configuration which takes precedence over initializers where `Oj.optimize_rails` supposed to be called. This PR modifies set_encoder method to read initial `escape_html_entities_in_json` value from ActiveSupport