### PR TITLE
Reduce rb_type() calling in `Oj.dump`

### DIFF
--- a/ext/oj/dump_object.c
+++ b/ext/oj/dump_object.c
@@ -226,47 +226,54 @@ static int hash_cb(VALUE key, VALUE value, VALUE ov) {
     }
     assure_size(out, size);
     fill_indent(out, depth);
-    if (rb_type(key) == T_STRING) {
+    switch (rb_type(key)) {
+    case T_STRING:
         dump_str_class(key, Qundef, depth, out);
         *out->cur++ = ':';
         oj_dump_obj_val(value, depth, out);
-    } else if (rb_type(key) == T_SYMBOL) {
+        break;
+
+    case T_SYMBOL:
         dump_sym(key, 0, out, false);
         *out->cur++ = ':';
         oj_dump_obj_val(value, depth, out);
-    } else {
-        int     d2 = depth + 1;
-        long    s2 = size + out->indent + 1;
-        int     i;
-        int     started = 0;
-        uint8_t b;
+        break;
 
-        assure_size(out, s2 + 15);
-        *out->cur++ = '"';
-        *out->cur++ = '^';
-        *out->cur++ = '#';
-        out->hash_cnt++;
-        for (i = 28; 0 <= i; i -= 4) {
-            b = (uint8_t)((out->hash_cnt >> i) & 0x0000000F);
-            if ('\0' != b) {
-                started = 1;
+    default:
+        {
+            int     d2 = depth + 1;
+            long    s2 = size + out->indent + 1;
+            int     i;
+            int     started = 0;
+            uint8_t b;
+
+            assure_size(out, s2 + 15);
+            *out->cur++ = '"';
+            *out->cur++ = '^';
+            *out->cur++ = '#';
+            out->hash_cnt++;
+            for (i = 28; 0 <= i; i -= 4) {
+                b = (uint8_t)((out->hash_cnt >> i) & 0x0000000F);
+                if ('\0' != b) {
+                    started = 1;
+                }
+                if (started) {
+                    *out->cur++ = hex_chars[b];
+                }
             }
-            if (started) {
-                *out->cur++ = hex_chars[b];
-            }
+            *out->cur++ = '"';
+            *out->cur++ = ':';
+            *out->cur++ = '[';
+            fill_indent(out, d2);
+            oj_dump_obj_val(key, d2, out);
+            assure_size(out, s2);
+            *out->cur++ = ',';
+            fill_indent(out, d2);
+            oj_dump_obj_val(value, d2, out);
+            assure_size(out, size);
+            fill_indent(out, depth);
+            *out->cur++ = ']';
         }
-        *out->cur++ = '"';
-        *out->cur++ = ':';
-        *out->cur++ = '[';
-        fill_indent(out, d2);
-        oj_dump_obj_val(key, d2, out);
-        assure_size(out, s2);
-        *out->cur++ = ',';
-        fill_indent(out, d2);
-        oj_dump_obj_val(value, d2, out);
-        assure_size(out, size);
-        fill_indent(out, depth);
-        *out->cur++ = ']';
     }
     out->depth  = depth;
     *out->cur++ = ',';


### PR DESCRIPTION
This patch will use switch statement instead to reduce times of rb_type() calling with if statement.

−               | before  | after    | result
--               | --      | --       | --
Oj.dump          | 1.175M  | 1.191M   | 1.014x

### Environment
- MacBook Air (M1, 2020)
- macOS 12.0
- Apple M1
- Ruby 3.0.2

### Before
```
Warming up --------------------------------------
             Oj.dump   119.325k i/100ms
Calculating -------------------------------------
             Oj.dump      1.175M (± 0.3%) i/s -      5.966M in   5.079028
```

### After
```
Warming up --------------------------------------
             Oj.dump   117.261k i/100ms
Calculating -------------------------------------
             Oj.dump      1.191M (± 0.5%) i/s -      5.980M in   5.021336s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

json =<<-EOF
{
  "$id": "https://example.com/person.schema.json",
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "title": "Person",
  "type": "object",
  "properties": {
    "firstName": {
      "type": "string",
      "description": "The person's first name."
    },
    "lastName": {
      "type": "string",
      "description": "The person's last name."
    },
    "age": {
      "description": "Age in years which must be equal to or greater than zero.",
      "type": "integer",
      "minimum": 0
    }
  }
}
EOF

data = Oj.load(json, symbol_keys: true)
Benchmark.ips do |x|
  x.report("Oj.dump") { Oj.dump(data) }
end
```