### PR TITLE
Fix `Oj::Doc` behaviour for inexisting path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # CHANGELOG
 
+- Fix `Oj::Doc` behaviour for inexisting path.
+  ```ruby
+  Oj::Doc.open('{"foo":1}') do |doc|
+    doc.fetch('/foo/bar') # used to give `1`, now gives `nil`
+    doc.exists?('/foo/bar') # used to give `true`, now gives `false`
+  end
+  ```
+
 ## 3.13.7 - 2021-09-16
 
 - The JSON gem allows invalid unicode so Oj, when mimicing JSON now

--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -879,6 +879,10 @@ static Leaf get_leaf(Leaf *stack, Leaf *lp, const char *path) {
             }
         } else if (NULL == leaf->elements) {
             leaf = NULL;
+        } else if (STR_VAL == leaf->value_type || RUBY_VAL == leaf->value_type) {
+            // We are trying to get a children of a leaf, which
+            // doesn't exist.
+            leaf = NULL;
         } else if (COL_VAL == leaf->value_type) {
             Leaf first = leaf->elements->next;
             Leaf e     = first;
@@ -1373,8 +1377,8 @@ static VALUE doc_fetch(int argc, VALUE *argv, VALUE self) {
  * Returns true if the value at the location identified by the path exists.
  *   @param [String] path path to the location
  * @example
- *   Oj::Doc.open('[1,2]') { |doc| doc.exists('/1') }  #=> true
- *   Oj::Doc.open('[1,2]') { |doc| doc.exists('/3') }  #=> false
+ *   Oj::Doc.open('[1,2]') { |doc| doc.exists?('/1') }  #=> true
+ *   Oj::Doc.open('[1,2]') { |doc| doc.exists?('/3') }  #=> false
  */
 static VALUE doc_exists(VALUE self, VALUE str) {
     Doc  doc;

--- a/test/test_fast.rb
+++ b/test/test_fast.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# encoding: utf-8
+# frozen_string_literal: true
 
 $: << File.dirname(__FILE__)
 
@@ -33,6 +33,17 @@ class DocTest < Minitest::Test
     Oj::Doc.open(json) do |doc|
       assert_equal(NilClass, doc.type)
       assert_nil(doc.fetch())
+    end
+  end
+
+  def test_leaf_of_existing_path
+    json = %{{"foo": 1, "fizz": true}}
+    Oj::Doc.open(json) do |doc|
+      %w(/foo/bar /fizz/bar).each do |path|
+        assert_nil(doc.fetch(path))
+        assert_equal(:default, doc.fetch(path, :default))
+        refute(doc.exists?(path))
+      end
     end
   end
 
@@ -282,11 +293,11 @@ class DocTest < Minitest::Test
        ['/nothing', nil],
        ['/array/10', nil],
       ].each do |path,val|
-	if val.nil?
-	  assert_nil(doc.fetch(path))
-	else
+        if val.nil?
+          assert_nil(doc.fetch(path))
+        else
           assert_equal(val, doc.fetch(path))
-	end
+        end
       end
     end
     # verify empty hash and arrays return nil when a member is requested
@@ -313,7 +324,7 @@ class DocTest < Minitest::Test
     end
   end
 
-  def test_exisits
+  def test_exists
     Oj::Doc.open(@json1) do |doc|
       [['/array/1', true],
        ['/array/1', true],
@@ -322,7 +333,7 @@ class DocTest < Minitest::Test
        ['/array/3', false],
        ['/nothing', false],
       ].each do |path,val|
-        assert_equal(val, doc.exists?(path))
+        assert_equal(val, doc.exists?(path), "failed for #{path.inspect}")
       end
     end
   end


### PR DESCRIPTION
```ruby
Oj::Doc.open('{"foo":1}') do |doc|
  doc.fetch('/foo/bar') # used to give `1`, now gives `nil`
  doc.exists?('/foo/bar') # used to give `true`, now gives `false`
end
```

Closes #707
