### PR TITLE
Enabled wider compatibility for .compat_load, better parity with JSON.parse in Ruby

### DIFF
--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -212,18 +212,6 @@ read_escaped_str(ParseInfo pi, const char *start) {
 	    case '"':	buf_append(&buf, '"');	break;
 	    case '/':	buf_append(&buf, '/');	break;
 	    case '\\':	buf_append(&buf, '\\');	break;
-	    case '\'':
-		// The json gem claims this is not an error despite the
-		// ECMA-404 indicating it is not valid.
-		if (CompatMode == pi->options.mode) {
-		    buf_append(&buf, '\'');
-		} else {
-		    pi->cur = s;
-		    oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "invalid escaped character");
-		    buf_cleanup(&buf);
-		    return;
-		}
-		break;
 	    case 'u':
 		s++;
 		if (0 == (code = read_hex(pi, s)) && err_has(&pi->err)) {
@@ -263,6 +251,12 @@ read_escaped_str(ParseInfo pi, const char *start) {
 		}
 		break;
 	    default:
+		// The json gem claims this is not an error despite the
+		// ECMA-404 indicating it is not valid.
+		if (CompatMode == pi->options.mode) {
+		    buf_append(&buf, *s);
+		    break;
+		}
 		pi->cur = s;
 		oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "invalid escaped character");
 		buf_cleanup(&buf);

--- a/ext/oj/sparse.c
+++ b/ext/oj/sparse.c
@@ -225,17 +225,6 @@ read_escaped_str(ParseInfo pi) {
 	    case '"':	buf_append(&buf, '"');	break;
 	    case '/':	buf_append(&buf, '/');	break;
 	    case '\\':	buf_append(&buf, '\\');	break;
-	    case '\'':
-		// The json gem claims this is not an error despite the
-		// ECMA-404 indicating it is not valid.
-		if (CompatMode == pi->options.mode) {
-		    buf_append(&buf, '\'');
-		} else {
-		    oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "invalid escaped character");
-		    buf_cleanup(&buf);
-		    return;
-		}
-		break;
 	    case 'u':
 		if (0 == (code = read_hex(pi)) && err_has(&pi->err)) {
 		    buf_cleanup(&buf);
@@ -273,6 +262,12 @@ read_escaped_str(ParseInfo pi) {
 		}
 		break;
 	    default:
+		// The json gem claims this is not an error despite the
+		// ECMA-404 indicating it is not valid.
+		if (CompatMode == pi->options.mode) {
+		    buf_append(&buf, c);
+		    break;
+		}
 		oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "invalid escaped character");
 		buf_cleanup(&buf);
 		return;

--- a/test/test_compat.rb
+++ b/test/test_compat.rb
@@ -236,6 +236,12 @@ class CompatJuice < Minitest::Test
     assert_equal({"a\nb" => true, "c\td" => false}, obj)
   end
 
+  def test_invalid_escapes_handled
+    json = '{"subtext":"\"404er\” \w \k \3 \a"}'
+    obj = Oj.compat_load(json)
+    assert_equal({"subtext" => "\"404er” w k 3 a"}, obj)
+  end
+
   def test_hash_escaping
     json = Oj.to_json({'<>' => '<>'}, mode: :compat)
     assert_equal(json, '{"<>":"<>"}')


### PR DESCRIPTION
Greater parity with `JSON.parse` on ruby, where it will ignore `/` in case of an invalid escape character. Such as `\”` (curly double quote) will be parsed to just `”`