### PR TITLE
Use strstr() to increase performance

### DIFF
--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -38,20 +38,26 @@ static void next_non_white(ParseInfo pi) {
 
 static void skip_comment(ParseInfo pi) {
     if ('*' == *pi->cur) {
+        char *end = NULL;
+
         pi->cur++;
-        for (; pi->cur < pi->end; pi->cur++) {
-            if ('*' == *pi->cur && '/' == *(pi->cur + 1)) {
-                pi->cur += 2;
-                return;
-            } else if (pi->end <= pi->cur) {
-                oj_set_error_at(pi,
-                                oj_parse_error_class,
-                                __FILE__,
-                                __LINE__,
-                                "comment not terminated");
-                return;
-            }
+        end = strstr(pi->cur, "*/");
+
+        if (NULL == end) {
+            pi->cur = pi->end;
+            return;
         }
+
+        if (pi->end <= end) {
+            oj_set_error_at(pi,
+                            oj_parse_error_class,
+                            __FILE__,
+                            __LINE__,
+                            "comment not terminated");
+            pi->cur = end;
+            return;
+        }
+        pi->cur = end + 2;
     } else if ('/' == *pi->cur) {
         for (; 1; pi->cur++) {
             switch (*pi->cur) {


### PR DESCRIPTION
This might increase performance on Linux where finding the end of a comment.

−              | before   | after  | result
--              | --       | --     | --
Oj.load (macOS) | 2.225M   | 2.212M | −
Oj.load (Linux) | 2.194M   | 2.396M | 1.092x

### Environment
- macOS
  - macOS 12.3.1
  - Apple M1 Max
  - Apple clang version 13.1.6 (clang-1316.0.21.2)
  - Ruby 3.1.1
- Linux
  - Kubuntu 21.10
  - AMD Ryzen 7 5700G
  - gcc version 11.2.0
  - Ruby 3.1.1

### macOS
#### Before
```
Warming up --------------------------------------
             Oj.load   221.388k i/100ms
Calculating -------------------------------------
             Oj.load      2.225M (± 0.2%) i/s -     22.360M in  10.048638s
```

#### After
```
Warming up --------------------------------------
             Oj.load   220.777k i/100ms
Calculating -------------------------------------
             Oj.load      2.212M (± 0.1%) i/s -     22.298M in  10.079709s
```

### Linux
#### Before
```
Warming up --------------------------------------
             Oj.load   219.053k i/100ms
Calculating -------------------------------------
             Oj.load      2.194M (± 0.2%) i/s -     22.124M in  10.083287s
```

#### After
```
Warming up --------------------------------------
             Oj.load   240.102k i/100ms
Calculating -------------------------------------
             Oj.load      2.396M (± 0.2%) i/s -     24.010M in  10.021516s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

json =<<-EOF
{
  /* aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa */
  "name": "foobarbaz"
}
EOF

Benchmark.ips do |x|
  x.time = 10

  x.report('Oj.load') { Oj.load(json) }
end
```