### PR TITLE
Use snprintf() of standard C library

### DIFF
--- a/ext/oj/oj.h
+++ b/ext/oj/oj.h
@@ -39,6 +39,12 @@ enum st_retval { ST_CONTINUE = 0, ST_STOP = 1, ST_DELETE = 2, ST_CHECK };
 #define NINF_VAL "-3.0e14159265358979323846"
 #define NAN_VAL "3.3e14159265358979323846"
 
+#if __STDC_VERSION__ >= 199901L
+    // To avoid using ruby_snprintf with C99.
+    #undef snprintf
+    #include <stdio.h>
+#endif
+
 typedef enum { Yes = 'y', No = 'n', NotSet = 0 } YesNo;
 
 typedef enum {


### PR DESCRIPTION
Ruby has its own implementation of `ruby_snprintf()`, which is used when `snprintf()` is called.

```c
#define snprintf ruby_snprintf
```
https://github.com/ruby/ruby/blob/cb4e2cb55a59833fc4f1f6db2f3082d1ffcafc80/include/ruby/subst.h#L13

I'm guessing that `ruby_snprintf()` will behave differently from `snprintf()`.

(Ref. https://github.com/ohler55/oj/commit/5e9c70775a9ebdd7262d7c47a70498ad48275c33)

−               | before | after  | result
--               | --     | --     | --
Oj.dump          | 1.459M | 1.894M | 1.298x

### Environment
- MacBook Pro (14 inch, 2021)
- macOS 12.0
- Apple M1 Max
- Ruby 3.1.0

### Before
```
Warming up --------------------------------------
             Oj.dump   145.852k i/100ms
Calculating -------------------------------------
             Oj.dump      1.459M (± 0.8%) i/s -     22.024M in  15.097734s
```

### After
```
Warming up --------------------------------------
             Oj.dump   189.609k i/100ms
Calculating -------------------------------------
             Oj.dump      1.894M (± 0.6%) i/s -     28.441M in  15.020956s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

data = {
  float: 3.141592653589793,
  fixnum: 2 ** 60
}

Benchmark.ips do |x|
  x.time = 15

  x.report('Oj.dump') { Oj.dump(data) }
end
```