### PR TITLE
Move assure_size() outside loop to dump array

### DIFF
--- a/ext/oj/custom.c
+++ b/ext/oj/custom.c
@@ -731,9 +731,9 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
         } else {
             size = d2 * out->indent + 2;
         }
+        assure_size(out, size * cnt);
         cnt--;
         for (i = 0; i <= cnt; i++) {
-            assure_size(out, size);
             if (out->opts->dump_opts.use) {
                 if (0 < out->opts->dump_opts.array_size) {
                     strcpy(out->cur, out->opts->dump_opts.array_nl);

--- a/ext/oj/dump_compat.c
+++ b/ext/oj/dump_compat.c
@@ -164,9 +164,9 @@ dump_array(VALUE a, int depth, Out out, bool as_ok) {
 	} else {
 	    size = d2 * out->indent + 2;
 	}
+	assure_size(out, size * cnt);
 	cnt--;
 	for (i = 0; i <= cnt; i++) {
-	    assure_size(out, size);
 	    if (out->opts->dump_opts.use) {
 		if (0 < out->opts->dump_opts.array_size) {
 		    strcpy(out->cur, out->opts->dump_opts.array_nl);

--- a/ext/oj/dump_object.c
+++ b/ext/oj/dump_object.c
@@ -139,9 +139,9 @@ static void dump_array_class(VALUE a, VALUE clas, int depth, Out out) {
         } else {
             size = d2 * out->indent + 2;
         }
+        assure_size(out, size * cnt);
         cnt--;
         for (i = 0; i <= cnt; i++) {
-            assure_size(out, size);
             if (out->opts->dump_opts.use) {
                 if (0 < out->opts->dump_opts.array_size) {
                     strcpy(out->cur, out->opts->dump_opts.array_nl);

--- a/ext/oj/dump_strict.c
+++ b/ext/oj/dump_strict.c
@@ -133,9 +133,9 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
         } else {
             size = d2 * out->indent + 2;
         }
+        assure_size(out, size * cnt);
         cnt--;
         for (i = 0; i <= cnt; i++) {
-            assure_size(out, size);
             if (out->opts->dump_opts.use) {
                 if (0 < out->opts->dump_opts.array_size) {
                     strcpy(out->cur, out->opts->dump_opts.array_nl);

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -1263,9 +1263,9 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
         } else {
             size = d2 * out->indent + 2;
         }
+        assure_size(out, size * cnt);
         cnt--;
         for (i = 0; i <= cnt; i++) {
-            assure_size(out, size);
             if (out->opts->dump_opts.use) {
                 if (0 < out->opts->dump_opts.array_size) {
                     strcpy(out->cur, out->opts->dump_opts.array_nl);

--- a/ext/oj/wab.c
+++ b/ext/oj/wab.c
@@ -124,9 +124,9 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
         *out->cur++ = ']';
     } else {
         size = d2 * out->indent + 2;
+        assure_size(out, size * cnt);
         cnt--;
         for (i = 0; i <= cnt; i++) {
-            assure_size(out, size);
             fill_indent(out, d2);
             oj_dump_wab_val(RARRAY_AREF(a, i), d2, out);
             if (i < cnt) {


### PR DESCRIPTION
−               | before | after  | result
--               | --     | --     | --
Oj.dump (macOS)  | 7.461k | 7.707k | 1.033x
Oj.dump (Linux)  | 8.391k | 8.660k | 1.032x

### Environment
- macOS
  - macOS 12.1
  - Apple M1 Max
  - Apple clang version 13.0.0 (clang-1300.0.29.30)
  - Ruby 3.1.0
- Linux
  - Zorin OS 16
  - AMD Ryzen 7 5700G
  - gcc version 11.1.0
  - Ruby 3.1.0

### macOS
#### Before
```
Warming up --------------------------------------
             Oj.dump   737.000  i/100ms
Calculating -------------------------------------
             Oj.dump      7.461k (± 1.1%) i/s -    112.024k in  15.015711s
```

#### After
```
Warming up --------------------------------------
             Oj.dump   763.000  i/100ms
Calculating -------------------------------------
             Oj.dump      7.707k (± 0.5%) i/s -    154.889k in  20.096531s
```

### Linux
#### Before
```
Warming up --------------------------------------
             Oj.dump   793.000  i/100ms
Calculating -------------------------------------
             Oj.dump      8.391k (± 0.9%) i/s -    126.087k in  15.028559s
```

#### After
```
Warming up --------------------------------------
             Oj.dump   828.000  i/100ms
Calculating -------------------------------------
             Oj.dump      8.660k (± 1.0%) i/s -    129.996k in  15.012866s

```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

data = (0..10000).to_a

Benchmark.ips do |x|
  x.time = 15

  x.report('Oj.dump') { Oj.dump(data, mode: :compat) }
end
```