### PR TITLE
Make sure Oj.default_options hash is unable to be modified directly

### DIFF
--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -499,7 +499,7 @@ static VALUE get_def_opts(VALUE self) {
         }
         rb_hash_aset(opts, ignore_sym, a);
     }
-    return opts;
+    return rb_obj_freeze(opts);
 }
 
 /* Document-method: default_options=

--- a/test/test_various.rb
+++ b/test/test_various.rb
@@ -152,6 +152,10 @@ class Juice < Minitest::Test
     assert_equal(orig, opts);
   end
 
+  def test_options_frozen
+    assert_raises(FrozenError) { Oj.default_options[:mode] = :strict }
+  end
+
   def test_nil
     dump_and_load(nil, false)
   end


### PR DESCRIPTION
Since modifying the hash is not supported, we can freeze it to avoid possible mistakes.

> Attempting to modify the Oj.default_options Hash directly will not set the changes on the actual default options but on a copy of the Hash