### PR TITLE
Update usage of :bigdecimal_as_decimal in Rails Mode

### DIFF
--- a/pages/Modes.md
+++ b/pages/Modes.md
@@ -141,7 +141,7 @@ information.
  3. By default the bigdecimal_as decimal is not set and the default encoding
     for Rails is as a string. Setting the value to true will encode a
     BigDecimal as a number which breaks compatibility.
-    **Beware**: after version 3.11.3 both `Oj.generate` and `JSON.generate`
+    Note: after version 3.11.3 both `Oj.generate` and `JSON.generate`
     will not honour this option in Rails Mode, detais on https://github.com/ohler55/oj/pull/716.
 
  4. The integer indent value in the default options will be honored by since


### PR DESCRIPTION
The option `:bigdecimal_as_decimal` is not available in Rails Mode (as discussed here https://github.com/ohler55/oj/issues/693), as the original JSON and Rails implementation does not have a way to "force" bigdecimal values to be encoded as numbers in json.