### PR TITLE
Use memcpy() to dump fixnum/float

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -1012,6 +1012,7 @@ void oj_dump_fixnum(VALUE obj, int depth, Out out, bool as_ok) {
     char *    b              = buf + sizeof(buf) - 1;
     long long num            = rb_num2ll(obj);
     int       neg            = 0;
+    int       cnt            = 0;
     bool      dump_as_string = false;
 
     if (out->opts->int_range_max != 0 && out->opts->int_range_min != 0 &&
@@ -1042,10 +1043,10 @@ void oj_dump_fixnum(VALUE obj, int depth, Out out, bool as_ok) {
     if (dump_as_string) {
         *--b = '"';
     }
-    assure_size(out, (sizeof(buf) - (b - buf)));
-    for (; '\0' != *b; b++) {
-        *out->cur++ = *b;
-    }
+    cnt = sizeof(buf) - (b - buf) - 1;
+    assure_size(out, cnt);
+    memcpy(out->cur, b, cnt);
+    out->cur += cnt;
     *out->cur = '\0';
 }
 
@@ -1195,9 +1196,8 @@ void oj_dump_float(VALUE obj, int depth, Out out, bool as_ok) {
         cnt = oj_dump_float_printf(buf, sizeof(buf), obj, d, out->opts->float_fmt);
     }
     assure_size(out, cnt);
-    for (b = buf; '\0' != *b; b++) {
-        *out->cur++ = *b;
-    }
+    memcpy(out->cur, buf, cnt);
+    out->cur += cnt;
     *out->cur = '\0';
 }
 

--- a/ext/oj/dump_compat.c
+++ b/ext/oj/dump_compat.c
@@ -613,18 +613,21 @@ dump_float(VALUE obj, int depth, Out out, bool as_ok) {
     } else if (OJ_INFINITY == d) {
 	if (WordNan == out->opts->dump_opts.nan_dump) {
 	    strcpy(buf, "Infinity");
+	    cnt = 8;
 	} else {
 	    raise_json_err("Infinity not allowed in JSON.", "GeneratorError");
 	}
     } else if (-OJ_INFINITY == d) {
 	if (WordNan == out->opts->dump_opts.nan_dump) {
 	    strcpy(buf, "-Infinity");
+	    cnt = 9;
 	} else {
 	    raise_json_err("-Infinity not allowed in JSON.", "GeneratorError");
 	}
     } else if (isnan(d)) {
 	if (WordNan == out->opts->dump_opts.nan_dump) {
 	    strcpy(buf, "NaN");
+	    cnt = 3;
 	} else {
 	    raise_json_err("NaN not allowed in JSON.", "GeneratorError");
 	}
@@ -639,9 +642,8 @@ dump_float(VALUE obj, int depth, Out out, bool as_ok) {
 	cnt = (int)RSTRING_LEN(rstr);
     }
     assure_size(out, cnt);
-    for (b = buf; '\0' != *b; b++) {
-	*out->cur++ = *b;
-    }
+    memcpy(out->cur, buf, cnt);
+    out->cur += cnt;
     *out->cur = '\0';
 }
 

--- a/ext/oj/dump_strict.c
+++ b/ext/oj/dump_strict.c
@@ -105,9 +105,8 @@ static void dump_float(VALUE obj, int depth, Out out, bool as_ok) {
         }
     }
     assure_size(out, cnt);
-    for (b = buf; '\0' != *b; b++) {
-        *out->cur++ = *b;
-    }
+    memcpy(out->cur, buf, cnt);
+    out->cur += cnt;
     *out->cur = '\0';
 }
 


### PR DESCRIPTION
This patch uses standard C library to copy the string.
(Ref. https://github.com/ohler55/oj/pull/674)

−               | before | after  | result
--               | --     | --     | --
Oj.dump          | 1.046M | 1.102M | 1.054x

### Environment
- Zorin OS 16
- AMD Ryzen 7 5700G
- gcc version 11.1.0
- Ruby 3.1.0

### Before
```
Warming up --------------------------------------
             Oj.dump   106.035k i/100ms
Calculating -------------------------------------
             Oj.dump      1.046M (± 1.0%) i/s -     15.799M in  15.098842s
```

### After
```
Warming up --------------------------------------
             Oj.dump   112.786k i/100ms
Calculating -------------------------------------
             Oj.dump      1.102M (± 1.1%) i/s -     16.580M in  15.051956s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

data = {
  float: 3.141592653589793,
  fixnum: 2 ** 60
}

Benchmark.ips do |x|
  x.time = 15

  x.report('Oj.dump') { Oj.dump(data, mode: :compat) }
end
```