### PR TITLE
Undefine uneeded `T_DATA` allocators

### DIFF
--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -1719,6 +1719,7 @@ static VALUE doc_not_implemented(VALUE self) {
  */
 void oj_init_doc() {
     oj_doc_class = rb_define_class_under(Oj, "Doc", rb_cObject);
+    rb_undef_alloc_func(oj_doc_class);
     rb_define_singleton_method(oj_doc_class, "open", doc_open, 1);
     rb_define_singleton_method(oj_doc_class, "open_file", doc_open_file, 1);
     rb_define_singleton_method(oj_doc_class, "parse", doc_open, 1);

--- a/ext/oj/intern.c
+++ b/ext/oj/intern.c
@@ -88,6 +88,7 @@ static VALUE form_attr(const char *str, size_t len) {
 
 void oj_hash_init() {
     VALUE cache_class = rb_define_class_under(Oj, "Cache", rb_cObject);
+    rb_undef_alloc_func(cache_class);
 
     str_cache     = cache_create(0, form_str, true, true);
     str_cache_obj = Data_Wrap_Struct(cache_class, cache_mark, cache_free, str_cache);

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -1740,6 +1740,7 @@ void Init_oj() {
     Oj = rb_define_module("Oj");
 
     oj_cstack_class = rb_define_class_under(Oj, "CStack", rb_cObject);
+    rb_undef_alloc_func(oj_cstack_class);
 
     oj_string_writer_init();
     oj_stream_writer_init();

--- a/ext/oj/stream_writer.c
+++ b/ext/oj/stream_writer.c
@@ -317,6 +317,7 @@ static VALUE stream_writer_flush(VALUE self) {
  */
 void oj_stream_writer_init() {
     oj_stream_writer_class = rb_define_class_under(Oj, "StreamWriter", rb_cObject);
+    rb_undef_alloc_func(oj_stream_writer_class);
     rb_define_module_function(oj_stream_writer_class, "new", stream_writer_new, -1);
     rb_define_method(oj_stream_writer_class, "push_key", stream_writer_push_key, 1);
     rb_define_method(oj_stream_writer_class, "push_object", stream_writer_push_object, -1);

--- a/ext/oj/string_writer.c
+++ b/ext/oj/string_writer.c
@@ -471,6 +471,7 @@ static VALUE str_writer_as_json(VALUE self) {
  */
 void oj_string_writer_init() {
     oj_string_writer_class = rb_define_class_under(Oj, "StringWriter", rb_cObject);
+    rb_undef_alloc_func(oj_string_writer_class);
     rb_define_module_function(oj_string_writer_class, "new", str_writer_new, -1);
     rb_define_method(oj_string_writer_class, "push_key", str_writer_push_key, 1);
     rb_define_method(oj_string_writer_class, "push_object", str_writer_push_object, -1);


### PR DESCRIPTION
This is now required to avoid warnings on ruby-head.

See: https://bugs.ruby-lang.org/issues/18007

From ruby-head CI:
```
/home/runner/work/oj/oj/lib/oj/oj.so: warning: undefining the allocator of T_DATA class Oj::Cache
/home/runner/work/oj/oj/test/test_custom.rb:302: warning: undefining the allocator of T_DATA class Oj::StringWriter
/home/runner/work/oj/oj/test/test_custom.rb:205: warning: undefining the allocator of T_DATA class Oj::CStack
/home/runner/work/oj/oj/test/test_fast.rb:317: warning: undefining the allocator of T_DATA class Oj::Doc
/home/runner/work/oj/oj/test/test_writer.rb:248: warning: undefining the allocator of T_DATA class Oj::StreamWriter
/home/runner/work/oj/oj/lib/oj/oj.so: warning: undefining the allocator of T_DATA class Oj::Cache
/home/runner/work/oj/oj/test/json_gem/json_common_interface_test.rb:151: warning: undefining the allocator of T_DATA class Oj::CStack
```