### PR TITLE
Make `oj_dump_ignore()` an inline function

### DIFF
--- a/ext/oj/custom.c
+++ b/ext/oj/custom.c
@@ -282,7 +282,7 @@ static int hash_cb(VALUE key, VALUE value, VALUE ov) {
     Out out   = (Out)ov;
     int depth = out->depth;
 
-    if (oj_dump_ignore(out->opts, value)) {
+    if (dump_ignore(out->opts, value)) {
         return ST_CONTINUE;
     }
     if (out->omit_nil && Qnil == value) {
@@ -577,7 +577,7 @@ static int dump_attr_cb(ID key, VALUE value, VALUE ov) {
     size_t      size;
     const char *attr;
 
-    if (oj_dump_ignore(out->opts, value)) {
+    if (dump_ignore(out->opts, value)) {
         return ST_CONTINUE;
     }
     if (out->omit_nil && Qnil == value) {

--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -1225,17 +1225,3 @@ int oj_dump_float_printf(char *buf, size_t blen, VALUE obj, double d, const char
     }
     return cnt;
 }
-
-bool oj_dump_ignore(Options opts, VALUE obj) {
-    if (NULL != opts->ignore && (ObjectMode == opts->mode || CustomMode == opts->mode)) {
-        VALUE *vp   = opts->ignore;
-        VALUE  clas = rb_obj_class(obj);
-
-        for (; Qnil != *vp; vp++) {
-            if (clas == *vp) {
-                return true;
-            }
-        }
-    }
-    return false;
-}

--- a/ext/oj/dump.h
+++ b/ext/oj/dump.h
@@ -50,7 +50,6 @@ extern VALUE oj_remove_to_json(int argc, VALUE *argv, VALUE self);
 
 extern int oj_dump_float_printf(char *buf, size_t blen, VALUE obj, double d, const char *format);
 
-extern bool   oj_dump_ignore(Options opts, VALUE obj);
 extern time_t oj_sec_from_time_hard_way(VALUE obj);
 
 inline static void assure_size(Out out, size_t len) {
@@ -67,6 +66,20 @@ inline static void fill_indent(Out out, int cnt) {
             *out->cur++ = ' ';
         }
     }
+}
+
+inline static bool dump_ignore(Options opts, VALUE obj) {
+    if (NULL != opts->ignore && (ObjectMode == opts->mode || CustomMode == opts->mode)) {
+        VALUE *vp   = opts->ignore;
+        VALUE  clas = rb_obj_class(obj);
+
+        for (; Qnil != *vp; vp++) {
+            if (clas == *vp) {
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 inline static void dump_ulong(unsigned long num, Out out) {

--- a/ext/oj/dump_object.c
+++ b/ext/oj/dump_object.c
@@ -218,7 +218,7 @@ static int hash_cb(VALUE key, VALUE value, VALUE ov) {
     int  depth = out->depth;
     long size  = depth * out->indent + 1;
 
-    if (oj_dump_ignore(out->opts, value)) {
+    if (dump_ignore(out->opts, value)) {
         return ST_CONTINUE;
     }
     if (out->omit_nil && Qnil == value) {
@@ -349,7 +349,7 @@ static int dump_attr_cb(ID key, VALUE value, VALUE ov) {
     size_t      size  = depth * out->indent + 1;
     const char *attr  = rb_id2name(key);
 
-    if (oj_dump_ignore(out->opts, value)) {
+    if (dump_ignore(out->opts, value)) {
         return ST_CONTINUE;
     }
     if (out->omit_nil && Qnil == value) {
@@ -612,7 +612,7 @@ static void dump_obj_attrs(VALUE obj, VALUE clas, slot_t id, int depth, Out out)
             }
             value = rb_ivar_get(obj, vid);
 
-            if (oj_dump_ignore(out->opts, value)) {
+            if (dump_ignore(out->opts, value)) {
                 continue;
             }
             if (out->omit_nil && Qnil == value) {
@@ -737,7 +737,7 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
 
         for (i = 0; i < cnt; i++) {
             v = RSTRUCT_GET(obj, i);
-            if (oj_dump_ignore(out->opts, v)) {
+            if (dump_ignore(out->opts, v)) {
                 v = Qnil;
             }
             assure_size(out, size);
@@ -755,7 +755,7 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
         for (i = 0; i < slen; i++) {
             assure_size(out, size);
             fill_indent(out, d3);
-            if (oj_dump_ignore(out->opts, v)) {
+            if (dump_ignore(out->opts, v)) {
                 v = Qnil;
             }
             oj_dump_obj_val(rb_struct_aref(obj, INT2FIX(i)), d3, out, 0, 0, true);


### PR DESCRIPTION
To improve `Oj.dump` performance, this PR make `oj_dump_ignore()` an inline function.

−               | before | after  | result
--               | --     | --     | --
Oj.dump          | 1.190M | 1.216M | 1.022x

### Environment
- MacBook Pro (M1 Max, 2021)
- macOS 12.0
- Apple M1 Max
- Ruby 3.0.2

### Before
```
Warming up --------------------------------------
             Oj.dump   119.103k i/100ms
Calculating -------------------------------------
             Oj.dump      1.190M (± 0.7%) i/s -     11.910M in  10.009672s
```

### After
```
Warming up --------------------------------------
             Oj.dump   121.394k i/100ms
Calculating -------------------------------------
             Oj.dump      1.216M (± 0.5%) i/s -     12.261M in  10.086493s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

json =<<-EOF
{
  "$id": "https://example.com/person.schema.json",
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "title": "Person",
  "type": "object",
  "properties": {
    "firstName": {
      "type": "string",
      "description": "The person's first name."
    },
    "lastName": {
      "type": "string",
      "description": "The person's last name."
    },
    "age": {
      "description": "Age in years which must be equal to or greater than zero.",
      "type": "integer",
      "minimum": 0
    }
  }
}
EOF

Benchmark.ips do |x|
  x.warmup = 10
  x.time = 10

  data = Oj.load(json, symbol_keys: true)
  x.report('Oj.dump') { Oj.dump(data) }
end
```