### PR TITLE
CI.yml - back to ruby/setup-ruby

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -68,7 +68,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }} (windows-2022)
     steps:
       - uses: actions/checkout@v2
-      - uses: MSP-Greg/ruby-setup-ruby@win-ucrt-1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true


### PR DESCRIPTION
ruby/setup-ruby is the repo with the custom action that loads Ruby and sets up the environment for it.

When PR #727 was done, several updates to ruby/setup-ruby were not yet merged. MSP-Greg/ruby-setup-ruby contained many of those updates, so CI was switched to that.

ruby/setup-ruby is now working with Windows-2022 image, so switch back to it.