### PR TITLE
Use NUM2LL() macro instead of rb_num2ll()

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -379,12 +379,12 @@ void oj_dump_time(VALUE obj, Out out, int withZone) {
         sec  = (long long)ts.tv_sec;
         nsec = ts.tv_nsec;
     } else {
-        sec  = rb_num2ll(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
-        nsec = rb_num2ll(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
+        sec  = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
+        nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
     }
 #else
-    sec  = rb_num2ll(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
-    nsec = rb_num2ll(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
+    sec  = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
+    nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
 #endif
 
     *b-- = '\0';
@@ -479,12 +479,12 @@ void oj_dump_xml_time(VALUE obj, Out out) {
         sec  = ts.tv_sec;
         nsec = ts.tv_nsec;
     } else {
-        sec  = rb_num2ll(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
-        nsec = rb_num2ll(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
+        sec  = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
+        nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
     }
 #else
-    sec  = rb_num2ll(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
-    nsec = rb_num2ll(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
+    sec  = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
+    nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
 #endif
 
     assure_size(out, 36);
@@ -1003,9 +1003,9 @@ void oj_dump_false(VALUE obj, int depth, Out out, bool as_ok) {
 void oj_dump_fixnum(VALUE obj, int depth, Out out, bool as_ok) {
     char      buf[32];
     char *    b              = buf + sizeof(buf) - 1;
-    long long num            = rb_num2ll(obj);
+    long long num            = NUM2LL(obj);
     int       neg            = 0;
-    int       cnt            = 0;
+    long      cnt            = 0;
     bool      dump_as_string = false;
 
     if (out->opts->int_range_max != 0 && out->opts->int_range_min != 0 &&

--- a/ext/oj/dump_compat.c
+++ b/ext/oj/dump_compat.c
@@ -476,12 +476,12 @@ time_alt(VALUE obj, int depth, Out out) {
 	sec = (long long)ts.tv_sec;
 	nsec = ts.tv_nsec;
     } else {
-	sec = rb_num2ll(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
-	nsec = rb_num2ll(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
+	sec = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
+	nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
     }
 #else
-    sec = rb_num2ll(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
-    nsec = rb_num2ll(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
+    sec = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
+    nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
 #endif
 
     attrs[0].num = sec;

--- a/ext/oj/odd.c
+++ b/ext/oj/odd.c
@@ -37,8 +37,8 @@ static VALUE get_datetime_secs(VALUE obj) {
     volatile VALUE rsecs = rb_funcall(obj, sec_id, 0);
     volatile VALUE rfrac = rb_funcall(obj, sec_fraction_id, 0);
     long           sec   = NUM2LONG(rsecs);
-    long long      num   = rb_num2ll(rb_funcall(rfrac, numerator_id, 0));
-    long long      den   = rb_num2ll(rb_funcall(rfrac, denominator_id, 0));
+    long long      num   = NUM2LL(rb_funcall(rfrac, numerator_id, 0));
+    long long      den   = NUM2LL(rb_funcall(rfrac, denominator_id, 0));
 
     num += sec * den;
 

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -330,12 +330,12 @@ static void dump_time(VALUE obj, int depth, Out out, bool as_ok) {
         sec  = (long long)ts.tv_sec;
         nsec = ts.tv_nsec;
     } else {
-        sec  = rb_num2ll(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
-        nsec = rb_num2ll(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
+        sec  = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
+        nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
     }
 #else
-    sec  = rb_num2ll(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
-    nsec = rb_num2ll(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
+    sec  = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
+    nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
 #endif
     dump_sec_nano(obj, sec, nsec, out);
 }
@@ -345,9 +345,9 @@ static void dump_timewithzone(VALUE obj, int depth, Out out, bool as_ok) {
     long long nsec = 0;
 
     if (rb_respond_to(obj, oj_tv_nsec_id)) {
-        nsec = rb_num2ll(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
+        nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
     } else if (rb_respond_to(obj, oj_tv_usec_id)) {
-        nsec = rb_num2ll(rb_funcall2(obj, oj_tv_usec_id, 0, 0)) * 1000;
+        nsec = NUM2LL(rb_funcall2(obj, oj_tv_usec_id, 0, 0)) * 1000;
     }
     dump_sec_nano(obj, sec, nsec, out);
 }

--- a/ext/oj/wab.c
+++ b/ext/oj/wab.c
@@ -201,12 +201,12 @@ static void dump_time(VALUE obj, Out out) {
         sec  = ts.tv_sec;
         nsec = ts.tv_nsec;
     } else {
-        sec  = rb_num2ll(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
-        nsec = rb_num2ll(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
+        sec  = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
+        nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
     }
 #else
-    sec  = rb_num2ll(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
-    nsec = rb_num2ll(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
+    sec  = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
+    nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
 #endif
 
     assure_size(out, 36);


### PR DESCRIPTION
By using NUM2LL() macro, seems that it can convert the value faster than rb_num2ll() directly.

```c
#define RB_NUM2LL  rb_num2ll_inline   /**< @alias{rb_num2ll_inline} */
#define NUM2LL     RB_NUM2LL          /**< @old{RB_NUM2LL} */

static inline LONG_LONG
rb_num2ll_inline(VALUE x)
{
    if (RB_FIXNUM_P(x))
        return RB_FIX2LONG(x);
    else
        return rb_num2ll(x);
}
```
https://github.com/ruby/ruby/blob/master/include/ruby/internal/arithmetic/long_long.h

−               | before | after  | result
--               | --     | --     | --
Oj.dump (macOS)  | 7.461k | 7.839k | 1.051x
Oj.dump (Linux)  | 8.391k | 9.140k | 1.089x

### Environment
- macOS
  - macOS 12.1
  - Apple M1 Max
  - Apple clang version 13.0.0 (clang-1300.0.29.30)
  - Ruby 3.1.0
- Linux
  - Zorin OS 16
  - AMD Ryzen 7 5700G
  - gcc version 11.1.0
  - Ruby 3.1.0

### macOS
#### Before
```
Warming up --------------------------------------
             Oj.dump   737.000  i/100ms
Calculating -------------------------------------
             Oj.dump      7.461k (± 1.1%) i/s -    112.024k in  15.015711s
```

#### After
```
Warming up --------------------------------------
             Oj.dump   783.000  i/100ms
Calculating -------------------------------------
             Oj.dump      7.839k (± 0.9%) i/s -    118.233k in  15.084888s
```

### Linux
#### Before
```
Warming up --------------------------------------
             Oj.dump   793.000  i/100ms
Calculating -------------------------------------
             Oj.dump      8.391k (± 0.9%) i/s -    126.087k in  15.028559s
```

#### After
```
Warming up --------------------------------------
             Oj.dump   887.000  i/100ms
Calculating -------------------------------------
             Oj.dump      9.140k (± 0.9%) i/s -    137.485k in  15.043569s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

data = (0..10000).to_a

Benchmark.ips do |x|
  x.time = 15

  x.report('Oj.dump') { Oj.dump(data, mode: :compat) }
end
```