### PR TITLE
Improve indentation performance

### DIFF
--- a/ext/oj/dump.h
+++ b/ext/oj/dump.h
@@ -62,9 +62,8 @@ inline static void fill_indent(Out out, int cnt) {
     if (0 < out->indent) {
         cnt *= out->indent;
         *out->cur++ = '\n';
-        for (; 0 < cnt; cnt--) {
-            *out->cur++ = ' ';
-        }
+        memset(out->cur, ' ', cnt);
+        out->cur += cnt;
     }
 }
 


### PR DESCRIPTION
Better performance in filling indent by using standard C function if the indentation is deep.

- macOS

−       | before   | after  | result
--       | --       | --     | --
indent 0 | 1.181M   | 1.180M | −
indent 2 | 1.065M   | 1.033M | 0.970x
indent 4 | 976.918k | 1.022M | 1.046x
indent 8 | 795.413k | 1.030M | 1.295x

- Linux

−       | before | after  | result
--       | --     | --     | --
indent 0 | 1.398M | 1.389M | −
indent 2 | 1.243M | 1.252M | 1.007x
indent 4 | 1.165M | 1.245M | 1.069x
indent 8 | 1.025M | 1.234M | 1.204x

### Environment
- macOS
  - macOS 12.3 beta
  - Apple M1 Max
  - Apple clang version 13.1.6 (clang-1316.0.20.6)
  - Ruby 3.1.1
- Linux
  - Kubuntu 21.10
  - AMD Ryzen 7 5700G
  - gcc version 11.2.0
  - Ruby 3.1.1

### macOS
#### Before
```
Warming up --------------------------------------
            indent 0   118.606k i/100ms
            indent 2   105.783k i/100ms
            indent 4    97.085k i/100ms
            indent 8    79.490k i/100ms
Calculating -------------------------------------
            indent 0      1.181M (± 0.5%) i/s -     17.791M in  15.060949s
            indent 2      1.065M (± 0.7%) i/s -     15.973M in  15.004965s
            indent 4    976.918k (± 0.7%) i/s -     14.660M in  15.006933s
            indent 8    795.413k (± 0.4%) i/s -     12.003M in  15.090549s
```

#### After
```
Warming up --------------------------------------
            indent 0   117.746k i/100ms
            indent 2   102.742k i/100ms
            indent 4   102.824k i/100ms
            indent 8   102.709k i/100ms
Calculating -------------------------------------
            indent 0      1.180M (± 0.5%) i/s -     17.780M in  15.065501s
            indent 2      1.033M (± 0.6%) i/s -     15.556M in  15.052999s
            indent 4      1.022M (± 0.7%) i/s -     15.424M in  15.089540s
            indent 8      1.030M (± 0.8%) i/s -     15.509M in  15.054297s
```

### Linux
#### Before
```
Warming up --------------------------------------
            indent 0   137.373k i/100ms
            indent 2   123.934k i/100ms
            indent 4   117.243k i/100ms
            indent 8   103.499k i/100ms
Calculating -------------------------------------
            indent 0      1.398M (± 0.2%) i/s -     21.018M in  15.035756s
            indent 2      1.243M (± 0.2%) i/s -     18.714M in  15.054698s
            indent 4      1.165M (± 0.4%) i/s -     17.586M in  15.090029s
            indent 8      1.025M (± 0.5%) i/s -     15.421M in  15.048213s
```

#### After
```
Warming up --------------------------------------
            indent 0   139.094k i/100ms
            indent 2   125.612k i/100ms
            indent 4   125.009k i/100ms
            indent 8   124.784k i/100ms
Calculating -------------------------------------
            indent 0      1.389M (± 0.1%) i/s -     20.864M in  15.022527s
            indent 2      1.252M (± 0.2%) i/s -     18.842M in  15.051203s
            indent 4      1.245M (± 0.3%) i/s -     18.751M in  15.061924s
            indent 8      1.234M (± 0.4%) i/s -     18.593M in  15.061765s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

json =<<-EOF
{
  "$id": "https://example.com/person.schema.json",
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "title": "Person",
  "type": "object",
  "properties": {
    "firstName": {
      "type": "string",
      "description": "The person's first name."
    },
    "lastName": {
      "type": "string",
      "description": "The person's last name."
    },
    "age": {
      "description": "Age in years which must be equal to or greater than zero.",
      "type": "integer",
      "minimum": 0
    }
  }
}
EOF

Benchmark.ips do |x|
  x.time = 15

  data = Oj.load(json)
  x.report('indent 0') { Oj.dump(data, mode: :compat) }
  x.report('indent 2') { Oj.dump(data, mode: :compat, indent: 2) }
  x.report('indent 4') { Oj.dump(data, mode: :compat, indent: 4) }
  x.report('indent 8') { Oj.dump(data, mode: :compat, indent: 8) }
end
```