### PR TITLE
Reduce memory usage in `Oj.load` with using Ruby 3.0 feature

### DIFF
--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -31,6 +31,7 @@ have_func('rb_gc_mark_movable')
 have_func('stpcpy')
 have_func('pthread_mutex_init')
 have_func('rb_enc_associate')
+have_func('rb_enc_interned_str')
 have_func('rb_ext_ractor_safe', 'ruby.h')
 # rb_hash_bulk_insert is deep down in a header not included in normal build and that seems to fool have_func.
 have_func('rb_hash_bulk_insert', 'ruby.h') unless '2' == version[0] && '6' == version[1]

--- a/ext/oj/object.c
+++ b/ext/oj/object.c
@@ -64,12 +64,16 @@ static VALUE calc_hash_key(ParseInfo pi, Val kval, char k1) {
         if (Yes == pi->options.sym_key) {
             rkey = ID2SYM(rb_intern3(kval->key, kval->klen, oj_utf8_encoding));
         } else {
+#if HAVE_RB_ENC_INTERNED_STR
+            rkey = rb_enc_interned_str(kval->key, kval->klen, oj_utf8_encoding);
+#else
             rkey = rb_str_new(kval->key, kval->klen);
             rkey = oj_encode(rkey);
+            OBJ_FREEZE(rkey);
+#endif
         }
     }
 #endif
-    OBJ_FREEZE(rkey);
     return rkey;
 }
 

--- a/ext/oj/strict.c
+++ b/ext/oj/strict.c
@@ -35,18 +35,22 @@ VALUE oj_calc_hash_key(ParseInfo pi, Val parent) {
         if (Yes == pi->options.sym_key) {
             rkey = ID2SYM(rb_intern3(parent->key, parent->klen, oj_utf8_encoding));
         } else {
+#if HAVE_RB_ENC_INTERNED_STR
+            rkey = rb_enc_interned_str(parent->key, parent->klen, oj_utf8_encoding);
+#else
             rkey = rb_str_new(parent->key, parent->klen);
             rkey = oj_encode(rkey);
+            OBJ_FREEZE(rkey);
+#endif
         }
-        OBJ_FREEZE(rkey);
         return rkey;
     }
     if (Yes == pi->options.sym_key) {
 	rkey = oj_sym_intern(parent->key, parent->klen);
     } else {
 	rkey = oj_str_intern(parent->key, parent->klen);
-    }
     OBJ_FREEZE(rkey);
+    }
     return rkey;
 }
 

--- a/ext/oj/wab.c
+++ b/ext/oj/wab.c
@@ -305,11 +305,15 @@ static VALUE calc_hash_key(ParseInfo pi, Val parent) {
     if (Yes == pi->options.cache_keys) {
         rkey = oj_sym_intern(parent->key, parent->klen);
     } else {
+#if HAVE_RB_ENC_INTERNED_STR
+        rkey = rb_enc_interned_str(parent->key, parent->klen, oj_utf8_encoding);
+#else
         rkey = rb_str_new(parent->key, parent->klen);
         rkey = oj_encode(rkey);
         rkey = rb_str_intern(rkey);
+        OBJ_FREEZE(rkey);
+#endif
     }
-    OBJ_FREEZE(rkey);
     return rkey;
 }
 


### PR DESCRIPTION
`rb_enc_interned_str()` was added in Ruby 3.0 which returns frozen string object.

It has same effect with `# frozen_string_literal: true` magic comment and
The object will be reused and reduce memory usage if you create a frozen String
with the same C string over and over.

Here is memory usage with sample code.

−               | before   | after
--               | --       | --
Oj.dump          | 33.904k  | 25.904k

### Environment
- MacBook Air (M1, 2020)
- macOS 12.0 beta 4
- Apple M1
- Ruby 3.0.2

### Before
```
[CPU]====================
Warming up --------------------------------------
             Oj.load     3.855k i/100ms
Calculating -------------------------------------
             Oj.load     38.190k (± 0.7%) i/s -    192.750k in   5.047359s
[MEMORY]====================
Calculating -------------------------------------
             Oj.load    33.904k memsize (     0.000  retained)
                       502.000  objects (     0.000  retained)
                         4.000  strings (     0.000  retained)
```

### After
```
[CPU]====================
Warming up --------------------------------------
             Oj.load     3.758k i/100ms
Calculating -------------------------------------
             Oj.load     37.368k (± 0.9%) i/s -    187.900k in   5.028814s
[MEMORY]====================
Calculating -------------------------------------
             Oj.load    25.904k memsize (     0.000  retained)
                       302.000  objects (     0.000  retained)
                         2.000  strings (     0.000  retained)
```

### Test code
Before, following objects will be generated for one Hash object

- A Hash object
- Two String as Hash key
- Two String as Hash value

After, the same hash keys will be reused.
(The following objects will be generated for one Hash object with this patch)

- A Hash object
- Two String as Hash value

```ruby
require 'benchmark/ips'
require 'benchmark/memory'
require 'oj'

item = {
  "type" => "string",
  "description" => "The important things"
}

data = (1..100).map { item }
json = Oj.dump(data)

puts "[CPU]" + "=" * 20
Benchmark.ips do |x|
  x.report('Oj.load') { Oj.load(json) }
end

puts "[MEMORY]" + "=" * 20
Benchmark.memory do |x|
  x.report('Oj.load') { Oj.load(json) }
end
```