### PR TITLE
Fix respond_to? on EasyHash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.11.3 - 2021-03-09
+
+- Fixed `respond_to?` method on `Oj::EasyHash`.
+
 ## 3.11.2 - 2021-01-27
 
 - Fixed JSON gem `:decimal_class` option.

--- a/lib/oj/easy_hash.rb
+++ b/lib/oj/easy_hash.rb
@@ -12,13 +12,14 @@ module Oj
 
     # Replaces the Object.respond_to?() method.
     # @param [Symbol] m method symbol
+    # @param [Boolean] include_all whether to include private and protected methods in the search
     # @return [Boolean] true for any method that matches an instance
     #                   variable reader, otherwise false.
-    def respond_to?(m)
+    def respond_to?(m, include_all = false)
       return true if super
-      return true if has_key?(key)
-      return true if has_key?(key.to_s)
-      has_key?(key.to_sym)
+      return true if has_key?(m)
+      return true if has_key?(m.to_s)
+      has_key?(m.to_sym)
     end
 
     def [](key)

--- a/test/test_hash.rb
+++ b/test/test_hash.rb
@@ -25,5 +25,15 @@ class Hashi < Minitest::Test
     assert_equal(3, obj[:abc])
     assert_equal(3, obj.abc())
   end
+
+  def test_marshal
+    h = Oj::EasyHash.new()
+    h['abc'] = 3
+    out = Marshal.dump(h)
+
+    obj = Marshal.load(out)
+    assert_equal(Oj::EasyHash, obj.class)
+    assert_equal(3, obj[:abc])
+  end
   
 end # HashTest


### PR DESCRIPTION
This fixes the wrong variable name in the `respond_to?` method. I found it when tried to serialize an instance of `Oj::EasyHash` using `Marshal.dump`.

Also, it adds an optional second argument to fix the deprecation warning:

```
warning: Oj::EasyHash#respond_to?(:marshal_dump) uses the deprecated method signature, which takes one parameter
```

Probably, not many people use this class, but in some cases I find it very useful and definitely more performant than `ActiveSupport::HashWithIndifferentAccess`.