### PR TITLE
Use standard C function to copy characters

### DIFF
--- a/ext/oj/code.c
+++ b/ext/oj/code.c
@@ -190,10 +190,11 @@ void oj_code_attrs(VALUE obj, Attr attrs, int depth, Out out, bool with_class) {
                 default: oj_dump_time(attrs->time, out, false); break;
                 }
             } else {
-                char  buf[32];
-                char *b   = buf + sizeof(buf) - 1;
-                int   neg = 0;
-                long  num = attrs->num;
+                char   buf[32];
+                char  *b   = buf + sizeof(buf) - 1;
+                int    neg = 0;
+                long   num = attrs->num;
+                size_t cnt = 0;
 
                 if (0 > num) {
                     neg = 1;
@@ -212,10 +213,10 @@ void oj_code_attrs(VALUE obj, Attr attrs, int depth, Out out, bool with_class) {
                 } else {
                     *b = '0';
                 }
-                assure_size(out, (sizeof(buf) - (b - buf)));
-                for (; '\0' != *b; b++) {
-                    *out->cur++ = *b;
-                }
+                cnt = sizeof(buf) - (b - buf) - 1;
+                assure_size(out, cnt);
+                memcpy(out->cur, b, cnt);
+                out->cur += cnt;
             }
         } else {
             oj_dump_compat_val(attrs->value, d3, out, true);

--- a/ext/oj/code.c
+++ b/ext/oj/code.c
@@ -140,21 +140,17 @@ void oj_code_attrs(VALUE obj, Attr attrs, int depth, Out out, bool with_class) {
     if (with_class) {
         fill_indent(out, d2);
         *out->cur++ = '"';
-        memcpy(out->cur, out->opts->create_id, out->opts->create_id_len);
-        out->cur += out->opts->create_id_len;
+        APPEND_CHARS(out->cur, out->opts->create_id, out->opts->create_id_len);
         *out->cur++ = '"';
         if (0 < out->opts->dump_opts.before_size) {
-            strcpy(out->cur, out->opts->dump_opts.before_sep);
-            out->cur += out->opts->dump_opts.before_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.before_sep, out->opts->dump_opts.before_size);
         }
         *out->cur++ = ':';
         if (0 < out->opts->dump_opts.after_size) {
-            strcpy(out->cur, out->opts->dump_opts.after_sep);
-            out->cur += out->opts->dump_opts.after_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.after_sep, out->opts->dump_opts.after_size);
         }
         *out->cur++ = '"';
-        memcpy(out->cur, classname, len);
-        out->cur += len;
+        APPEND_CHARS(out->cur, classname, len);
         *out->cur++ = '"';
         no_comma    = false;
     }
@@ -168,17 +164,14 @@ void oj_code_attrs(VALUE obj, Attr attrs, int depth, Out out, bool with_class) {
         }
         fill_indent(out, d2);
         *out->cur++ = '"';
-        memcpy(out->cur, attrs->name, attrs->len);
-        out->cur += attrs->len;
+        APPEND_CHARS(out->cur, attrs->name, attrs->len);
         *out->cur++ = '"';
         if (0 < out->opts->dump_opts.before_size) {
-            strcpy(out->cur, out->opts->dump_opts.before_sep);
-            out->cur += out->opts->dump_opts.before_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.before_sep, out->opts->dump_opts.before_size);
         }
         *out->cur++ = ':';
         if (0 < out->opts->dump_opts.after_size) {
-            strcpy(out->cur, out->opts->dump_opts.after_sep);
-            out->cur += out->opts->dump_opts.after_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.after_sep, out->opts->dump_opts.after_size);
         }
         if (Qundef == attrs->value) {
             if (Qundef != attrs->time) {
@@ -215,8 +208,7 @@ void oj_code_attrs(VALUE obj, Attr attrs, int depth, Out out, bool with_class) {
                 }
                 cnt = sizeof(buf) - (b - buf) - 1;
                 assure_size(out, cnt);
-                memcpy(out->cur, b, cnt);
-                out->cur += cnt;
+                APPEND_CHARS(out->cur, b, cnt);
             }
         } else {
             oj_dump_compat_val(attrs->value, d3, out, true);

--- a/ext/oj/custom.c
+++ b/ext/oj/custom.c
@@ -295,15 +295,13 @@ static int hash_cb(VALUE key, VALUE value, VALUE ov) {
         assure_size(out,
                     depth * out->opts->dump_opts.indent_size + out->opts->dump_opts.hash_size + 1);
         if (0 < out->opts->dump_opts.hash_size) {
-            strcpy(out->cur, out->opts->dump_opts.hash_nl);
-            out->cur += out->opts->dump_opts.hash_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.hash_nl, out->opts->dump_opts.hash_size);
         }
         if (0 < out->opts->dump_opts.indent_size) {
             int i;
 
             for (i = depth; 0 < i; i--) {
-                strcpy(out->cur, out->opts->dump_opts.indent_str);
-                out->cur += out->opts->dump_opts.indent_size;
+                APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
             }
         }
     }
@@ -317,13 +315,11 @@ static int hash_cb(VALUE key, VALUE value, VALUE ov) {
     } else {
         assure_size(out, out->opts->dump_opts.before_size + out->opts->dump_opts.after_size + 2);
         if (0 < out->opts->dump_opts.before_size) {
-            strcpy(out->cur, out->opts->dump_opts.before_sep);
-            out->cur += out->opts->dump_opts.before_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.before_sep, out->opts->dump_opts.before_size);
         }
         *out->cur++ = ':';
         if (0 < out->opts->dump_opts.after_size) {
-            strcpy(out->cur, out->opts->dump_opts.after_sep);
-            out->cur += out->opts->dump_opts.after_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.after_sep, out->opts->dump_opts.after_size);
         }
     }
     oj_dump_custom_val(value, depth, out, true);
@@ -344,8 +340,7 @@ static void dump_hash(VALUE obj, int depth, Out out, bool as_ok) {
     cnt = (int)RHASH_SIZE(obj);
     assure_size(out, 2);
     if (0 == cnt) {
-        memcpy(out->cur, "{}", 2);
-        out->cur += 2;
+        APPEND_CHARS(out->cur, "{}", 2);
     } else {
         *out->cur++ = '{';
         out->depth  = depth + 1;
@@ -361,15 +356,13 @@ static void dump_hash(VALUE obj, int depth, Out out, bool as_ok) {
                 out,
                 depth * out->opts->dump_opts.indent_size + out->opts->dump_opts.hash_size + 1);
             if (0 < out->opts->dump_opts.hash_size) {
-                strcpy(out->cur, out->opts->dump_opts.hash_nl);
-                out->cur += out->opts->dump_opts.hash_size;
+                APPEND_CHARS(out->cur, out->opts->dump_opts.hash_nl, out->opts->dump_opts.hash_size);
             }
             if (0 < out->opts->dump_opts.indent_size) {
                 int i;
 
                 for (i = depth; 0 < i; i--) {
-                    strcpy(out->cur, out->opts->dump_opts.indent_str);
-                    out->cur += out->opts->dump_opts.indent_size;
+                    APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
                 }
             }
         }
@@ -397,23 +390,18 @@ static void dump_odd(VALUE obj, Odd odd, VALUE clas, int depth, Out out) {
         assure_size(out, size);
         fill_indent(out, d2);
         *out->cur++ = '"';
-        memcpy(out->cur, out->opts->create_id, out->opts->create_id_len);
-        out->cur += out->opts->create_id_len;
+        APPEND_CHARS(out->cur, out->opts->create_id, out->opts->create_id_len);
         *out->cur++ = '"';
         if (0 < out->opts->dump_opts.before_size) {
-            strcpy(out->cur, out->opts->dump_opts.before_sep);
-            out->cur += out->opts->dump_opts.before_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.before_sep, out->opts->dump_opts.before_size);
         }
         *out->cur++ = ':';
         if (0 < out->opts->dump_opts.after_size) {
-            strcpy(out->cur, out->opts->dump_opts.after_sep);
-            out->cur += out->opts->dump_opts.after_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.after_sep, out->opts->dump_opts.after_size);
         }
         *out->cur++ = '"';
-        memcpy(out->cur, classname, clen);
-        out->cur += clen;
-        memcpy(out->cur, "\",", 2);
-        out->cur += 2;
+        APPEND_CHARS(out->cur, classname, clen);
+        APPEND_CHARS(out->cur, "\",", 2);
     }
     if (odd->raw) {
         v = rb_funcall(obj, *odd->attrs, 0);
@@ -429,12 +417,9 @@ static void dump_odd(VALUE obj, Odd odd, VALUE clas, int depth, Out out) {
             assure_size(out, size);
             fill_indent(out, d2);
             *out->cur++ = '"';
-            memcpy(out->cur, name, nlen);
-            out->cur += nlen;
-            memcpy(out->cur, "\":", 2);
-            out->cur += 2;
-            memcpy(out->cur, s, len);
-            out->cur += len;
+            APPEND_CHARS(out->cur, name, nlen);
+            APPEND_CHARS(out->cur, "\":", 2);
+            APPEND_CHARS(out->cur, s, len);
             *out->cur = '\0';
         }
     } else {
@@ -514,8 +499,7 @@ static VALUE dump_common(VALUE obj, int depth, Out out) {
         len = (int)RSTRING_LEN(rs);
 
         assure_size(out, len + 1);
-        memcpy(out->cur, s, len);
-        out->cur += len;
+        APPEND_CHARS(out->cur, s, len);
         *out->cur = '\0';
     } else if (Yes == out->opts->as_json && rb_respond_to(obj, oj_as_json_id)) {
         volatile VALUE aj;
@@ -633,21 +617,17 @@ static void dump_obj_attrs(VALUE obj, VALUE clas, slot_t id, int depth, Out out)
         assure_size(out, size);
         fill_indent(out, d2);
         *out->cur++ = '"';
-        memcpy(out->cur, out->opts->create_id, out->opts->create_id_len);
-        out->cur += out->opts->create_id_len;
+        APPEND_CHARS(out->cur, out->opts->create_id, out->opts->create_id_len);
         *out->cur++ = '"';
         if (0 < out->opts->dump_opts.before_size) {
-            strcpy(out->cur, out->opts->dump_opts.before_sep);
-            out->cur += out->opts->dump_opts.before_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.before_sep, out->opts->dump_opts.before_size);
         }
         *out->cur++ = ':';
         if (0 < out->opts->dump_opts.after_size) {
-            strcpy(out->cur, out->opts->dump_opts.after_sep);
-            out->cur += out->opts->dump_opts.after_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.after_sep, out->opts->dump_opts.after_size);
         }
         *out->cur++ = '"';
-        memcpy(out->cur, classname, len);
-        out->cur += len;
+        APPEND_CHARS(out->cur, classname, len);
         *out->cur++   = '"';
         class_written = true;
     }
@@ -736,14 +716,12 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
         for (i = 0; i <= cnt; i++) {
             if (out->opts->dump_opts.use) {
                 if (0 < out->opts->dump_opts.array_size) {
-                    strcpy(out->cur, out->opts->dump_opts.array_nl);
-                    out->cur += out->opts->dump_opts.array_size;
+                    APPEND_CHARS(out->cur, out->opts->dump_opts.array_nl, out->opts->dump_opts.array_size);
                 }
                 if (0 < out->opts->dump_opts.indent_size) {
                     int i;
                     for (i = d2; 0 < i; i--) {
-                        strcpy(out->cur, out->opts->dump_opts.indent_str);
-                        out->cur += out->opts->dump_opts.indent_size;
+                        APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
                     }
                 }
             } else {
@@ -758,15 +736,13 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
         assure_size(out, size);
         if (out->opts->dump_opts.use) {
             if (0 < out->opts->dump_opts.array_size) {
-                strcpy(out->cur, out->opts->dump_opts.array_nl);
-                out->cur += out->opts->dump_opts.array_size;
+                APPEND_CHARS(out->cur, out->opts->dump_opts.array_nl, out->opts->dump_opts.array_size);
             }
             if (0 < out->opts->dump_opts.indent_size) {
                 int i;
 
                 for (i = depth; 0 < i; i--) {
-                    strcpy(out->cur, out->opts->dump_opts.indent_str);
-                    out->cur += out->opts->dump_opts.indent_size;
+                    APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
                 }
             }
         } else {
@@ -800,8 +776,7 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
             *out->cur++ = '"';
             oj_dump_custom_val(rb_funcall(obj, oj_begin_id, 0), d3, out, false);
             assure_size(out, 3);
-            memcpy(out->cur, "..", 2);
-            out->cur += 2;
+            APPEND_CHARS(out->cur, "..", 2);
             if (Qtrue == rb_funcall(obj, oj_exclude_end_id, 0)) {
                 *out->cur++ = '.';
             }
@@ -844,10 +819,8 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
             assure_size(out, size + len + 3);
             fill_indent(out, d3);
             *out->cur++ = '"';
-            memcpy(out->cur, name, len);
-            out->cur += len;
-            memcpy(out->cur, "\":", 2);
-            out->cur += 2;
+            APPEND_CHARS(out->cur, name, len);
+            APPEND_CHARS(out->cur, "\":", 2);
             oj_dump_custom_val(v, d3, out, true);
             *out->cur++ = ',';
         }

--- a/ext/oj/custom.c
+++ b/ext/oj/custom.c
@@ -344,8 +344,8 @@ static void dump_hash(VALUE obj, int depth, Out out, bool as_ok) {
     cnt = (int)RHASH_SIZE(obj);
     assure_size(out, 2);
     if (0 == cnt) {
-        *out->cur++ = '{';
-        *out->cur++ = '}';
+        memcpy(out->cur, "{}", 2);
+        out->cur += 2;
     } else {
         *out->cur++ = '{';
         out->depth  = depth + 1;
@@ -412,8 +412,8 @@ static void dump_odd(VALUE obj, Odd odd, VALUE clas, int depth, Out out) {
         *out->cur++ = '"';
         memcpy(out->cur, classname, clen);
         out->cur += clen;
-        *out->cur++ = '"';
-        *out->cur++ = ',';
+        memcpy(out->cur, "\",", 2);
+        out->cur += 2;
     }
     if (odd->raw) {
         v = rb_funcall(obj, *odd->attrs, 0);
@@ -431,8 +431,8 @@ static void dump_odd(VALUE obj, Odd odd, VALUE clas, int depth, Out out) {
             *out->cur++ = '"';
             memcpy(out->cur, name, nlen);
             out->cur += nlen;
-            *out->cur++ = '"';
-            *out->cur++ = ':';
+            memcpy(out->cur, "\":", 2);
+            out->cur += 2;
             memcpy(out->cur, s, len);
             out->cur += len;
             *out->cur = '\0';
@@ -800,8 +800,8 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
             *out->cur++ = '"';
             oj_dump_custom_val(rb_funcall(obj, oj_begin_id, 0), d3, out, false);
             assure_size(out, 3);
-            *out->cur++ = '.';
-            *out->cur++ = '.';
+            memcpy(out->cur, "..", 2);
+            out->cur += 2;
             if (Qtrue == rb_funcall(obj, oj_exclude_end_id, 0)) {
                 *out->cur++ = '.';
             }
@@ -846,8 +846,8 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
             *out->cur++ = '"';
             memcpy(out->cur, name, len);
             out->cur += len;
-            *out->cur++ = '"';
-            *out->cur++ = ':';
+            memcpy(out->cur, "\":", 2);
+            out->cur += 2;
             oj_dump_custom_val(v, d3, out, true);
             *out->cur++ = ',';
         }

--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -291,14 +291,12 @@ static const char *dump_unicode(const char *str, const char *end, Out out, const
         code -= 0x00010000;
         c1          = ((code >> 10) & 0x000003FF) + 0x0000D800;
         code        = (code & 0x000003FF) + 0x0000DC00;
-        memcpy(out->cur, "\\u", 2);
-        out->cur += 2;
+        APPEND_CHARS(out->cur, "\\u", 2);
         for (i = 3; 0 <= i; i--) {
             *out->cur++ = hex_chars[(uint8_t)(c1 >> (i * 4)) & 0x0F];
         }
     }
-    memcpy(out->cur, "\\u", 2);
-    out->cur += 2;
+    APPEND_CHARS(out->cur, "\\u", 2);
     for (i = 3; 0 <= i; i--) {
         *out->cur++ = hex_chars[(uint8_t)(code >> (i * 4)) & 0x0F];
     }
@@ -347,8 +345,7 @@ long oj_check_circular(VALUE obj, Out out) {
         } else {
             if (ObjectMode == out->opts->mode) {
                 assure_size(out, 18);
-                memcpy(out->cur, "\"^r", 3);
-                out->cur += 3;
+                APPEND_CHARS(out->cur, "\"^r", 3);
                 dump_ulong(id, out);
                 *out->cur++ = '"';
             }
@@ -450,8 +447,7 @@ void oj_dump_time(VALUE obj, Out out, int withZone) {
     b++;
     size = sizeof(buf) - (b - buf) - 1;
     assure_size(out, size);
-    memcpy(out->cur, b, size);
-    out->cur += size;
+    APPEND_CHARS(out->cur, b, size);
     *out->cur = '\0';
 }
 
@@ -805,8 +801,7 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
     *out->cur++ = '"';
 
     if (escape1) {
-        memcpy(out->cur, "\\u00", 4);
-        out->cur += 4;
+        APPEND_CHARS(out->cur, "\\u00", 4);
         dump_hex((uint8_t)*str, out);
         cnt--;
         size--;
@@ -817,8 +812,7 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
         if (is_sym) {
             *out->cur++ = ':';
         }
-        memcpy(out->cur, str, cnt);
-        out->cur += cnt;
+        APPEND_CHARS(out->cur, str, cnt);
         *out->cur++ = '"';
     } else {
         const char *end         = str + cnt;
@@ -868,8 +862,7 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
                 break;
             case '6':  // control characters
                 if (*(uint8_t *)str < 0x80) {
-                    memcpy(out->cur, "\\u00", 4);
-                    out->cur += 4;
+                    APPEND_CHARS(out->cur, "\\u00", 4);
                     dump_hex((uint8_t)*str, out);
                 } else {
                     if (0xe2 == (uint8_t)*str &&
@@ -948,8 +941,7 @@ void oj_dump_obj_to_s(VALUE obj, Out out) {
 
 void oj_dump_raw(const char *str, size_t cnt, Out out) {
     assure_size(out, cnt + 10);
-    memcpy(out->cur, str, cnt);
-    out->cur += cnt;
+    APPEND_CHARS(out->cur, str, cnt);
     *out->cur = '\0';
 }
 
@@ -979,22 +971,19 @@ void oj_grow_out(Out out, size_t len) {
 
 void oj_dump_nil(VALUE obj, int depth, Out out, bool as_ok) {
     assure_size(out, 4);
-    memcpy(out->cur, "null", 4);
-    out->cur += 4;
+    APPEND_CHARS(out->cur, "null", 4);
     *out->cur   = '\0';
 }
 
 void oj_dump_true(VALUE obj, int depth, Out out, bool as_ok) {
     assure_size(out, 4);
-    memcpy(out->cur, "true", 4);
-    out->cur += 4;
+    APPEND_CHARS(out->cur, "true", 4);
     *out->cur   = '\0';
 }
 
 void oj_dump_false(VALUE obj, int depth, Out out, bool as_ok) {
     assure_size(out, 5);
-    memcpy(out->cur, "false", 5);
-    out->cur += 5;
+    APPEND_CHARS(out->cur, "false", 5);
     *out->cur   = '\0';
 }
 
@@ -1036,8 +1025,7 @@ void oj_dump_fixnum(VALUE obj, int depth, Out out, bool as_ok) {
     }
     cnt = sizeof(buf) - (b - buf) - 1;
     assure_size(out, cnt);
-    memcpy(out->cur, b, cnt);
-    out->cur += cnt;
+    APPEND_CHARS(out->cur, b, cnt);
     *out->cur = '\0';
 }
 
@@ -1053,8 +1041,7 @@ void oj_dump_bignum(VALUE obj, int depth, Out out, bool as_ok) {
     } else {
         assure_size(out, cnt);
     }
-    memcpy(out->cur, RSTRING_PTR(rs), cnt);
-    out->cur += cnt;
+    APPEND_CHARS(out->cur, RSTRING_PTR(rs), cnt);
     if (dump_as_string) {
         *out->cur++ = '"';
     }
@@ -1187,8 +1174,7 @@ void oj_dump_float(VALUE obj, int depth, Out out, bool as_ok) {
         cnt = oj_dump_float_printf(buf, sizeof(buf), obj, d, out->opts->float_fmt);
     }
     assure_size(out, cnt);
-    memcpy(out->cur, buf, cnt);
-    out->cur += cnt;
+    APPEND_CHARS(out->cur, buf, cnt);
     *out->cur = '\0';
 }
 

--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -291,14 +291,14 @@ static const char *dump_unicode(const char *str, const char *end, Out out, const
         code -= 0x00010000;
         c1          = ((code >> 10) & 0x000003FF) + 0x0000D800;
         code        = (code & 0x000003FF) + 0x0000DC00;
-        *out->cur++ = '\\';
-        *out->cur++ = 'u';
+        memcpy(out->cur, "\\u", 2);
+        out->cur += 2;
         for (i = 3; 0 <= i; i--) {
             *out->cur++ = hex_chars[(uint8_t)(c1 >> (i * 4)) & 0x0F];
         }
     }
-    *out->cur++ = '\\';
-    *out->cur++ = 'u';
+    memcpy(out->cur, "\\u", 2);
+    out->cur += 2;
     for (i = 3; 0 <= i; i--) {
         *out->cur++ = hex_chars[(uint8_t)(code >> (i * 4)) & 0x0F];
     }
@@ -347,9 +347,8 @@ long oj_check_circular(VALUE obj, Out out) {
         } else {
             if (ObjectMode == out->opts->mode) {
                 assure_size(out, 18);
-                *out->cur++ = '"';
-                *out->cur++ = '^';
-                *out->cur++ = 'r';
+                memcpy(out->cur, "\"^r", 3);
+                out->cur += 3;
                 dump_ulong(id, out);
                 *out->cur++ = '"';
             }
@@ -806,10 +805,8 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
     *out->cur++ = '"';
 
     if (escape1) {
-        *out->cur++ = '\\';
-        *out->cur++ = 'u';
-        *out->cur++ = '0';
-        *out->cur++ = '0';
+        memcpy(out->cur, "\\u00", 4);
+        out->cur += 4;
         dump_hex((uint8_t)*str, out);
         cnt--;
         size--;
@@ -871,10 +868,8 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
                 break;
             case '6':  // control characters
                 if (*(uint8_t *)str < 0x80) {
-                    *out->cur++ = '\\';
-                    *out->cur++ = 'u';
-                    *out->cur++ = '0';
-                    *out->cur++ = '0';
+                    memcpy(out->cur, "\\u00", 4);
+                    out->cur += 4;
                     dump_hex((uint8_t)*str, out);
                 } else {
                     if (0xe2 == (uint8_t)*str &&

--- a/ext/oj/dump.h
+++ b/ext/oj/dump.h
@@ -96,8 +96,7 @@ inline static void dump_ulong(unsigned long num, Out out) {
         *b = '0';
     }
     cnt = sizeof(buf) - (b - buf) - 1;
-    memcpy(out->cur, b, cnt);
-    out->cur += cnt;
+    APPEND_CHARS(out->cur, b, cnt);
     *out->cur = '\0';
 }
 

--- a/ext/oj/dump.h
+++ b/ext/oj/dump.h
@@ -82,8 +82,9 @@ inline static bool dump_ignore(Options opts, VALUE obj) {
 }
 
 inline static void dump_ulong(unsigned long num, Out out) {
-    char  buf[32];
-    char *b = buf + sizeof(buf) - 1;
+    char   buf[32];
+    char  *b   = buf + sizeof(buf) - 1;
+    size_t cnt = 0;
 
     *b-- = '\0';
     if (0 < num) {
@@ -94,9 +95,9 @@ inline static void dump_ulong(unsigned long num, Out out) {
     } else {
         *b = '0';
     }
-    for (; '\0' != *b; b++) {
-        *out->cur++ = *b;
-    }
+    cnt = sizeof(buf) - (b - buf) - 1;
+    memcpy(out->cur, b, cnt);
+    out->cur += cnt;
     *out->cur = '\0';
 }
 

--- a/ext/oj/dump_compat.c
+++ b/ext/oj/dump_compat.c
@@ -32,21 +32,17 @@ dump_obj_classname(const char *classname, int depth, Out out) {
     *out->cur++ = '{';
     fill_indent(out, d2);
     *out->cur++ = '"';
-    memcpy(out->cur, out->opts->create_id, out->opts->create_id_len);
-    out->cur += out->opts->create_id_len;
+    APPEND_CHARS(out->cur, out->opts->create_id, out->opts->create_id_len);
     *out->cur++ = '"';
     if (0 < out->opts->dump_opts.before_size) {
-	strcpy(out->cur, out->opts->dump_opts.before_sep);
-	out->cur += out->opts->dump_opts.before_size;
+	APPEND_CHARS(out->cur, out->opts->dump_opts.before_sep, out->opts->dump_opts.before_size);
     }
     *out->cur++ = ':';
     if (0 < out->opts->dump_opts.after_size) {
-	strcpy(out->cur, out->opts->dump_opts.after_sep);
-	out->cur += out->opts->dump_opts.after_size;
+	APPEND_CHARS(out->cur, out->opts->dump_opts.after_sep, out->opts->dump_opts.after_size);
     }
     *out->cur++ = '"';
-    memcpy(out->cur, classname, len);
-    out->cur += len;
+    APPEND_CHARS(out->cur, classname, len);
     *out->cur++ = '"';
 }
 
@@ -71,15 +67,13 @@ dump_values_array(VALUE *values, int depth, Out out) {
 	    assure_size(out, size);
 	    if (out->opts->dump_opts.use) {
 		if (0 < out->opts->dump_opts.array_size) {
-		    strcpy(out->cur, out->opts->dump_opts.array_nl);
-		    out->cur += out->opts->dump_opts.array_size;
+		    APPEND_CHARS(out->cur, out->opts->dump_opts.array_nl, out->opts->dump_opts.array_size);
 		}
 		if (0 < out->opts->dump_opts.indent_size) {
 		    int	i;
 
 		    for (i = d2; 0 < i; i--) {
-			strcpy(out->cur, out->opts->dump_opts.indent_str);
-			out->cur += out->opts->dump_opts.indent_size;
+			APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
 		    }
 		}
 	    } else {
@@ -93,15 +87,13 @@ dump_values_array(VALUE *values, int depth, Out out) {
 	assure_size(out, size);
 	if (out->opts->dump_opts.use) {
 	    if (0 < out->opts->dump_opts.array_size) {
-		strcpy(out->cur, out->opts->dump_opts.array_nl);
-		out->cur += out->opts->dump_opts.array_size;
+		APPEND_CHARS(out->cur, out->opts->dump_opts.array_nl, out->opts->dump_opts.array_size);
 	    }
 	    if (0 < out->opts->dump_opts.indent_size) {
 		int	i;
 
 		for (i = depth; 0 < i; i--) {
-		    strcpy(out->cur, out->opts->dump_opts.indent_str);
-		    out->cur += out->opts->dump_opts.indent_size;
+		    APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
 		}
 	    }
 	} else {
@@ -133,8 +125,7 @@ dump_to_json(VALUE obj, Out out) {
     len = (int)RSTRING_LEN(rs);
 
     assure_size(out, len + 1);
-    memcpy(out->cur, s, len);
-    out->cur += len;
+    APPEND_CHARS(out->cur, s, len);
     *out->cur = '\0';
 }
 
@@ -169,14 +160,12 @@ dump_array(VALUE a, int depth, Out out, bool as_ok) {
 	for (i = 0; i <= cnt; i++) {
 	    if (out->opts->dump_opts.use) {
 		if (0 < out->opts->dump_opts.array_size) {
-		    strcpy(out->cur, out->opts->dump_opts.array_nl);
-		    out->cur += out->opts->dump_opts.array_size;
+		    APPEND_CHARS(out->cur, out->opts->dump_opts.array_nl, out->opts->dump_opts.array_size);
 		}
 		if (0 < out->opts->dump_opts.indent_size) {
 		    int	i;
 		    for (i = d2; 0 < i; i--) {
-			strcpy(out->cur, out->opts->dump_opts.indent_str);
-			out->cur += out->opts->dump_opts.indent_size;
+			APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
 		    }
 		}
 	    } else {
@@ -191,15 +180,13 @@ dump_array(VALUE a, int depth, Out out, bool as_ok) {
 	    size = out->opts->dump_opts.array_size + out->opts->dump_opts.indent_size * depth + 1;
 	    assure_size(out, size);
 	    if (0 < out->opts->dump_opts.array_size) {
-		strcpy(out->cur, out->opts->dump_opts.array_nl);
-		out->cur += out->opts->dump_opts.array_size;
+		APPEND_CHARS(out->cur, out->opts->dump_opts.array_nl, out->opts->dump_opts.array_size);
 	    }
 	    if (0 < out->opts->dump_opts.indent_size) {
 		int	i;
 
 		for (i = depth; 0 < i; i--) {
-		    strcpy(out->cur, out->opts->dump_opts.indent_str);
-		    out->cur += out->opts->dump_opts.indent_size;
+		    APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
 		}
 	    }
 	} else {
@@ -336,31 +323,25 @@ exception_alt(VALUE obj, int depth, Out out) {
     assure_size(out, size + sep_len + 6);
     *out->cur++ = ',';
     fill_indent(out, d3);
-    memcpy(out->cur, "\"m\"", 3);
-    out->cur += 3;
+    APPEND_CHARS(out->cur, "\"m\"", 3);
     if (0 < out->opts->dump_opts.before_size) {
-	strcpy(out->cur, out->opts->dump_opts.before_sep);
-	out->cur += out->opts->dump_opts.before_size;
+	APPEND_CHARS(out->cur, out->opts->dump_opts.before_sep, out->opts->dump_opts.before_size);
     }
     *out->cur++ = ':';
     if (0 < out->opts->dump_opts.after_size) {
-	strcpy(out->cur, out->opts->dump_opts.after_sep);
-	out->cur += out->opts->dump_opts.after_size;
+	APPEND_CHARS(out->cur, out->opts->dump_opts.after_sep, out->opts->dump_opts.after_size);
     }
     oj_dump_str(rb_funcall(obj, message_id, 0), 0, out, false);
     assure_size(out, size + sep_len + 6);
     *out->cur++ = ',';
     fill_indent(out, d3);
-    memcpy(out->cur, "\"b\"", 3);
-    out->cur += 3;
+    APPEND_CHARS(out->cur, "\"b\"", 3);
     if (0 < out->opts->dump_opts.before_size) {
-	strcpy(out->cur, out->opts->dump_opts.before_sep);
-	out->cur += out->opts->dump_opts.before_size;
+	APPEND_CHARS(out->cur, out->opts->dump_opts.before_sep, out->opts->dump_opts.before_size);
     }
     *out->cur++ = ':';
     if (0 < out->opts->dump_opts.after_size) {
-	strcpy(out->cur, out->opts->dump_opts.after_sep);
-	out->cur += out->opts->dump_opts.after_size;
+	APPEND_CHARS(out->cur, out->opts->dump_opts.after_sep, out->opts->dump_opts.after_size);
     }
     dump_array(rb_funcall(obj, backtrace_id, 0), depth, out, false);
     fill_indent(out, depth);
@@ -396,16 +377,13 @@ range_alt(VALUE obj, int depth, Out out) {
     assure_size(out, size + sep_len + 6);
     *out->cur++ = ',';
     fill_indent(out, d3);
-    memcpy(out->cur, "\"a\"", 3);
-    out->cur += 3;
+    APPEND_CHARS(out->cur, "\"a\"", 3);
     if (0 < out->opts->dump_opts.before_size) {
-	strcpy(out->cur, out->opts->dump_opts.before_sep);
-	out->cur += out->opts->dump_opts.before_size;
+	APPEND_CHARS(out->cur, out->opts->dump_opts.before_sep, out->opts->dump_opts.before_size);
     }
     *out->cur++ = ':';
     if (0 < out->opts->dump_opts.after_size) {
-	strcpy(out->cur, out->opts->dump_opts.after_sep);
-	out->cur += out->opts->dump_opts.after_size;
+	APPEND_CHARS(out->cur, out->opts->dump_opts.after_sep, out->opts->dump_opts.after_size);
     }
     args[0] = rb_funcall(obj, oj_begin_id, 0);
     args[1] = rb_funcall(obj, oj_end_id, 0);
@@ -639,8 +617,7 @@ dump_float(VALUE obj, int depth, Out out, bool as_ok) {
 	cnt = (int)RSTRING_LEN(rstr);
     }
     assure_size(out, cnt);
-    memcpy(out->cur, buf, cnt);
-    out->cur += cnt;
+    APPEND_CHARS(out->cur, buf, cnt);
     *out->cur = '\0';
 }
 
@@ -658,14 +635,12 @@ hash_cb(VALUE key, VALUE value, VALUE ov) {
     } else {
 	assure_size(out, depth * out->opts->dump_opts.indent_size + out->opts->dump_opts.hash_size + 1);
 	if (0 < out->opts->dump_opts.hash_size) {
-	    strcpy(out->cur, out->opts->dump_opts.hash_nl);
-	    out->cur += out->opts->dump_opts.hash_size;
+	    APPEND_CHARS(out->cur, out->opts->dump_opts.hash_nl, out->opts->dump_opts.hash_size);
 	}
 	if (0 < out->opts->dump_opts.indent_size) {
 	    int	i;
 	    for (i = depth; 0 < i; i--) {
-		strcpy(out->cur, out->opts->dump_opts.indent_str);
-		out->cur += out->opts->dump_opts.indent_size;
+		APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
 	    }
 	}
     }
@@ -686,13 +661,11 @@ hash_cb(VALUE key, VALUE value, VALUE ov) {
     } else {
 	assure_size(out, out->opts->dump_opts.before_size + out->opts->dump_opts.after_size + 2);
 	if (0 < out->opts->dump_opts.before_size) {
-	    strcpy(out->cur, out->opts->dump_opts.before_sep);
-	    out->cur += out->opts->dump_opts.before_size;
+	    APPEND_CHARS(out->cur, out->opts->dump_opts.before_sep, out->opts->dump_opts.before_size);
 	}
 	*out->cur++ = ':';
 	if (0 < out->opts->dump_opts.after_size) {
-	    strcpy(out->cur, out->opts->dump_opts.after_sep);
-	    out->cur += out->opts->dump_opts.after_size;
+	    APPEND_CHARS(out->cur, out->opts->dump_opts.after_sep, out->opts->dump_opts.after_size);
 	}
     }
     oj_dump_compat_val(value, depth, out, true);
@@ -718,8 +691,7 @@ dump_hash(VALUE obj, int depth, Out out, bool as_ok) {
     cnt = (int)RHASH_SIZE(obj);
     assure_size(out, 2);
     if (0 == cnt) {
-	memcpy(out->cur, "{}", 2);
-	out->cur += 2;
+	APPEND_CHARS(out->cur, "{}", 2);
     } else {
 	*out->cur++ = '{';
 	out->depth = depth + 1;
@@ -733,15 +705,13 @@ dump_hash(VALUE obj, int depth, Out out, bool as_ok) {
 	} else {
 	    assure_size(out, depth * out->opts->dump_opts.indent_size + out->opts->dump_opts.hash_size + 1);
 	    if (0 < out->opts->dump_opts.hash_size) {
-		strcpy(out->cur, out->opts->dump_opts.hash_nl);
-		out->cur += out->opts->dump_opts.hash_size;
+		APPEND_CHARS(out->cur, out->opts->dump_opts.hash_nl, out->opts->dump_opts.hash_size);
 	    }
 	    if (0 < out->opts->dump_opts.indent_size) {
 		int	i;
 
 		for (i = depth; 0 < i; i--) {
-		    strcpy(out->cur, out->opts->dump_opts.indent_str);
-		    out->cur += out->opts->dump_opts.indent_size;
+		    APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
 		}
 	    }
 	}
@@ -785,8 +755,7 @@ dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
 	*out->cur++ = '"';
 	oj_dump_compat_val(rb_funcall(obj, oj_begin_id, 0), 0, out, false);
 	assure_size(out, 3);
-	memcpy(out->cur, "..", 2);
-	out->cur += 2;
+	APPEND_CHARS(out->cur, "..", 2);
 	if (Qtrue == rb_funcall(obj, oj_exclude_end_id, 0)) {
 	    *out->cur++ = '.';
 	}
@@ -832,16 +801,13 @@ dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
 	assure_size(out, size + sep_len + 6);
 	*out->cur++ = ',';
 	fill_indent(out, d3);
-	memcpy(out->cur, "\"v\"", 3);
-	out->cur += 3;
+	APPEND_CHARS(out->cur, "\"v\"", 3);
 	if (0 < out->opts->dump_opts.before_size) {
-	    strcpy(out->cur, out->opts->dump_opts.before_sep);
-	    out->cur += out->opts->dump_opts.before_size;
+	    APPEND_CHARS(out->cur, out->opts->dump_opts.before_sep, out->opts->dump_opts.before_size);
 	}
 	*out->cur++ = ':';
 	if (0 < out->opts->dump_opts.after_size) {
-	    strcpy(out->cur, out->opts->dump_opts.after_sep);
-	    out->cur += out->opts->dump_opts.after_size;
+	    APPEND_CHARS(out->cur, out->opts->dump_opts.after_sep, out->opts->dump_opts.after_size);
 	}
 	for (i = 0; i < cnt; i++) {
 #ifdef RSTRUCT_LEN
@@ -884,8 +850,7 @@ dump_bignum(VALUE obj, int depth, Out out, bool as_ok) {
     } else {
 	assure_size(out, cnt);
     }
-    memcpy(out->cur, RSTRING_PTR(rs), cnt);
-    out->cur += cnt;
+    APPEND_CHARS(out->cur, RSTRING_PTR(rs), cnt);
     if (dump_as_string) {
 	*out->cur++ = '"';
     }

--- a/ext/oj/dump_compat.c
+++ b/ext/oj/dump_compat.c
@@ -336,9 +336,8 @@ exception_alt(VALUE obj, int depth, Out out) {
     assure_size(out, size + sep_len + 6);
     *out->cur++ = ',';
     fill_indent(out, d3);
-    *out->cur++ = '"';
-    *out->cur++ = 'm';
-    *out->cur++ = '"';
+    memcpy(out->cur, "\"m\"", 3);
+    out->cur += 3;
     if (0 < out->opts->dump_opts.before_size) {
 	strcpy(out->cur, out->opts->dump_opts.before_sep);
 	out->cur += out->opts->dump_opts.before_size;
@@ -352,9 +351,8 @@ exception_alt(VALUE obj, int depth, Out out) {
     assure_size(out, size + sep_len + 6);
     *out->cur++ = ',';
     fill_indent(out, d3);
-    *out->cur++ = '"';
-    *out->cur++ = 'b';
-    *out->cur++ = '"';
+    memcpy(out->cur, "\"b\"", 3);
+    out->cur += 3;
     if (0 < out->opts->dump_opts.before_size) {
 	strcpy(out->cur, out->opts->dump_opts.before_sep);
 	out->cur += out->opts->dump_opts.before_size;
@@ -398,9 +396,8 @@ range_alt(VALUE obj, int depth, Out out) {
     assure_size(out, size + sep_len + 6);
     *out->cur++ = ',';
     fill_indent(out, d3);
-    *out->cur++ = '"';
-    *out->cur++ = 'a';
-    *out->cur++ = '"';
+    memcpy(out->cur, "\"a\"", 3);
+    out->cur += 3;
     if (0 < out->opts->dump_opts.before_size) {
 	strcpy(out->cur, out->opts->dump_opts.before_sep);
 	out->cur += out->opts->dump_opts.before_size;
@@ -721,8 +718,8 @@ dump_hash(VALUE obj, int depth, Out out, bool as_ok) {
     cnt = (int)RHASH_SIZE(obj);
     assure_size(out, 2);
     if (0 == cnt) {
-	*out->cur++ = '{';
-	*out->cur++ = '}';
+	memcpy(out->cur, "{}", 2);
+	out->cur += 2;
     } else {
 	*out->cur++ = '{';
 	out->depth = depth + 1;
@@ -788,8 +785,8 @@ dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
 	*out->cur++ = '"';
 	oj_dump_compat_val(rb_funcall(obj, oj_begin_id, 0), 0, out, false);
 	assure_size(out, 3);
-	*out->cur++ = '.';
-	*out->cur++ = '.';
+	memcpy(out->cur, "..", 2);
+	out->cur += 2;
 	if (Qtrue == rb_funcall(obj, oj_exclude_end_id, 0)) {
 	    *out->cur++ = '.';
 	}
@@ -835,9 +832,8 @@ dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
 	assure_size(out, size + sep_len + 6);
 	*out->cur++ = ',';
 	fill_indent(out, d3);
-	*out->cur++ = '"';
-	*out->cur++ = 'v';
-	*out->cur++ = '"';
+	memcpy(out->cur, "\"v\"", 3);
+	out->cur += 3;
 	if (0 < out->opts->dump_opts.before_size) {
 	    strcpy(out->cur, out->opts->dump_opts.before_sep);
 	    out->cur += out->opts->dump_opts.before_size;

--- a/ext/oj/dump_leaf.c
+++ b/ext/oj/dump_leaf.c
@@ -36,8 +36,7 @@ inline static void dump_chars(const char *s, size_t size, Out out) {
     if (out->end - out->cur <= (long)size) {
         grow(out, size);
     }
-    memcpy(out->cur, s, size);
-    out->cur += size;
+    APPEND_CHARS(out->cur, s, size);
     *out->cur = '\0';
 }
 

--- a/ext/oj/dump_object.c
+++ b/ext/oj/dump_object.c
@@ -24,8 +24,7 @@ static void dump_data(VALUE obj, int depth, Out out, bool as_ok) {
 
     if (rb_cTime == clas) {
         assure_size(out, 6);
-        memcpy(out->cur, "{\"^t\":", 6);
-        out->cur += 6;
+        APPEND_CHARS(out->cur, "{\"^t\":", 6);
         dump_time(obj, out);
         *out->cur++ = '}';
         *out->cur   = '\0';
@@ -87,8 +86,7 @@ static void dump_class(VALUE obj, int depth, Out out, bool as_ok) {
     size_t      len = strlen(s);
 
     assure_size(out, 6);
-    memcpy(out->cur, "{\"^c\":", 6);
-    out->cur += 6;
+    APPEND_CHARS(out->cur, "{\"^c\":", 6);
     oj_dump_cstr(s, len, 0, 0, out);
     *out->cur++ = '}';
     *out->cur   = '\0';
@@ -112,8 +110,7 @@ static void dump_array_class(VALUE a, VALUE clas, int depth, Out out) {
     if (0 < id) {
         assure_size(out, d2 * out->indent + 16);
         fill_indent(out, d2);
-        memcpy(out->cur, "\"^i", 3);
-        out->cur += 3;
+        APPEND_CHARS(out->cur, "\"^i", 3);
         dump_ulong(id, out);
         *out->cur++ = '"';
     }
@@ -135,14 +132,12 @@ static void dump_array_class(VALUE a, VALUE clas, int depth, Out out) {
         for (i = 0; i <= cnt; i++) {
             if (out->opts->dump_opts.use) {
                 if (0 < out->opts->dump_opts.array_size) {
-                    strcpy(out->cur, out->opts->dump_opts.array_nl);
-                    out->cur += out->opts->dump_opts.array_size;
+                    APPEND_CHARS(out->cur, out->opts->dump_opts.array_nl, out->opts->dump_opts.array_size);
                 }
                 if (0 < out->opts->dump_opts.indent_size) {
                     int i;
                     for (i = d2; 0 < i; i--) {
-                        strcpy(out->cur, out->opts->dump_opts.indent_str);
-                        out->cur += out->opts->dump_opts.indent_size;
+                        APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
                     }
                 }
             } else {
@@ -159,15 +154,13 @@ static void dump_array_class(VALUE a, VALUE clas, int depth, Out out) {
             // printf("*** d2: %u  indent: %u '%s'\n", d2, out->opts->dump_opts->indent_size,
             // out->opts->dump_opts->indent);
             if (0 < out->opts->dump_opts.array_size) {
-                strcpy(out->cur, out->opts->dump_opts.array_nl);
-                out->cur += out->opts->dump_opts.array_size;
+                APPEND_CHARS(out->cur, out->opts->dump_opts.array_nl, out->opts->dump_opts.array_size);
             }
             if (0 < out->opts->dump_opts.indent_size) {
                 int i;
 
                 for (i = depth; 0 < i; i--) {
-                    strcpy(out->cur, out->opts->dump_opts.indent_str);
-                    out->cur += out->opts->dump_opts.indent_size;
+                    APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
                 }
             }
         } else {
@@ -239,8 +232,7 @@ static int hash_cb(VALUE key, VALUE value, VALUE ov) {
             uint8_t b;
 
             assure_size(out, s2 + 15);
-            memcpy(out->cur, "\"^#", 3);
-            out->cur += 3;
+            APPEND_CHARS(out->cur, "\"^#", 3);
             out->hash_cnt++;
             for (i = 28; 0 <= i; i -= 4) {
                 b = (uint8_t)((out->hash_cnt >> i) & 0x0000000F);
@@ -251,8 +243,7 @@ static int hash_cb(VALUE key, VALUE value, VALUE ov) {
                     *out->cur++ = hex_chars[b];
                 }
             }
-            memcpy(out->cur, "\":[", 3);
-            out->cur += 3;
+            APPEND_CHARS(out->cur, "\":[", 3);
             fill_indent(out, d2);
             oj_dump_obj_val(key, d2, out);
             assure_size(out, s2);
@@ -282,8 +273,7 @@ static void dump_hash_class(VALUE obj, VALUE clas, int depth, Out out) {
     size = depth * out->indent + 2;
     assure_size(out, 2);
     if (0 == cnt) {
-        memcpy(out->cur, "{}", 2);
-        out->cur += 2;
+        APPEND_CHARS(out->cur, "{}", 2);
     } else {
         long id = oj_check_circular(obj, out);
 
@@ -294,8 +284,7 @@ static void dump_hash_class(VALUE obj, VALUE clas, int depth, Out out) {
         if (0 < id) {
             assure_size(out, size + 16);
             fill_indent(out, depth + 1);
-            memcpy(out->cur, "\"^i\":", 5);
-            out->cur += 5;
+            APPEND_CHARS(out->cur, "\"^i\":", 5);
             dump_ulong(id, out);
             *out->cur++ = ',';
         }
@@ -311,15 +300,13 @@ static void dump_hash_class(VALUE obj, VALUE clas, int depth, Out out) {
             size = depth * out->opts->dump_opts.indent_size + out->opts->dump_opts.hash_size + 1;
             assure_size(out, size);
             if (0 < out->opts->dump_opts.hash_size) {
-                strcpy(out->cur, out->opts->dump_opts.hash_nl);
-                out->cur += out->opts->dump_opts.hash_size;
+                APPEND_CHARS(out->cur, out->opts->dump_opts.hash_nl, out->opts->dump_opts.hash_size);
             }
             if (0 < out->opts->dump_opts.indent_size) {
                 int i;
 
                 for (i = depth; 0 < i; i--) {
-                    strcpy(out->cur, out->opts->dump_opts.indent_str);
-                    out->cur += out->opts->dump_opts.indent_size;
+                    APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
                 }
             }
         }
@@ -394,8 +381,7 @@ static void dump_odd(VALUE obj, Odd odd, VALUE clas, int depth, Out out) {
         size = d2 * out->indent + clen + 10;
         assure_size(out, size);
         fill_indent(out, d2);
-        memcpy(out->cur, "\"^O\":", 5);
-        out->cur += 5;
+        APPEND_CHARS(out->cur, "\"^O\":", 5);
         oj_dump_cstr(class_name, clen, 0, 0, out);
         *out->cur++ = ',';
     }
@@ -413,12 +399,9 @@ static void dump_odd(VALUE obj, Odd odd, VALUE clas, int depth, Out out) {
             assure_size(out, size);
             fill_indent(out, d2);
             *out->cur++ = '"';
-            memcpy(out->cur, name, nlen);
-            out->cur += nlen;
-            memcpy(out->cur, "\":", 2);
-            out->cur += 2;
-            memcpy(out->cur, s, len);
-            out->cur += len;
+            APPEND_CHARS(out->cur, name, nlen);
+            APPEND_CHARS(out->cur, "\":", 2);
+            APPEND_CHARS(out->cur, s, len);
             *out->cur = '\0';
         }
     } else {
@@ -492,16 +475,14 @@ static void dump_obj_attrs(VALUE obj, VALUE clas, slot_t id, int depth, Out out)
 
         assure_size(out, d2 * out->indent + clen + 10);
         fill_indent(out, d2);
-        memcpy(out->cur, "\"^o\":", 5);
-        out->cur += 5;
+        APPEND_CHARS(out->cur, "\"^o\":", 5);
         oj_dump_cstr(class_name, clen, 0, 0, out);
     }
     if (0 < id) {
         assure_size(out, d2 * out->indent + 16);
         *out->cur++ = ',';
         fill_indent(out, d2);
-        memcpy(out->cur, "\"^i\":", 5);
-        out->cur += 5;
+        APPEND_CHARS(out->cur, "\"^i\":", 5);
         dump_ulong(id, out);
     }
     switch (type) {
@@ -509,24 +490,21 @@ static void dump_obj_attrs(VALUE obj, VALUE clas, slot_t id, int depth, Out out)
         assure_size(out, d2 * out->indent + 14);
         *out->cur++ = ',';
         fill_indent(out, d2);
-        memcpy(out->cur, "\"self\":", 7);
-        out->cur += 7;
+        APPEND_CHARS(out->cur, "\"self\":", 7);
         oj_dump_cstr(RSTRING_PTR(obj), (int)RSTRING_LEN(obj), 0, 0, out);
         break;
     case T_ARRAY:
         assure_size(out, d2 * out->indent + 14);
         *out->cur++ = ',';
         fill_indent(out, d2);
-        memcpy(out->cur, "\"self\":", 7);
-        out->cur += 7;
+        APPEND_CHARS(out->cur, "\"self\":", 7);
         dump_array_class(obj, Qundef, depth + 1, out);
         break;
     case T_HASH:
         assure_size(out, d2 * out->indent + 14);
         *out->cur++ = ',';
         fill_indent(out, d2);
-        memcpy(out->cur, "\"self\":", 7);
-        out->cur += 7;
+        APPEND_CHARS(out->cur, "\"self\":", 7);
         dump_hash_class(obj, Qundef, depth + 1, out);
         break;
     default: break;
@@ -650,8 +628,7 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
     assure_size(out, size);
     *out->cur++ = '{';
     fill_indent(out, d2);
-    memcpy(out->cur, "\"^u\":[", 6);
-    out->cur += 6;
+    APPEND_CHARS(out->cur, "\"^u\":[", 6);
     if ('#' == *class_name) {
         VALUE       ma = rb_struct_s_members(clas);
         const char *name;
@@ -669,16 +646,14 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
                 *out->cur++ = ',';
             }
             *out->cur++ = '"';
-            memcpy(out->cur, name, len);
-            out->cur += len;
+            APPEND_CHARS(out->cur, name, len);
             *out->cur++ = '"';
         }
         *out->cur++ = ']';
     } else {
         fill_indent(out, d3);
         *out->cur++ = '"';
-        memcpy(out->cur, class_name, len);
-        out->cur += len;
+        APPEND_CHARS(out->cur, class_name, len);
         *out->cur++ = '"';
     }
     *out->cur++ = ',';
@@ -722,8 +697,7 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
     }
 #endif
     out->cur--;
-    memcpy(out->cur, "]}", 2);
-    out->cur += 2;
+    APPEND_CHARS(out->cur, "]}", 2);
     *out->cur   = '\0';
 }
 

--- a/ext/oj/dump_object.c
+++ b/ext/oj/dump_object.c
@@ -24,12 +24,8 @@ static void dump_data(VALUE obj, int depth, Out out, bool as_ok) {
 
     if (rb_cTime == clas) {
         assure_size(out, 6);
-        *out->cur++ = '{';
-        *out->cur++ = '"';
-        *out->cur++ = '^';
-        *out->cur++ = 't';
-        *out->cur++ = '"';
-        *out->cur++ = ':';
+        memcpy(out->cur, "{\"^t\":", 6);
+        out->cur += 6;
         dump_time(obj, out);
         *out->cur++ = '}';
         *out->cur   = '\0';
@@ -91,12 +87,8 @@ static void dump_class(VALUE obj, int depth, Out out, bool as_ok) {
     size_t      len = strlen(s);
 
     assure_size(out, 6);
-    *out->cur++ = '{';
-    *out->cur++ = '"';
-    *out->cur++ = '^';
-    *out->cur++ = 'c';
-    *out->cur++ = '"';
-    *out->cur++ = ':';
+    memcpy(out->cur, "{\"^c\":", 6);
+    out->cur += 6;
     oj_dump_cstr(s, len, 0, 0, out);
     *out->cur++ = '}';
     *out->cur   = '\0';
@@ -120,9 +112,8 @@ static void dump_array_class(VALUE a, VALUE clas, int depth, Out out) {
     if (0 < id) {
         assure_size(out, d2 * out->indent + 16);
         fill_indent(out, d2);
-        *out->cur++ = '"';
-        *out->cur++ = '^';
-        *out->cur++ = 'i';
+        memcpy(out->cur, "\"^i", 3);
+        out->cur += 3;
         dump_ulong(id, out);
         *out->cur++ = '"';
     }
@@ -248,9 +239,8 @@ static int hash_cb(VALUE key, VALUE value, VALUE ov) {
             uint8_t b;
 
             assure_size(out, s2 + 15);
-            *out->cur++ = '"';
-            *out->cur++ = '^';
-            *out->cur++ = '#';
+            memcpy(out->cur, "\"^#", 3);
+            out->cur += 3;
             out->hash_cnt++;
             for (i = 28; 0 <= i; i -= 4) {
                 b = (uint8_t)((out->hash_cnt >> i) & 0x0000000F);
@@ -261,9 +251,8 @@ static int hash_cb(VALUE key, VALUE value, VALUE ov) {
                     *out->cur++ = hex_chars[b];
                 }
             }
-            *out->cur++ = '"';
-            *out->cur++ = ':';
-            *out->cur++ = '[';
+            memcpy(out->cur, "\":[", 3);
+            out->cur += 3;
             fill_indent(out, d2);
             oj_dump_obj_val(key, d2, out);
             assure_size(out, s2);
@@ -293,8 +282,8 @@ static void dump_hash_class(VALUE obj, VALUE clas, int depth, Out out) {
     size = depth * out->indent + 2;
     assure_size(out, 2);
     if (0 == cnt) {
-        *out->cur++ = '{';
-        *out->cur++ = '}';
+        memcpy(out->cur, "{}", 2);
+        out->cur += 2;
     } else {
         long id = oj_check_circular(obj, out);
 
@@ -305,11 +294,8 @@ static void dump_hash_class(VALUE obj, VALUE clas, int depth, Out out) {
         if (0 < id) {
             assure_size(out, size + 16);
             fill_indent(out, depth + 1);
-            *out->cur++ = '"';
-            *out->cur++ = '^';
-            *out->cur++ = 'i';
-            *out->cur++ = '"';
-            *out->cur++ = ':';
+            memcpy(out->cur, "\"^i\":", 5);
+            out->cur += 5;
             dump_ulong(id, out);
             *out->cur++ = ',';
         }
@@ -408,11 +394,8 @@ static void dump_odd(VALUE obj, Odd odd, VALUE clas, int depth, Out out) {
         size = d2 * out->indent + clen + 10;
         assure_size(out, size);
         fill_indent(out, d2);
-        *out->cur++ = '"';
-        *out->cur++ = '^';
-        *out->cur++ = 'O';
-        *out->cur++ = '"';
-        *out->cur++ = ':';
+        memcpy(out->cur, "\"^O\":", 5);
+        out->cur += 5;
         oj_dump_cstr(class_name, clen, 0, 0, out);
         *out->cur++ = ',';
     }
@@ -432,8 +415,8 @@ static void dump_odd(VALUE obj, Odd odd, VALUE clas, int depth, Out out) {
             *out->cur++ = '"';
             memcpy(out->cur, name, nlen);
             out->cur += nlen;
-            *out->cur++ = '"';
-            *out->cur++ = ':';
+            memcpy(out->cur, "\":", 2);
+            out->cur += 2;
             memcpy(out->cur, s, len);
             out->cur += len;
             *out->cur = '\0';
@@ -509,22 +492,16 @@ static void dump_obj_attrs(VALUE obj, VALUE clas, slot_t id, int depth, Out out)
 
         assure_size(out, d2 * out->indent + clen + 10);
         fill_indent(out, d2);
-        *out->cur++ = '"';
-        *out->cur++ = '^';
-        *out->cur++ = 'o';
-        *out->cur++ = '"';
-        *out->cur++ = ':';
+        memcpy(out->cur, "\"^o\":", 5);
+        out->cur += 5;
         oj_dump_cstr(class_name, clen, 0, 0, out);
     }
     if (0 < id) {
         assure_size(out, d2 * out->indent + 16);
         *out->cur++ = ',';
         fill_indent(out, d2);
-        *out->cur++ = '"';
-        *out->cur++ = '^';
-        *out->cur++ = 'i';
-        *out->cur++ = '"';
-        *out->cur++ = ':';
+        memcpy(out->cur, "\"^i\":", 5);
+        out->cur += 5;
         dump_ulong(id, out);
     }
     switch (type) {
@@ -532,39 +509,24 @@ static void dump_obj_attrs(VALUE obj, VALUE clas, slot_t id, int depth, Out out)
         assure_size(out, d2 * out->indent + 14);
         *out->cur++ = ',';
         fill_indent(out, d2);
-        *out->cur++ = '"';
-        *out->cur++ = 's';
-        *out->cur++ = 'e';
-        *out->cur++ = 'l';
-        *out->cur++ = 'f';
-        *out->cur++ = '"';
-        *out->cur++ = ':';
+        memcpy(out->cur, "\"self\":", 7);
+        out->cur += 7;
         oj_dump_cstr(RSTRING_PTR(obj), (int)RSTRING_LEN(obj), 0, 0, out);
         break;
     case T_ARRAY:
         assure_size(out, d2 * out->indent + 14);
         *out->cur++ = ',';
         fill_indent(out, d2);
-        *out->cur++ = '"';
-        *out->cur++ = 's';
-        *out->cur++ = 'e';
-        *out->cur++ = 'l';
-        *out->cur++ = 'f';
-        *out->cur++ = '"';
-        *out->cur++ = ':';
+        memcpy(out->cur, "\"self\":", 7);
+        out->cur += 7;
         dump_array_class(obj, Qundef, depth + 1, out);
         break;
     case T_HASH:
         assure_size(out, d2 * out->indent + 14);
         *out->cur++ = ',';
         fill_indent(out, d2);
-        *out->cur++ = '"';
-        *out->cur++ = 's';
-        *out->cur++ = 'e';
-        *out->cur++ = 'l';
-        *out->cur++ = 'f';
-        *out->cur++ = '"';
-        *out->cur++ = ':';
+        memcpy(out->cur, "\"self\":", 7);
+        out->cur += 7;
         dump_hash_class(obj, Qundef, depth + 1, out);
         break;
     default: break;
@@ -688,12 +650,8 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
     assure_size(out, size);
     *out->cur++ = '{';
     fill_indent(out, d2);
-    *out->cur++ = '"';
-    *out->cur++ = '^';
-    *out->cur++ = 'u';
-    *out->cur++ = '"';
-    *out->cur++ = ':';
-    *out->cur++ = '[';
+    memcpy(out->cur, "\"^u\":[", 6);
+    out->cur += 6;
     if ('#' == *class_name) {
         VALUE       ma = rb_struct_s_members(clas);
         const char *name;
@@ -764,8 +722,8 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
     }
 #endif
     out->cur--;
-    *out->cur++ = ']';
-    *out->cur++ = '}';
+    memcpy(out->cur, "]}", 2);
+    out->cur += 2;
     *out->cur   = '\0';
 }
 

--- a/ext/oj/dump_strict.c
+++ b/ext/oj/dump_strict.c
@@ -105,8 +105,7 @@ static void dump_float(VALUE obj, int depth, Out out, bool as_ok) {
         }
     }
     assure_size(out, cnt);
-    memcpy(out->cur, buf, cnt);
-    out->cur += cnt;
+    APPEND_CHARS(out->cur, buf, cnt);
     *out->cur = '\0';
 }
 
@@ -138,14 +137,12 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
         for (i = 0; i <= cnt; i++) {
             if (out->opts->dump_opts.use) {
                 if (0 < out->opts->dump_opts.array_size) {
-                    strcpy(out->cur, out->opts->dump_opts.array_nl);
-                    out->cur += out->opts->dump_opts.array_size;
+                    APPEND_CHARS(out->cur, out->opts->dump_opts.array_nl, out->opts->dump_opts.array_size);
                 }
                 if (0 < out->opts->dump_opts.indent_size) {
                     int i;
                     for (i = d2; 0 < i; i--) {
-                        strcpy(out->cur, out->opts->dump_opts.indent_str);
-                        out->cur += out->opts->dump_opts.indent_size;
+                        APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
                     }
                 }
             } else {
@@ -166,15 +163,13 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
             // printf("*** d2: %u  indent: %u '%s'\n", d2, out->opts->dump_opts->indent_size,
             // out->opts->dump_opts->indent);
             if (0 < out->opts->dump_opts.array_size) {
-                strcpy(out->cur, out->opts->dump_opts.array_nl);
-                out->cur += out->opts->dump_opts.array_size;
+                APPEND_CHARS(out->cur, out->opts->dump_opts.array_nl, out->opts->dump_opts.array_size);
             }
             if (0 < out->opts->dump_opts.indent_size) {
                 int i;
 
                 for (i = depth; 0 < i; i--) {
-                    strcpy(out->cur, out->opts->dump_opts.indent_str);
-                    out->cur += out->opts->dump_opts.indent_size;
+                    APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
                 }
             }
         } else {
@@ -213,14 +208,12 @@ static int hash_cb(VALUE key, VALUE value, VALUE ov) {
         size = depth * out->opts->dump_opts.indent_size + out->opts->dump_opts.hash_size + 1;
         assure_size(out, size);
         if (0 < out->opts->dump_opts.hash_size) {
-            strcpy(out->cur, out->opts->dump_opts.hash_nl);
-            out->cur += out->opts->dump_opts.hash_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.hash_nl, out->opts->dump_opts.hash_size);
         }
         if (0 < out->opts->dump_opts.indent_size) {
             int i;
             for (i = depth; 0 < i; i--) {
-                strcpy(out->cur, out->opts->dump_opts.indent_str);
-                out->cur += out->opts->dump_opts.indent_size;
+                APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
             }
         }
         if (rtype == T_STRING) {
@@ -231,13 +224,11 @@ static int hash_cb(VALUE key, VALUE value, VALUE ov) {
         size = out->opts->dump_opts.before_size + out->opts->dump_opts.after_size + 2;
         assure_size(out, size);
         if (0 < out->opts->dump_opts.before_size) {
-            strcpy(out->cur, out->opts->dump_opts.before_sep);
-            out->cur += out->opts->dump_opts.before_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.before_sep, out->opts->dump_opts.before_size);
         }
         *out->cur++ = ':';
         if (0 < out->opts->dump_opts.after_size) {
-            strcpy(out->cur, out->opts->dump_opts.after_sep);
-            out->cur += out->opts->dump_opts.after_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.after_sep, out->opts->dump_opts.after_size);
         }
     }
     if (NullMode == out->opts->mode) {
@@ -280,15 +271,13 @@ static void dump_hash(VALUE obj, int depth, Out out, bool as_ok) {
             size = depth * out->opts->dump_opts.indent_size + out->opts->dump_opts.hash_size + 1;
             assure_size(out, size);
             if (0 < out->opts->dump_opts.hash_size) {
-                strcpy(out->cur, out->opts->dump_opts.hash_nl);
-                out->cur += out->opts->dump_opts.hash_size;
+                APPEND_CHARS(out->cur, out->opts->dump_opts.hash_nl, out->opts->dump_opts.hash_size);
             }
             if (0 < out->opts->dump_opts.indent_size) {
                 int i;
 
                 for (i = depth; 0 < i; i--) {
-                    strcpy(out->cur, out->opts->dump_opts.indent_str);
-                    out->cur += out->opts->dump_opts.indent_size;
+                    APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
                 }
             }
         }

--- a/ext/oj/oj.h
+++ b/ext/oj/oj.h
@@ -375,6 +375,12 @@ extern bool oj_use_hash_alt;
 extern bool oj_use_array_alt;
 extern bool string_writer_optimized;
 
+#define APPEND_CHARS(buffer, chars, size) \
+    { \
+        memcpy(buffer, chars, size); \
+        buffer += size; \
+    }
+
 #ifdef HAVE_PTHREAD_MUTEX_INIT
 extern pthread_mutex_t oj_cache_mutex;
 #else

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -167,17 +167,14 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
         }
         fill_indent(out, d3);
         *out->cur++ = '"';
-        memcpy(out->cur, name, len);
-        out->cur += len;
+        APPEND_CHARS(out->cur, name, len);
         *out->cur++ = '"';
         if (0 < out->opts->dump_opts.before_size) {
-            strcpy(out->cur, out->opts->dump_opts.before_sep);
-            out->cur += out->opts->dump_opts.before_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.before_sep, out->opts->dump_opts.before_size);
         }
         *out->cur++ = ':';
         if (0 < out->opts->dump_opts.after_size) {
-            strcpy(out->cur, out->opts->dump_opts.after_sep);
-            out->cur += out->opts->dump_opts.after_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.after_sep, out->opts->dump_opts.after_size);
         }
 #ifdef RSTRUCT_LEN
         v = RSTRUCT_GET(obj, i);
@@ -405,14 +402,12 @@ static void dump_row(VALUE row, StrLen cols, int ccnt, int depth, Out out) {
         assure_size(out, size);
         if (out->opts->dump_opts.use) {
             if (0 < out->opts->dump_opts.array_size) {
-                strcpy(out->cur, out->opts->dump_opts.array_nl);
-                out->cur += out->opts->dump_opts.array_size;
+                APPEND_CHARS(out->cur, out->opts->dump_opts.array_nl, out->opts->dump_opts.array_size);
             }
             if (0 < out->opts->dump_opts.indent_size) {
                 int i;
                 for (i = d2; 0 < i; i--) {
-                    strcpy(out->cur, out->opts->dump_opts.indent_str);
-                    out->cur += out->opts->dump_opts.indent_size;
+                    APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
                 }
             }
         } else {
@@ -429,15 +424,13 @@ static void dump_row(VALUE row, StrLen cols, int ccnt, int depth, Out out) {
     assure_size(out, size);
     if (out->opts->dump_opts.use) {
         if (0 < out->opts->dump_opts.array_size) {
-            strcpy(out->cur, out->opts->dump_opts.array_nl);
-            out->cur += out->opts->dump_opts.array_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.array_nl, out->opts->dump_opts.array_size);
         }
         if (0 < out->opts->dump_opts.indent_size) {
             int i;
 
             for (i = depth; 0 < i; i--) {
-                strcpy(out->cur, out->opts->dump_opts.indent_str);
-                out->cur += out->opts->dump_opts.indent_size;
+                APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
             }
         }
     } else {
@@ -477,14 +470,12 @@ static void dump_activerecord_result(VALUE obj, int depth, Out out, bool as_ok) 
         assure_size(out, size);
         if (out->opts->dump_opts.use) {
             if (0 < out->opts->dump_opts.array_size) {
-                strcpy(out->cur, out->opts->dump_opts.array_nl);
-                out->cur += out->opts->dump_opts.array_size;
+                APPEND_CHARS(out->cur, out->opts->dump_opts.array_nl, out->opts->dump_opts.array_size);
             }
             if (0 < out->opts->dump_opts.indent_size) {
                 int i;
                 for (i = d2; 0 < i; i--) {
-                    strcpy(out->cur, out->opts->dump_opts.indent_str);
-                    out->cur += out->opts->dump_opts.indent_size;
+                    APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
                 }
             }
         } else {
@@ -500,15 +491,13 @@ static void dump_activerecord_result(VALUE obj, int depth, Out out, bool as_ok) 
     assure_size(out, size);
     if (out->opts->dump_opts.use) {
         if (0 < out->opts->dump_opts.array_size) {
-            strcpy(out->cur, out->opts->dump_opts.array_nl);
-            out->cur += out->opts->dump_opts.array_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.array_nl, out->opts->dump_opts.array_size);
         }
         if (0 < out->opts->dump_opts.indent_size) {
             int i;
 
             for (i = depth; 0 < i; i--) {
-                strcpy(out->cur, out->opts->dump_opts.indent_str);
-                out->cur += out->opts->dump_opts.indent_size;
+                APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
             }
         }
     } else {
@@ -1271,14 +1260,12 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
         for (i = 0; i <= cnt; i++) {
             if (out->opts->dump_opts.use) {
                 if (0 < out->opts->dump_opts.array_size) {
-                    strcpy(out->cur, out->opts->dump_opts.array_nl);
-                    out->cur += out->opts->dump_opts.array_size;
+                    APPEND_CHARS(out->cur, out->opts->dump_opts.array_nl, out->opts->dump_opts.array_size);
                 }
                 if (0 < out->opts->dump_opts.indent_size) {
                     int i;
                     for (i = d2; 0 < i; i--) {
-                        strcpy(out->cur, out->opts->dump_opts.indent_str);
-                        out->cur += out->opts->dump_opts.indent_size;
+                        APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
                     }
                 }
             } else {
@@ -1293,15 +1280,13 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
         assure_size(out, size);
         if (out->opts->dump_opts.use) {
             if (0 < out->opts->dump_opts.array_size) {
-                strcpy(out->cur, out->opts->dump_opts.array_nl);
-                out->cur += out->opts->dump_opts.array_size;
+                APPEND_CHARS(out->cur, out->opts->dump_opts.array_nl, out->opts->dump_opts.array_size);
             }
             if (0 < out->opts->dump_opts.indent_size) {
                 int i;
 
                 for (i = depth; 0 < i; i--) {
-                    strcpy(out->cur, out->opts->dump_opts.indent_str);
-                    out->cur += out->opts->dump_opts.indent_size;
+                    APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
                 }
             }
         } else {
@@ -1339,14 +1324,12 @@ static int hash_cb(VALUE key, VALUE value, VALUE ov) {
         size = depth * out->opts->dump_opts.indent_size + out->opts->dump_opts.hash_size + 1;
         assure_size(out, size);
         if (0 < out->opts->dump_opts.hash_size) {
-            strcpy(out->cur, out->opts->dump_opts.hash_nl);
-            out->cur += out->opts->dump_opts.hash_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.hash_nl, out->opts->dump_opts.hash_size);
         }
         if (0 < out->opts->dump_opts.indent_size) {
             int i;
             for (i = depth; 0 < i; i--) {
-                strcpy(out->cur, out->opts->dump_opts.indent_str);
-                out->cur += out->opts->dump_opts.indent_size;
+                APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
             }
         }
         if (rtype == T_STRING) {
@@ -1357,13 +1340,11 @@ static int hash_cb(VALUE key, VALUE value, VALUE ov) {
         size = out->opts->dump_opts.before_size + out->opts->dump_opts.after_size + 2;
         assure_size(out, size);
         if (0 < out->opts->dump_opts.before_size) {
-            strcpy(out->cur, out->opts->dump_opts.before_sep);
-            out->cur += out->opts->dump_opts.before_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.before_sep, out->opts->dump_opts.before_size);
         }
         *out->cur++ = ':';
         if (0 < out->opts->dump_opts.after_size) {
-            strcpy(out->cur, out->opts->dump_opts.after_sep);
-            out->cur += out->opts->dump_opts.after_size;
+            APPEND_CHARS(out->cur, out->opts->dump_opts.after_sep, out->opts->dump_opts.after_size);
         }
     }
     dump_rails_val(value, depth, out, true);
@@ -1406,15 +1387,13 @@ static void dump_hash(VALUE obj, int depth, Out out, bool as_ok) {
             size = depth * out->opts->dump_opts.indent_size + out->opts->dump_opts.hash_size + 1;
             assure_size(out, size);
             if (0 < out->opts->dump_opts.hash_size) {
-                strcpy(out->cur, out->opts->dump_opts.hash_nl);
-                out->cur += out->opts->dump_opts.hash_size;
+                APPEND_CHARS(out->cur, out->opts->dump_opts.hash_nl, out->opts->dump_opts.hash_size);
             }
             if (0 < out->opts->dump_opts.indent_size) {
                 int i;
 
                 for (i = depth; 0 < i; i--) {
-                    strcpy(out->cur, out->opts->dump_opts.indent_str);
-                    out->cur += out->opts->dump_opts.indent_size;
+                    APPEND_CHARS(out->cur, out->opts->dump_opts.indent_str, out->opts->dump_opts.indent_size);
                 }
             }
         }


### PR DESCRIPTION
It has a slightly better performance to copy characters by using standard C function

−       | before   | after    | result
--       | --       | --       | --
macOS    | 363.396k | 377.166k | 1.038x
Linux    | 347.901k | 354.864k | 1.020x

### Environment
- macOS
  - macOS 12.3 beta
  - Apple M1 Max
  - Apple clang version 13.1.6 (clang-1316.0.20.6)
  - Ruby 3.1.1
- Linux
  - Kubuntu 21.10
  - AMD Ryzen 7 5700G
  - gcc version 11.2.0
  - Ruby 3.1.1

### macOS
#### Before
```
Warming up --------------------------------------
            Oj.dump     36.222k i/100ms
Calculating -------------------------------------
            Oj.dump     363.396k (± 0.4%) i/s -      7.281M in  20.035345s
```

### After
```
Warming up --------------------------------------
            Oj.dump     37.656k i/100ms
Calculating -------------------------------------
            Oj.dump     377.166k (± 0.4%) i/s -      7.569M in  20.068008s
```

### Linux
#### Before
```
Warming up --------------------------------------
            Oj.dump     34.784k i/100ms
Calculating -------------------------------------
            Oj.dump     347.901k (± 0.4%) i/s -      6.992M in  20.096716s
```

#### After
```
Warming up --------------------------------------
            Oj.dump     35.345k i/100ms
Calculating -------------------------------------
            Oj.dump     354.864k (± 0.3%) i/s -      7.104M in  20.020172s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

class Foo
  attr_accessor :bar

  def initialize
    @foo = 'foo'
    @bar = 'bar'
  end
end

class Bar < Struct.new(:x, :y)
end

ary = [2 ** 60, 2 ** 61, 2 ** 62, 2 ** 63]
ary << ary

hash = {
  name: 'hogehoge',
  age: 42,
}
hash[:circular] = hash

data = {
  klass: Foo,
  object: Foo.new,
  array: ary,
  range: (1..10),
  hash: hash,
  data: Time.new,
  struct: Bar.new(1024, 2048),
  string: "a" * 100,
  symbol: ("a" * 100).to_sym,
  regex: /foo|bar|baz/,
  rational: 42.to_r,
  complex: Complex('2/3+3/4i'),
}

Benchmark.ips do |x|
  x.time = 20

  x.report('Oj.dump ') { Oj.dump(data, mode: :object, circular: true) }
end
```