### PR TITLE
Add support Rails 6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ gemfile:
   - gemfiles/no_rails.gemfile
   - gemfiles/rails_5.gemfile
   - gemfiles/rails_6.gemfile
+  - gemfiles/rails_6.1.gemfile
 
 matrix:
   fast_finish: true
@@ -39,6 +40,8 @@ matrix:
       os: osx
     # Rails 6 only support Ruby 2.5 and above.
     - gemfile: gemfiles/rails_6.gemfile
+      rvm: 2.4.10
+    - gemfile: gemfiles/rails_6.1.gemfile
       rvm: 2.4.10
     - os: osx
       rvm: 2.4.10

--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ task :test_all => [:clean, :compile] do
   cmds = "ruby test/tests.rb && ruby test/tests_mimic.rb && ruby test/tests_mimic_addition.rb"
   puts "\n" + "#"*90
   puts cmds
-  Bundler.with_clean_env do
+  Bundler.with_original_env do
     status = system(cmds)
   end
   exitcode = 1 unless status
@@ -36,7 +36,7 @@ task :test_all => [:clean, :compile] do
       cmd = "REAL_JSON_GEM=1 bundle exec ruby -Itest #{file}"
       puts "\n" + "#"*90
       puts cmd
-      Bundler.with_clean_env do
+      Bundler.with_original_env do
         status = system(cmd)
       end
       exitcode = 1 unless status

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gem "rails", "6.1.3.1"
+gem "sqlite3"
+
+gemspec :path => "../"

--- a/test/activerecord/result_test.rb
+++ b/test/activerecord/result_test.rb
@@ -21,7 +21,12 @@ class ActiveRecordResultTest < Minitest::Test
 					["row 3 col 1", "row 3 col 2"],
 				      ])
     #puts "*** result: #{Oj.dump(result, indent: 2)}"
-   
-    assert_equal Oj.dump(result, mode: :rails), Oj.dump(result.to_hash)
+    json_result = if ActiveRecord.version >= Gem::Version.new("6")
+                    result.to_a
+                  else
+                    result.to_hash
+                  end
+
+    assert_equal Oj.dump(result, mode: :rails), Oj.dump(json_result)
   end
 end


### PR DESCRIPTION
Add support of Rails 6.1 in Travis
Rails 6 deprecated `ActiveRecord::Base#to_hash`.
Rails 6.1 removed `ActiveRecord::Base#to_hash`.
https://github.com/rails/rails/pull/33912

Bundler 2.x deprecated `Bundler.with_clean_env`
https://github.com/rubygems/rubygems/blob/a969c0f16aa56cdb69e2a051f2b093427010e1d9/bundler/UPGRADING.md#helper-deprecations