### PR TITLE
Fix class cache to solve a SEGV

### DIFF
--- a/ext/oj/intern.c
+++ b/ext/oj/intern.c
@@ -275,6 +275,7 @@ VALUE oj_class_intern(const char *key, size_t len, bool safe, ParseInfo pi, int 
         bucket->len = len;
         bucket->val = resolve_classpath(pi, key, len, auto_define, error_class);
     }
+    rb_gc_register_mark_object(bucket->val);
     return bucket->val;
 }
 


### PR DESCRIPTION
When marshaling using `Oj.object_dump`, it might cause a SEGV with GC.compact.
This patch will fix a SEGV.

Related to https://github.com/ohler55/oj/issues/745

## Test code
```ruby
require 'oj'

class Foo
end

def dump_and_load(obj)
  json = Oj.dump(obj, :indent => 2, :mode => :object)
  Oj.object_load(json);
end

1000.times do |i|
  obj = Foo.new()
  dump_and_load(obj)
  GC.verify_compaction_references(double_heap: true, toward: :empty)

  puts "#{Integer(`ps -o rss= -p #{Process.pid}`) / 1024.0} MB" if i % 100 == 0
end
```