### PR TITLE
Add Ruby 3.1 into CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -14,6 +14,7 @@ jobs:
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         ruby:
           - head
+          - '3.1'
           - '3.0'
           - '2.7'
           - '2.6'
@@ -39,7 +40,7 @@ jobs:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
       MAKE: make -j 2
     runs-on: ${{ matrix.os }}-latest
-    continue-on-error: ${{ matrix.ruby == '3.0' || matrix.ruby == 'head'}}
+    continue-on-error: ${{ matrix.ruby == 'head'}}
     name: Ruby ${{ matrix.ruby }} (${{ matrix.os }}${{ matrix.gemfile != 'no_rails' && ', ' || '' }}${{ matrix.gemfile != 'no_rails' && matrix.gemfile || '' }})
     steps:
       - uses: actions/checkout@v2
@@ -53,7 +54,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ ucrt, '3.0', 2.7, 2.6 ]
+        ruby: [ ucrt, '3.1', '3.0', '2.7', '2.6' ]
 
     env:
       BUNDLE_GEMFILE: gemfiles/no_rails.gemfile


### PR DESCRIPTION
Seems that Ruby 3.1 was relased at all platforms.

- https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/
- https://rubyinstaller.org/2021/12/31/rubyinstaller-3.1.0-1-released.html

So, this PR will add Ruby 3.1 into CI.