### PR TITLE
Use rb_type() to check primitive class type

### DIFF
--- a/ext/oj/compat.c
+++ b/ext/oj/compat.c
@@ -45,7 +45,7 @@ static void hash_set_cstr(ParseInfo pi, Val kval, const char *str, size_t len, c
                 rstr = rb_funcall(clas, oj_json_create_id, 1, rstr);
             }
         }
-        if (rb_cHash != rb_obj_class(parent->val)) {
+        if (T_HASH != rb_type(parent->val)) {
             // The rb_hash_set would still work but the unit tests for the
             // json gem require the less efficient []= method be called to set
             // values. Even using the store method to set the values will fail
@@ -125,7 +125,7 @@ static void add_num(ParseInfo pi, NumInfo ni) {
 static void hash_set_num(struct _parseInfo *pi, Val parent, NumInfo ni) {
     volatile VALUE rval = oj_num_as_value(ni);
 
-    if (!oj_use_hash_alt && rb_cHash != rb_obj_class(parent->val)) {
+    if (!oj_use_hash_alt && T_HASH != rb_type(parent->val)) {
         // The rb_hash_set would still work but the unit tests for the
         // json gem require the less efficient []= method be called to set
         // values. Even using the store method to set the values will fail
@@ -144,7 +144,7 @@ static void hash_set_num(struct _parseInfo *pi, Val parent, NumInfo ni) {
 }
 
 static void hash_set_value(ParseInfo pi, Val parent, VALUE value) {
-    if (rb_cHash != rb_obj_class(parent->val)) {
+    if (T_HASH != rb_type(parent->val)) {
         // The rb_hash_set would still work but the unit tests for the
         // json gem require the less efficient []= method be called to set
         // values. Even using the store method to set the values will fail
@@ -176,7 +176,7 @@ static void array_append_num(ParseInfo pi, NumInfo ni) {
     Val            parent = stack_peek(&pi->stack);
     volatile VALUE rval   = oj_num_as_value(ni);
 
-    if (!oj_use_array_alt && rb_cArray != rb_obj_class(parent->val)) {
+    if (!oj_use_array_alt && T_ARRAY != rb_type(parent->val)) {
         // The rb_ary_push would still work but the unit tests for the json
         // gem require the less efficient << method be called to push the
         // values.

--- a/ext/oj/dump_compat.c
+++ b/ext/oj/dump_compat.c
@@ -149,7 +149,7 @@ dump_array(VALUE a, int depth, Out out, bool as_ok) {
 	raise_json_err("Too deeply nested", "NestingError");
 	return;
     }
-    if (as_ok && !oj_use_hash_alt && rb_obj_class(a) != rb_cArray && rb_respond_to(a, oj_to_json_id)) {
+    if (as_ok && !oj_use_hash_alt && T_ARRAY != rb_type(a) && rb_respond_to(a, oj_to_json_id)) {
 	dump_to_json(a, out);
 	return;
     }
@@ -712,7 +712,7 @@ dump_hash(VALUE obj, int depth, Out out, bool as_ok) {
 	raise_json_err("Too deeply nested", "NestingError");
 	return;
     }
-    if (as_ok && !oj_use_hash_alt && rb_obj_class(obj) != rb_cHash && rb_respond_to(obj, oj_to_json_id)) {
+    if (as_ok && !oj_use_hash_alt && T_HASH != rb_type(obj) && rb_respond_to(obj, oj_to_json_id)) {
 	dump_to_json(obj, out);
 	return;
     }

--- a/ext/oj/object.c
+++ b/ext/oj/object.c
@@ -536,7 +536,7 @@ WHICH_TYPE:
         }
         break;
     case T_HASH:
-        if (rb_cHash != rb_obj_class(parent->val)) {
+        if (T_HASH != rb_type(parent->val)) {
             if (4 == klen && 's' == *key && 'e' == key[1] && 'l' == key[2] && 'f' == key[3]) {
                 rb_funcall(parent->val, oj_replace_id, 1, value);
             } else {


### PR DESCRIPTION
It seems slightly faster to use `rb_type()` to check for primitive class types than `rb_obj_class()​`.

−               | before   | after    | result
--               | --       | --       | --
Oj.dump          | 439.927k | 442.567k | 1.006x

### Environment
- MacBook Pro (M1 Max, 2021)
- macOS 12.0
- Apple M1 Max
- Ruby 3.0.2

### Before
```
Warming up --------------------------------------
Oj.load(symbol_keys)    44.036k i/100ms
Calculating -------------------------------------
Oj.load(symbol_keys)    439.927k (± 0.3%) i/s -      4.404M in  10.009941s
```

### After
```
Warming up --------------------------------------
Oj.load(symbol_keys)    44.146k i/100ms
Calculating -------------------------------------
Oj.load(symbol_keys)    442.567k (± 0.3%) i/s -      4.459M in  10.074843s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

json =<<-EOF
{
  "$id": "https://example.com/person.schema.json",
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "title": "Person",
  "type": "object",
  "properties": {
    "firstName": {
      "type": "string",
      "description": "The person's first name."
    },
    "lastName": {
      "type": "string",
      "description": "The person's last name."
    },
    "age": {
      "description": "Age in years which must be equal to or greater than zero.",
      "type": "integer",
      "minimum": 0
    }
  }
}
EOF

Benchmark.ips do |x|
  x.warmup = 10
  x.time = 10

  x.report('Oj.load(symbol_keys)') { Oj.load(json, symbol_keys:true) }
end
```