### PR TITLE
run on latest Ruby runtimes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ env:
 language: ruby
 rvm:
   - 2.3.8
-  - 2.4.9
-  - 2.5.7
-  - 2.6.5
-  - 2.7.0
+  - 2.4.10
+  - 2.5.8
+  - 2.6.6
+  - 2.7.1
 
 gemfile:
   - gemfiles/no_rails.gemfile
@@ -22,29 +22,27 @@ gemfile:
 
 matrix:
   fast_finish: true
-  allow_failures:
-    - rvm: 2.6.5 # travis doesn't have this version on some macOSs
 
   exclude:
     - gemfile: gemfiles/no_rails.gemfile
       rvm: 2.3.8
     - gemfile: gemfiles/no_rails.gemfile
-      rvm: 2.4.9
+      rvm: 2.4.10
       os: osx
     - gemfile: gemfiles/rails_5.gemfile
-      rvm: 2.4.9
+      rvm: 2.4.10
       os: osx
     - gemfile: gemfiles/rails_5.gemfile
-      rvm: 2.5.7
+      rvm: 2.5.8
       os: osx
     # Rails 6 only support Ruby 2.5 and above.
     - gemfile: gemfiles/rails_6.gemfile
       rvm: 2.3.8
     - gemfile: gemfiles/rails_6.gemfile
-      rvm: 2.4.9
+      rvm: 2.4.10
     - os: osx
       rvm: 2.3.8
     - os: osx
-      rvm: 2.4.9
+      rvm: 2.4.10
     - os: osx
-      rvm: 2.5.7
+      rvm: 2.5.8


### PR DESCRIPTION
#### description

There has been an update on the Ruby releases since March 31.
https://www.ruby-lang.org/en/downloads/releases/

- 2.4.10
- 2.5.8
- 2.6.6
- 2.7.1
