### PR TITLE
Use RARRAY_AREF() instead to improve array accessing

### DIFF
--- a/ext/oj/custom.c
+++ b/ext/oj/custom.c
@@ -749,7 +749,7 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
             } else {
                 fill_indent(out, d2);
             }
-            oj_dump_custom_val(rb_ary_entry(a, i), d2, out, true);
+            oj_dump_custom_val(RARRAY_AREF(a, i), d2, out, true);
             if (i < cnt) {
                 *out->cur++ = ',';
             }
@@ -833,7 +833,7 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
             v = rb_struct_aref(obj, INT2FIX(i));
 #endif
             if (ma != Qnil) {
-                volatile VALUE s = rb_sym2str(rb_ary_entry(ma, i));
+                volatile VALUE s = rb_sym2str(RARRAY_AREF(ma, i));
 
                 name = RSTRING_PTR(s);
                 len  = (int)RSTRING_LEN(s);

--- a/ext/oj/dump_compat.c
+++ b/ext/oj/dump_compat.c
@@ -182,7 +182,7 @@ dump_array(VALUE a, int depth, Out out, bool as_ok) {
 	    } else {
 		fill_indent(out, d2);
 	    }
-	    oj_dump_compat_val(rb_ary_entry(a, i), d2, out, true);
+	    oj_dump_compat_val(RARRAY_AREF(a, i), d2, out, true);
 	    if (i < cnt) {
 		*out->cur++ = ',';
 	    }

--- a/ext/oj/dump_object.c
+++ b/ext/oj/dump_object.c
@@ -157,7 +157,7 @@ static void dump_array_class(VALUE a, VALUE clas, int depth, Out out) {
             } else {
                 fill_indent(out, d2);
             }
-            oj_dump_obj_val(rb_ary_entry(a, i), d2, out);
+            oj_dump_obj_val(RARRAY_AREF(a, i), d2, out);
             if (i < cnt) {
                 *out->cur++ = ',';
             }
@@ -701,7 +701,7 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
 
         *out->cur++ = '[';
         for (i = 0; i < cnt; i++) {
-            volatile VALUE s = rb_sym2str(rb_ary_entry(ma, i));
+            volatile VALUE s = rb_sym2str(RARRAY_AREF(ma, i));
 
             name = RSTRING_PTR(s);
             len  = (int)RSTRING_LEN(s);

--- a/ext/oj/dump_strict.c
+++ b/ext/oj/dump_strict.c
@@ -153,9 +153,9 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
                 fill_indent(out, d2);
             }
             if (NullMode == out->opts->mode) {
-                oj_dump_null_val(rb_ary_entry(a, i), d2, out);
+                oj_dump_null_val(RARRAY_AREF(a, i), d2, out);
             } else {
-                oj_dump_strict_val(rb_ary_entry(a, i), d2, out);
+                oj_dump_strict_val(RARRAY_AREF(a, i), d2, out);
             }
             if (i < cnt) {
                 *out->cur++ = ',';

--- a/ext/oj/mimic_json.c
+++ b/ext/oj/mimic_json.c
@@ -272,7 +272,7 @@ static int mimic_walk(VALUE key, VALUE obj, VALUE proc) {
         size_t i;
 
         for (i = 0; i < cnt; i++) {
-            mimic_walk(Qnil, rb_ary_entry(obj, i), proc);
+            mimic_walk(Qnil, RARRAY_AREF(obj, i), proc);
         }
         break;
     }

--- a/ext/oj/object.c
+++ b/ext/oj/object.c
@@ -325,7 +325,7 @@ static int hat_value(ParseInfo pi, Val parent, const char *key, size_t klen, vol
                 int            i, cnt = (int)RARRAY_LEN(e1);
 
                 for (i = 0; i < cnt; i++) {
-                    rstr    = rb_ary_entry(e1, i);
+                    rstr    = RARRAY_AREF(e1, i);
                     args[i] = rb_funcall(rstr, oj_to_sym_id, 0);
                 }
                 sc = rb_funcall2(rb_cStruct, oj_new_id, cnt, args);

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -916,7 +916,7 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
 
                 copts->ignore = ALLOC_N(VALUE, cnt + 1);
                 for (i = 0; i < cnt; i++) {
-                    copts->ignore[i] = rb_ary_entry(v, i);
+                    copts->ignore[i] = RARRAY_AREF(v, i);
                 }
                 copts->ignore[i] = Qnil;
             }

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -157,7 +157,7 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
     assure_size(out, 2);
     *out->cur++ = '{';
     for (i = 0; i < cnt; i++) {
-        volatile VALUE s = rb_sym2str(rb_ary_entry(ma, i));
+        volatile VALUE s = rb_sym2str(RARRAY_AREF(ma, i));
 
         name = RSTRING_PTR(s);
         len  = (int)RSTRING_LEN(s);
@@ -383,7 +383,7 @@ static StrLen columns_array(VALUE rcols, int *ccnt) {
     *ccnt = cnt;
     cols  = ALLOC_N(struct _strLen, cnt);
     for (i = 0, cp = cols; i < cnt; i++, cp++) {
-        v = rb_ary_entry(rcols, i);
+        v = RARRAY_AREF(rcols, i);
         if (T_STRING != rb_type(v)) {
             v = rb_funcall(v, oj_to_s_id, 0);
         }
@@ -420,7 +420,7 @@ static void dump_row(VALUE row, StrLen cols, int ccnt, int depth, Out out) {
         }
         oj_dump_cstr(cols->str, cols->len, 0, 0, out);
         *out->cur++ = ':';
-        dump_rails_val(rb_ary_entry(row, i), depth, out, true);
+        dump_rails_val(RARRAY_AREF(row, i), depth, out, true);
         if (i < ccnt - 1) {
             *out->cur++ = ',';
         }
@@ -490,7 +490,7 @@ static void dump_activerecord_result(VALUE obj, int depth, Out out, bool as_ok) 
         } else {
             fill_indent(out, d2);
         }
-        dump_row(rb_ary_entry(rows, i), cols, ccnt, d2, out);
+        dump_row(RARRAY_AREF(rows, i), cols, ccnt, d2, out);
         if (i < rcnt - 1) {
             *out->cur++ = ',';
         }
@@ -1281,7 +1281,7 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
             } else {
                 fill_indent(out, d2);
             }
-            dump_rails_val(rb_ary_entry(a, i), d2, out, true);
+            dump_rails_val(RARRAY_AREF(a, i), d2, out, true);
             if (i < cnt) {
                 *out->cur++ = ',';
             }

--- a/ext/oj/wab.c
+++ b/ext/oj/wab.c
@@ -128,7 +128,7 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
         for (i = 0; i <= cnt; i++) {
             assure_size(out, size);
             fill_indent(out, d2);
-            oj_dump_wab_val(rb_ary_entry(a, i), d2, out);
+            oj_dump_wab_val(RARRAY_AREF(a, i), d2, out);
             if (i < cnt) {
                 *out->cur++ = ',';
             }


### PR DESCRIPTION
`rb_ary_entry()` includes boundary value handling, etc.

```c
static inline VALUE
rb_ary_entry_internal(VALUE ary, long offset)
{
    long len = RARRAY_LEN(ary);
    const VALUE *ptr = RARRAY_CONST_PTR_TRANSIENT(ary);
    if (len == 0) return Qnil;
    if (offset < 0) {
        offset += len;
        if (offset < 0) return Qnil;
    }
    else if (len <= offset) {
        return Qnil;
    }
    return ptr[offset];
}
```

Oj has simply array handling and it does not need them.
This patch will cut off the these overheads.

−               | before | after  | result
--               | --     | --     | --
Oj.dump          | 1.593M | 1.687M | 1.059x

### Environment
- MacBook Pro (14 inch, 2021)
- macOS 12.0
- Apple M1 Max
- Ruby 3.0.2

### Before
```
Warming up --------------------------------------
             Oj.dump   159.458k i/100ms
Calculating -------------------------------------
             Oj.dump      1.593M (± 0.6%) i/s -     15.946M in  10.010658s
```

### After
```
Warming up --------------------------------------
             Oj.dump   168.482k i/100ms
Calculating -------------------------------------
             Oj.dump      1.687M (± 0.4%) i/s -     17.017M in  10.084360s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

data = {
  "strings": ("a".."z").to_a,
}

Benchmark.ips do |x|
  x.warmup = 10
  x.time = 10

  x.report('Oj.dump') { Oj.dump(data) }
end
```