### PR TITLE
Install rails dependency for osx in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ env:
   global:
     - MAKE="make -j 2"
 
+addons:
+  homebrew:
+    packages:
+      - shared-mime-info
+
 language: ruby
 rvm:
   - 2.4.10
@@ -15,11 +20,6 @@ rvm:
   - 2.7.2
   - 3.0.0
   #- ruby-head
-
-addons:
-  homebrew:
-    packages:
-      - shared-mime-info
 
 gemfile:
   - gemfiles/no_rails.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,6 @@ env:
   global:
     - MAKE="make -j 2"
 
-addons:
-  homebrew:
-    packages:
-      - shared-mime-info
-
 language: ruby
 rvm:
   - 2.4.10

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rails", "5.2.3"
+gem "rails", "5.2.5"
 gem "sqlite3"
 
 gemspec :path => "../"

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "rails", "6.0.0"
+gem "rails", "6.0.3.6"
 gem "sqlite3"
 
 gemspec :path => "../"


### PR DESCRIPTION
Update Rails versions to skip broken `mimemagic` gem and skip `shared-mime-info` native extension installation.
https://github.com/rails/rails/issues/41750