### PR TITLE
Use double rather than long double in oj_num_as_value

### DIFF
--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -795,13 +795,13 @@ oj_num_as_value(NumInfo ni) {
 	    }
 	} else {
 	    // All these machinations are to get rounding to work better.
-	    long double	d = (long double)ni->i * (long double)ni->div + (long double)ni->num;
-	    int		x = (int)((int64_t)ni->exp - ni->di);
+	    double d = (double)ni->i * (double)ni->div + (double)ni->num;
+	    int	x = (int)((int64_t)ni->exp - ni->di);
 
 	    // Rounding sometimes cuts off the last digit even if there are only
 	    // 15 digits. This attempts to fix those few cases where this
 	    // occurs.
-	    if ((long double)INT64_MAX > d && (int64_t)d != (ni->i * ni->div + ni->num)) {
+	    if ((double)INT64_MAX > d && (int64_t)d != (ni->i * ni->div + ni->num)) {
 		volatile VALUE	bd = rb_str_new(ni->str, ni->len);
 
 		rnum = rb_rescue2(parse_big_decimal, bd, rescue_big_decimal, bd, rb_eException, 0);
@@ -809,16 +809,16 @@ oj_num_as_value(NumInfo ni) {
 		    rnum = rb_funcall(rnum, rb_intern("to_f"), 0);
 		}
 	    } else {
-		d = roundl(d);
+		d = round(d);
 		if (0 < x) {
-		    d *= powl(10.0L, x);
+		    d *= pow(10.0, x);
 		} else if (0 > x) {
-		    d /= powl(10.0L, -x);
+		    d /= pow(10.0, -x);
 		}
 		if (ni->neg) {
 		    d = -d;
 		}
-		rnum = rb_float_new((double)d);
+		rnum = rb_float_new(d);
 	    }
 	}
     }

--- a/test/json_gem/json_common_interface_test.rb
+++ b/test/json_gem/json_common_interface_test.rb
@@ -15,7 +15,7 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
   def setup
     @hash = {
       'a' => 2,
-      'b' => 3.141,
+      'b' => 5.23683071,
       'c' => 'c',
       'd' => [ 1, "b", 3.14 ],
       'e' => { 'foo' => 'bar' },
@@ -23,7 +23,7 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
       'h' => 1000.0,
       'i' => 0.001
     }
-    @json = '{"a":2,"b":3.141,"c":"c","d":[1,"b",3.14],"e":{"foo":"bar"},'\
+    @json = '{"a":2,"b":5.23683071,"c":"c","d":[1,"b",3.14],"e":{"foo":"bar"},'\
       '"g":"\\"\\u0000\\u001f","h":1000.0,"i":0.001}'
   end
 


### PR DESCRIPTION
Fixes #538.

It seems that double are already enough, and better handled by ruby
internals:

```c
VALUE working() {
  long double d = 5.23683071;
  return rb_float_new((double)d);
}

VALUE not_working() {
  long double d = 5.23683071L;
  return rb_float_new((double)d);
}

void Init_main() {
  rb_define_global_function("working", working, 0);
  rb_define_global_function("not_working", not_working, 0);
}
```

`working` returns the correct value, `not_working` returns a floating
point issued stuff (5.2368307099999996).

Moreover, long double are not widely supported in ruby, for instance in
vsnprintf.c, line 528:

```c
#define	LONGDBL		0x008		/* long double; unimplemented */
```

Or the ffi lib doesn't seem to like it either: https://github.com/ffi/ffi/issues/194