### PR TITLE
Fix rails version check is weird

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -52,7 +52,7 @@ task :default => :test_all
 begin
   require "rails/version"
 
-  if Rails.version =~ /4\.\d/
+  if Rails.version =~ /^4\.\d/
     Rake::TestTask.new "activesupport4" do |t|
       t.libs << 'test'
       t.pattern = 'test/activesupport4/*_test.rb'
@@ -62,7 +62,7 @@ begin
     Rake::Task[:test_all].enhance ["activesupport4"]
   end
 
-  if Rails.version =~ /5\.\d/
+  if Rails.version =~ /^5\.\d/
     Rake::TestTask.new "activesupport5" do |t|
       t.libs << 'test'
       t.pattern = 'test/activesupport5/*_test.rb'
@@ -72,7 +72,7 @@ begin
     Rake::Task[:test_all].enhance ["activesupport5"]
   end
 
-  if Rails.version =~ /6\.\d/
+  if Rails.version =~ /^6\.\d/
     Rake::TestTask.new "activesupport6" do |t|
       t.libs << 'test'
       t.pattern = 'test/activesupport6/*_test.rb'


### PR DESCRIPTION
if rails version is 6.1.4.1, `Rails.version =~ /4\.\d/` is evaluated as true.
hence regular expressions must check start character.