### PR TITLE
Improve `Oj.dump` performance with `Time` object

### DIFF
--- a/ext/oj/dump_compat.c
+++ b/ext/oj/dump_compat.c
@@ -645,6 +645,16 @@ dump_float(VALUE obj, int depth, Out out, bool as_ok) {
     *out->cur = '\0';
 }
 
+static void
+dump_time(VALUE obj, int depth, Out out, bool as_ok) {
+    if ((as_ok && rb_respond_to(obj, oj_to_json_id)) &&
+        (Yes == out->opts->to_json || rb_respond_to(obj, oj_as_json_id))) {
+        dump_to_json(obj, out);
+        return;
+    }
+    oj_dump_ruby_time(obj, out);
+}
+
 static int
 hash_cb(VALUE key, VALUE value, VALUE ov) {
     Out	out = (Out)ov;
@@ -765,6 +775,11 @@ dump_obj(VALUE obj, int depth, Out out, bool as_ok) {
     if (Yes == out->opts->raw_json && rb_respond_to(obj, oj_raw_json_id)) {
 	oj_dump_raw_json(obj, depth, out);
 	return;
+    }
+
+    if (rb_cTime == rb_obj_class(obj)) {
+        dump_time(obj, depth, out, as_ok);
+        return;
     }
     if (as_ok && rb_respond_to(obj, oj_to_json_id)) {
 	dump_to_json(obj, out);

--- a/ext/oj/dump_compat.c
+++ b/ext/oj/dump_compat.c
@@ -800,12 +800,12 @@ dump_obj(VALUE obj, int depth, Out out, bool as_ok) {
 	return;
     }
 
-    if (as_ok && rb_respond_to(obj, oj_as_json_id)) {
-        dump_as_json(obj, depth, out, true);
-        return;
-    }
     if (rb_cTime == rb_obj_class(obj)) {
-        oj_dump_ruby_time(obj, out);
+        if (as_ok && rb_respond_to(obj, oj_as_json_id)) {
+            dump_as_json(obj, depth, out, true);
+        } else {
+            oj_dump_ruby_time(obj, out);
+        }
         return;
     }
     if (as_ok && rb_respond_to(obj, oj_to_json_id)) {


### PR DESCRIPTION
If `Time#to_json` existed, it would have been called.
And `Time#to_json` is quite slow.

However, if you just call `require 'json'` before, it would define `Time#to_json`.
`Time#to_json` and `Time#to_s` have same behavior until overriding `Time#to_json` by calling `require 'json/add/time'`.

If you really want to use `Time#to_json`, you can use `use_to_json` flag.
`Oj.dump(Time.now, mode: :compat, use_to_json: true)`

−               | before   | after    | result
--               | --       | --       | --
Oj.dump          | 4.454M   | 4.452M   | -
Oj.dump (compat) | 585.849k | 1.038M   | 1.77x
Oj.dump (rails)  | 1.012M   | 1.006M   | -

### Environment
- MacBook Air (M1, 2020)
- macOS 12.0 beta 4
- Apple M1
- Ruby 3.0.2

### Before
```
Warming up --------------------------------------
       JSON.generate    61.732k i/100ms
             Oj.dump   452.219k i/100ms
    Oj.dump (compat)    59.191k i/100ms
     Oj.dump (rails)   101.236k i/100ms
Calculating -------------------------------------
       JSON.generate    610.348k (± 0.7%) i/s -      3.087M in   5.057383s
             Oj.dump      4.454M (± 0.8%) i/s -     22.611M in   5.077251s
    Oj.dump (compat)    585.849k (± 0.9%) i/s -      2.960M in   5.052141s
     Oj.dump (rails)      1.012M (± 0.6%) i/s -      5.062M in   5.004297s
```

### After
```
Warming up --------------------------------------
       JSON.generate    60.994k i/100ms
             Oj.dump   443.062k i/100ms
    Oj.dump (compat)   102.736k i/100ms
     Oj.dump (rails)   101.957k i/100ms
Calculating -------------------------------------
       JSON.generate    614.990k (± 1.0%) i/s -      3.111M in   5.058600s
             Oj.dump      4.452M (± 0.9%) i/s -     22.596M in   5.075861s
    Oj.dump (compat)      1.038M (± 0.9%) i/s -      5.240M in   5.047304s
     Oj.dump (rails)      1.006M (± 0.8%) i/s -      5.098M in   5.067830s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'
require 'json'

data = {
  created_at: Time.now,
}

Benchmark.ips do |x|
  x.report('JSON.generate') { JSON.generate(data) }
  x.report('Oj.dump') { Oj.dump(data) }
  x.report('Oj.dump (compat)') { Oj.dump(data, mode: :compat) }
  x.report('Oj.dump (rails)') { Oj.dump(data, mode: :rails) }
end
```