### PR TITLE
Actions - Add Windows CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - develop
-      - master
+      - '*'
   pull_request:
 
 jobs:
@@ -45,6 +44,25 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake
+
+  Windows:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ ucrt, '3.0', 2.7, 2.6 ]
+
+    env:
+      BUNDLE_GEMFILE: gemfiles/no_rails.gemfile
+      MAKE: make -j 2
+    runs-on: windows-2022
+    name: Ruby ${{ matrix.ruby }} (windows-2022)
+    steps:
+      - uses: actions/checkout@v2
+      - uses: MSP-Greg/ruby-setup-ruby@win-ucrt-1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ Gemfile.lock
 *.so
 vendor
 gemfiles/*.lock
+tmp

--- a/Rakefile
+++ b/Rakefile
@@ -17,12 +17,12 @@ end
 =end
 
 task :test_all => [:clean, :compile] do
+  STDOUT.flush
   exitcode = 0
   status = 0
 
   cmds = "ruby test/tests.rb && ruby test/tests_mimic.rb && ruby test/tests_mimic_addition.rb"
-  puts "\n" + "#"*90
-  puts cmds
+  STDOUT.syswrite "\n#{'#'*90}\n#{cmds}\n"
   Bundler.with_original_env do
     status = system(cmds)
   end
@@ -33,10 +33,10 @@ task :test_all => [:clean, :compile] do
   # tests.
   if RUBY_VERSION >= '2.4'
     Dir.glob('test/json_gem/*_test.rb').each do |file|
-      cmd = "REAL_JSON_GEM=1 bundle exec ruby -Itest #{file}"
-      puts "\n" + "#"*90
-      puts cmd
+      cmd = "bundle exec ruby -Itest #{file}"
+      STDOUT.syswrite "\n#{'#'*90}\n#{cmd}\n"
       Bundler.with_original_env do
+        ENV['REAL_JSON_GEM'] = '1'
         status = system(cmd)
       end
       exitcode = 1 unless status

--- a/test/test_saj.rb
+++ b/test/test_saj.rb
@@ -180,7 +180,7 @@ class SajTest < Minitest::Test
     assert_equal([:add_value, 12345, nil], handler.calls.first)
     type, message, line, column = handler.calls.last
     assert_equal([:error, 1, 6], [type, line, column])
-    assert_match(%r{invalid format, extra characters at line 1, column 6 \[(?:[a-z\.]+/)*saj\.c:\d+\]}, message)
+    assert_match(%r{invalid format, extra characters at line 1, column 6 \[(?:[A-Za-z]:\/)?(?:[a-z\.]+/)*saj\.c:\d+\]}, message)
   end
 
 end


### PR DESCRIPTION
This adds basic CI for Windows, Ruby 2.6 thru head (ucrt)

1. '[CI] - add windows-2022 2.6 - master' - workflow - added a separate job for Windows.  Also, removed the restriction on branches, which allows people to run CI in their forks.  If you do work here in another branch and the merge the branches, this may run CI twice.  I can revert.

2. 'test_saj.rb - fix for windows paths' - simple fix for windows paths

3. '[CI] rakefile & .gitignore' - Rakefile - Make cmd handling cross-platform.  Actions CI does 'odd' things with STDOUT, especially on Windows.  Added changes in rakefile are to display output in correct order.  Added tmp dir to .gitignore.

Happy to change anything...