### PR TITLE
Use index of encoding whether it need to convert

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -703,9 +703,10 @@ void oj_write_obj_to_stream(VALUE obj, VALUE stream, Options copts) {
 }
 
 void oj_dump_str(VALUE obj, int depth, Out out, bool as_ok) {
-    rb_encoding *enc = rb_enc_get(obj);
+    int idx = RB_ENCODING_GET(obj);
 
-    if (oj_utf8_encoding != enc) {
+    if (oj_utf8_encoding_index != idx) {
+        rb_encoding *enc = rb_enc_from_index(idx);
         obj = rb_str_conv_enc(obj, enc, oj_utf8_encoding);
     }
     oj_dump_cstr(RSTRING_PTR(obj), (int)RSTRING_LEN(obj), 0, 0, out);

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -153,6 +153,7 @@ static VALUE xmlschema_sym;
 static VALUE xss_safe_sym;
 
 rb_encoding *oj_utf8_encoding = 0;
+int oj_utf8_encoding_index = 0;
 
 #ifdef HAVE_PTHREAD_MUTEX_INIT
 pthread_mutex_t oj_cache_mutex;
@@ -1748,7 +1749,8 @@ void Init_oj() {
     // On Rubinius the require fails but can be done from a ruby file.
     rb_protect(protect_require, Qnil, &err);
     rb_require("stringio");
-    oj_utf8_encoding = rb_enc_find("UTF-8");
+    oj_utf8_encoding_index = rb_enc_find_index("UTF-8");
+    oj_utf8_encoding = rb_enc_from_index(oj_utf8_encoding_index);
 
     // rb_define_module_function(Oj, "hash_test", hash_test, 0);
 

--- a/ext/oj/oj.h
+++ b/ext/oj/oj.h
@@ -282,6 +282,7 @@ extern VALUE oj_rails_encode(int argc, VALUE *argv, VALUE self);
 extern VALUE           Oj;
 extern struct _options oj_default_options;
 extern rb_encoding *   oj_utf8_encoding;
+extern int             oj_utf8_encoding_index;
 
 extern VALUE oj_bag_class;
 extern VALUE oj_bigdecimal_class;

--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -972,9 +972,10 @@ static VALUE protect_parse(VALUE pip) {
 extern int oj_utf8_index;
 
 static void oj_pi_set_input_str(ParseInfo pi, volatile VALUE *inputp) {
-    rb_encoding *enc = rb_enc_get(*inputp);
+    int idx = RB_ENCODING_GET(*inputp);
 
-    if (oj_utf8_encoding != enc) {
+    if (oj_utf8_encoding_index != idx) {
+        rb_encoding *enc = rb_enc_from_index(idx);
         *inputp = rb_str_conv_enc(*inputp, enc, oj_utf8_encoding);
     }
     pi->json = RSTRING_PTR(*inputp);


### PR DESCRIPTION
It can get the rb_encoding object based on its index value.

```c
rb_encoding*
rb_enc_get(VALUE obj)
{
    return rb_enc_from_index(rb_enc_get_index(obj));
}
```

Since UTF-8 has been used widely, it is sufficient to know only the index in most cases in this part.

−               | before | after  | result
--               | --     | --     | --
Oj.dump          | 1.026M | 1.119M | 1.091x

### Environment
- MacBook Pro (14 inch, 2021)
- macOS 12.0
- Apple M1 Max
- Ruby 3.1.0

### Before
```
Warming up --------------------------------------
             Oj.dump   102.823k i/100ms
Calculating -------------------------------------
             Oj.dump      1.026M (± 0.4%) i/s -     10.282M in  10.024252s
```

### After
```
Warming up --------------------------------------
             Oj.dump   110.736k i/100ms
Calculating -------------------------------------
             Oj.dump      1.119M (± 0.4%) i/s -     11.295M in  10.093770s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

json =<<-EOF
{
  "$id": "https://example.com/person.schema.json",
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "title": "Person",
  "type": "object",
  "properties": {
    "firstName": {
      "type": "string",
      "description": "The person's first name."
    },
    "lastName": {
      "type": "string",
      "description": "The person's last name."
    },
    "age": {
      "description": "Age in years which must be equal to or greater than zero.",
      "type": "integer",
      "minimum": 0
    }
  }
}
EOF

Benchmark.ips do |x|
  x.warmup = 10
  x.time = 10

  data = Oj.load(json)
  x.report('Oj.dump') { Oj.dump(data, mode: :compat) }
end
```