### PR TITLE
Fix buffer allocation/grow problem and refactor buffer code.

### DIFF
--- a/ext/oj/dump.h
+++ b/ext/oj/dump.h
@@ -13,6 +13,13 @@
 // Extra padding at end of buffer.
 #define BUFFER_EXTRA 64
 
+#define DEFAULT_BUFFER_SIZE 4096
+#define STACK_BUFFER_SIZE 4096
+
+typedef struct __oj_stack_buffer {
+    char buffer[STACK_BUFFER_SIZE];
+} stack_buffer;
+
 extern void oj_dump_nil(VALUE obj, int depth, Out out, bool as_ok);
 extern void oj_dump_true(VALUE obj, int depth, Out out, bool as_ok);
 extern void oj_dump_false(VALUE obj, int depth, Out out, bool as_ok);
@@ -31,6 +38,15 @@ extern void oj_dump_time(VALUE obj, Out out, int withZone);
 extern void oj_dump_obj_to_s(VALUE obj, Out out);
 
 extern const char *oj_nan_str(VALUE obj, int opt, int mode, bool plus, int *lenp);
+
+// initialize an out buffer with the provided stack allocated memory
+extern void oj_out_init_stack_buffer(Out out, stack_buffer * buffer);
+// allocate default sized heap memory buffer and initialize out structure
+extern void oj_out_init_allocate(Out out);
+// allocate n sized heap memory buffer and initialize out structure
+extern void oj_out_init_allocate_n(Out out, size_t cnt);
+// clean up the out buffer if it uses heap allocated memory
+extern void oj_out_free(Out out);
 
 extern void oj_grow_out(Out out, size_t len);
 extern long oj_check_circular(VALUE obj, Out out);

--- a/ext/oj/dump.h
+++ b/ext/oj/dump.h
@@ -13,13 +13,6 @@
 // Extra padding at end of buffer.
 #define BUFFER_EXTRA 64
 
-#define DEFAULT_BUFFER_SIZE 4096
-#define STACK_BUFFER_SIZE 4096
-
-typedef struct __oj_stack_buffer {
-    char buffer[STACK_BUFFER_SIZE];
-} stack_buffer;
-
 extern void oj_dump_nil(VALUE obj, int depth, Out out, bool as_ok);
 extern void oj_dump_true(VALUE obj, int depth, Out out, bool as_ok);
 extern void oj_dump_false(VALUE obj, int depth, Out out, bool as_ok);
@@ -40,11 +33,7 @@ extern void oj_dump_obj_to_s(VALUE obj, Out out);
 extern const char *oj_nan_str(VALUE obj, int opt, int mode, bool plus, int *lenp);
 
 // initialize an out buffer with the provided stack allocated memory
-extern void oj_out_init_stack_buffer(Out out, stack_buffer * buffer);
-// allocate default sized heap memory buffer and initialize out structure
-extern void oj_out_init_allocate(Out out);
-// allocate n sized heap memory buffer and initialize out structure
-extern void oj_out_init_allocate_n(Out out, size_t cnt);
+extern void oj_out_init(Out out);
 // clean up the out buffer if it uses heap allocated memory
 extern void oj_out_free(Out out);
 

--- a/ext/oj/dump_leaf.c
+++ b/ext/oj/dump_leaf.c
@@ -8,34 +8,8 @@
 
 static void dump_leaf(Leaf leaf, int depth, Out out);
 
-static void grow(Out out, size_t len) {
-    size_t size = out->end - out->buf;
-    long   pos  = out->cur - out->buf;
-    char * buf;
-
-    size *= 2;
-    if (size <= len * 2 + pos) {
-        size += len;
-    }
-    if (out->allocated) {
-        buf = REALLOC_N(out->buf, char, (size + BUFFER_EXTRA));
-    } else {
-        buf            = ALLOC_N(char, (size + BUFFER_EXTRA));
-        out->allocated = true;
-        memcpy(buf, out->buf, out->end - out->buf + BUFFER_EXTRA);
-    }
-    if (0 == buf) {
-        rb_raise(rb_eNoMemError, "Failed to create string. [%d:%s]\n", ENOSPC, strerror(ENOSPC));
-    }
-    out->buf = buf;
-    out->end = buf + size;
-    out->cur = out->buf + pos;
-}
-
 inline static void dump_chars(const char *s, size_t size, Out out) {
-    if (out->end - out->cur <= (long)size) {
-        grow(out, size);
-    }
+    assure_size(out, size);
     APPEND_CHARS(out->cur, s, size);
     *out->cur = '\0';
 }
@@ -80,9 +54,7 @@ static void dump_leaf_array(Leaf leaf, int depth, Out out) {
     int    d2 = depth + 1;
 
     size = 2;
-    if (out->end - out->cur <= (long)size) {
-        grow(out, size);
-    }
+    assure_size(out, size);
     *out->cur++ = '[';
     if (0 == leaf->elements) {
         *out->cur++ = ']';
@@ -92,9 +64,7 @@ static void dump_leaf_array(Leaf leaf, int depth, Out out) {
 
         size = d2 * out->indent + 2;
         do {
-            if (out->end - out->cur <= (long)size) {
-                grow(out, size);
-            }
+            assure_size(out, size);
             fill_indent(out, d2);
             dump_leaf(e, d2, out);
             if (e->next != first) {
@@ -103,9 +73,7 @@ static void dump_leaf_array(Leaf leaf, int depth, Out out) {
             e = e->next;
         } while (e != first);
         size = depth * out->indent + 1;
-        if (out->end - out->cur <= (long)size) {
-            grow(out, size);
-        }
+        assure_size(out, size);
         fill_indent(out, depth);
         *out->cur++ = ']';
     }
@@ -117,9 +85,7 @@ static void dump_leaf_hash(Leaf leaf, int depth, Out out) {
     int    d2 = depth + 1;
 
     size = 2;
-    if (out->end - out->cur <= (long)size) {
-        grow(out, size);
-    }
+    assure_size(out, size);
     *out->cur++ = '{';
     if (0 == leaf->elements) {
         *out->cur++ = '}';
@@ -129,9 +95,7 @@ static void dump_leaf_hash(Leaf leaf, int depth, Out out) {
 
         size = d2 * out->indent + 2;
         do {
-            if (out->end - out->cur <= (long)size) {
-                grow(out, size);
-            }
+            assure_size(out, size);
             fill_indent(out, d2);
             oj_dump_cstr(e->key, strlen(e->key), 0, 0, out);
             *out->cur++ = ':';
@@ -142,9 +106,7 @@ static void dump_leaf_hash(Leaf leaf, int depth, Out out) {
             e = e->next;
         } while (e != first);
         size = depth * out->indent + 1;
-        if (out->end - out->cur <= (long)size) {
-            grow(out, size);
-        }
+        assure_size(out, size);
         fill_indent(out, depth);
         *out->cur++ = '}';
     }
@@ -167,10 +129,7 @@ static void dump_leaf(Leaf leaf, int depth, Out out) {
 
 void oj_dump_leaf_to_json(Leaf leaf, Options copts, Out out) {
     if (0 == out->buf) {
-        out->buf = ALLOC_N(char, 4096);
-        out->end = out->buf + 4095 -
-                   BUFFER_EXTRA;  // 1 less than end plus extra for possible errors
-        out->allocated = true;
+        oj_out_init_allocate(out);
     }
     out->cur      = out->buf;
     out->circ_cnt = 0;
@@ -181,14 +140,13 @@ void oj_dump_leaf_to_json(Leaf leaf, Options copts, Out out) {
 }
 
 void oj_write_leaf_to_file(Leaf leaf, const char *path, Options copts) {
-    char        buf[4096];
-    struct _out out;
-    size_t      size;
-    FILE *      f;
+    stack_buffer buf;
+    struct _out  out;
+    size_t       size;
+    FILE *       f;
 
-    out.buf       = buf;
-    out.end       = buf + sizeof(buf) - BUFFER_EXTRA;
-    out.allocated = false;
+    oj_out_init_stack_buffer(&out, &buf);
+
     out.omit_nil  = copts->dump_opts.omit_nil;
     oj_dump_leaf_to_json(leaf, copts, &out);
     size = out.cur - out.buf;
@@ -200,8 +158,8 @@ void oj_write_leaf_to_file(Leaf leaf, const char *path, Options copts) {
 
         rb_raise(rb_eIOError, "Write failed. [%d:%s]\n", err, strerror(err));
     }
-    if (out.allocated) {
-        xfree(out.buf);
-    }
+
+    oj_out_free(&out);
+
     fclose(f);
 }

--- a/ext/oj/dump_leaf.c
+++ b/ext/oj/dump_leaf.c
@@ -129,7 +129,7 @@ static void dump_leaf(Leaf leaf, int depth, Out out) {
 
 void oj_dump_leaf_to_json(Leaf leaf, Options copts, Out out) {
     if (0 == out->buf) {
-        oj_out_init_allocate(out);
+        oj_out_init(out);
     }
     out->cur      = out->buf;
     out->circ_cnt = 0;
@@ -140,12 +140,11 @@ void oj_dump_leaf_to_json(Leaf leaf, Options copts, Out out) {
 }
 
 void oj_write_leaf_to_file(Leaf leaf, const char *path, Options copts) {
-    stack_buffer buf;
-    struct _out  out;
-    size_t       size;
-    FILE *       f;
+    struct _out out;
+    size_t      size;
+    FILE *      f;
 
-    oj_out_init_stack_buffer(&out, &buf);
+    oj_out_init(&out);
 
     out.omit_nil  = copts->dump_opts.omit_nil;
     oj_dump_leaf_to_json(leaf, copts, &out);

--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -1611,18 +1611,16 @@ static VALUE doc_dump(int argc, VALUE *argv, VALUE self) {
         volatile VALUE rjson;
 
         if (0 == filename) {
-            char        buf[4096];
-            struct _out out;
+            stack_buffer buf;
+            struct _out  out;
 
-            out.buf       = buf;
-            out.end       = buf + sizeof(buf) - BUFFER_EXTRA;
-            out.allocated = false;
+            oj_out_init_stack_buffer(&out, &buf);
+
             out.omit_nil  = oj_default_options.dump_opts.omit_nil;
             oj_dump_leaf_to_json(leaf, &oj_default_options, &out);
             rjson = rb_str_new2(out.buf);
-            if (out.allocated) {
-                xfree(out.buf);
-            }
+
+            oj_out_free(&out);
         } else {
             oj_write_leaf_to_file(leaf, filename, &oj_default_options);
             rjson = Qnil;

--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -1611,10 +1611,9 @@ static VALUE doc_dump(int argc, VALUE *argv, VALUE self) {
         volatile VALUE rjson;
 
         if (0 == filename) {
-            stack_buffer buf;
-            struct _out  out;
+            struct _out out;
 
-            oj_out_init_stack_buffer(&out, &buf);
+            oj_out_init(&out);
 
             out.omit_nil  = oj_default_options.dump_opts.omit_nil;
             oj_dump_leaf_to_json(leaf, &oj_default_options, &out);

--- a/ext/oj/mimic_json.c
+++ b/ext/oj/mimic_json.c
@@ -198,7 +198,6 @@ static int mimic_limit_arg(VALUE a) {
  * Returns [_String_] a JSON string.
  */
 static VALUE mimic_dump(int argc, VALUE *argv, VALUE self) {
-    stack_buffer    buf;
     struct _out     out;
     struct _options copts = oj_default_options;
     VALUE           rstr;
@@ -207,7 +206,7 @@ static VALUE mimic_dump(int argc, VALUE *argv, VALUE self) {
     copts.str_rx.head = NULL;
     copts.str_rx.tail = NULL;
 
-    oj_out_init_stack_buffer(&out, &buf);
+    oj_out_init(&out);
 
     out.caller        = CALLER_DUMP;
     copts.escape_mode = JXEsc;
@@ -358,16 +357,15 @@ static VALUE mimic_dump_load(int argc, VALUE *argv, VALUE self) {
 }
 
 static VALUE mimic_generate_core(int argc, VALUE *argv, Options copts) {
-    stack_buffer buf;
     struct _out out;
     VALUE       rstr;
 
     if (0 == argc) {
         rb_raise(rb_eArgError, "wrong number of arguments (0))");
     }
-    memset(buf.buffer, 0, sizeof(buf.buffer));
+    memset(out.stack_buffer, 0, sizeof(out.stack_buffer));
 
-    oj_out_init_stack_buffer(&out, &buf);
+    oj_out_init(&out);
 
     out.omit_nil  = copts->dump_opts.omit_nil;
     out.caller    = CALLER_GENERATE;
@@ -745,7 +743,6 @@ static struct _options mimic_object_to_json_options = {0,              // indent
                                                        }};
 
 static VALUE mimic_object_to_json(int argc, VALUE *argv, VALUE self) {
-    stack_buffer    buf;
     struct _out     out;
     VALUE           rstr;
     struct _options copts = oj_default_options;
@@ -753,7 +750,7 @@ static VALUE mimic_object_to_json(int argc, VALUE *argv, VALUE self) {
     copts.str_rx.head = NULL;
     copts.str_rx.tail = NULL;
 
-    oj_out_init_stack_buffer(&out, &buf);
+    oj_out_init(&out);
 
     out.omit_nil      = copts.dump_opts.omit_nil;
     copts.mode        = CompatMode;

--- a/ext/oj/mimic_json.c
+++ b/ext/oj/mimic_json.c
@@ -198,7 +198,7 @@ static int mimic_limit_arg(VALUE a) {
  * Returns [_String_] a JSON string.
  */
 static VALUE mimic_dump(int argc, VALUE *argv, VALUE self) {
-    char            buf[4096];
+    stack_buffer    buf;
     struct _out     out;
     struct _options copts = oj_default_options;
     VALUE           rstr;
@@ -206,9 +206,9 @@ static VALUE mimic_dump(int argc, VALUE *argv, VALUE self) {
 
     copts.str_rx.head = NULL;
     copts.str_rx.tail = NULL;
-    out.buf           = buf;
-    out.end           = buf + sizeof(buf) - BUFFER_EXTRA;
-    out.allocated     = false;
+
+    oj_out_init_stack_buffer(&out, &buf);
+
     out.caller        = CALLER_DUMP;
     copts.escape_mode = JXEsc;
     copts.mode        = CompatMode;
@@ -257,9 +257,9 @@ static VALUE mimic_dump(int argc, VALUE *argv, VALUE self) {
         rb_funcall2(io, oj_write_id, 1, args);
         rstr = io;
     }
-    if (out.allocated) {
-        xfree(out.buf);
-    }
+
+    oj_out_free(&out);
+
     return rstr;
 }
 
@@ -358,18 +358,17 @@ static VALUE mimic_dump_load(int argc, VALUE *argv, VALUE self) {
 }
 
 static VALUE mimic_generate_core(int argc, VALUE *argv, Options copts) {
-    char        buf[4096];
+    stack_buffer buf;
     struct _out out;
     VALUE       rstr;
 
     if (0 == argc) {
         rb_raise(rb_eArgError, "wrong number of arguments (0))");
     }
-    memset(buf, 0, sizeof(buf));
+    memset(buf.buffer, 0, sizeof(buf.buffer));
 
-    out.buf       = buf;
-    out.end       = buf + sizeof(buf) - BUFFER_EXTRA;
-    out.allocated = false;
+    oj_out_init_stack_buffer(&out, &buf);
+
     out.omit_nil  = copts->dump_opts.omit_nil;
     out.caller    = CALLER_GENERATE;
     // For obj.to_json or generate nan is not allowed but if called from dump
@@ -401,9 +400,9 @@ static VALUE mimic_generate_core(int argc, VALUE *argv, Options copts) {
     }
     rstr = rb_str_new2(out.buf);
     rstr = oj_encode(rstr);
-    if (out.allocated) {
-        xfree(out.buf);
-    }
+
+    oj_out_free(&out);
+
     return rstr;
 }
 
@@ -746,16 +745,16 @@ static struct _options mimic_object_to_json_options = {0,              // indent
                                                        }};
 
 static VALUE mimic_object_to_json(int argc, VALUE *argv, VALUE self) {
-    char            buf[4096];
+    stack_buffer    buf;
     struct _out     out;
     VALUE           rstr;
     struct _options copts = oj_default_options;
 
     copts.str_rx.head = NULL;
     copts.str_rx.tail = NULL;
-    out.buf           = buf;
-    out.end           = buf + sizeof(buf) - BUFFER_EXTRA;
-    out.allocated     = false;
+
+    oj_out_init_stack_buffer(&out, &buf);
+
     out.omit_nil      = copts.dump_opts.omit_nil;
     copts.mode        = CompatMode;
     copts.to_json     = No;
@@ -771,9 +770,9 @@ static VALUE mimic_object_to_json(int argc, VALUE *argv, VALUE self) {
     }
     rstr = rb_str_new2(out.buf);
     rstr = oj_encode(rstr);
-    if (out.allocated) {
-        xfree(out.buf);
-    }
+
+    oj_out_free(&out);
+
     return rstr;
 }
 

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -1257,7 +1257,6 @@ static VALUE dump_ensure(VALUE a) {
  * - *options* [_Hash_] same as default_options
  */
 static VALUE dump(int argc, VALUE *argv, VALUE self) {
-    stack_buffer    buf;
     struct dump_arg arg;
     struct _out     out;
     struct _options copts = oj_default_options;
@@ -1279,7 +1278,7 @@ static VALUE dump(int argc, VALUE *argv, VALUE self) {
     arg.argc  = argc;
     arg.argv  = argv;
 
-    oj_out_init_stack_buffer(arg.out, &buf);
+    oj_out_init(arg.out);
 
     arg.out->omit_nil  = copts.dump_opts.omit_nil;
     arg.out->caller    = CALLER_DUMP;
@@ -1312,7 +1311,6 @@ static VALUE dump(int argc, VALUE *argv, VALUE self) {
  * Returns [_String_] the encoded JSON.
  */
 static VALUE to_json(int argc, VALUE *argv, VALUE self) {
-    stack_buffer    buf;
     struct _out     out;
     struct _options copts = oj_default_options;
     VALUE           rstr;
@@ -1328,7 +1326,7 @@ static VALUE to_json(int argc, VALUE *argv, VALUE self) {
     copts.mode    = CompatMode;
     copts.to_json = Yes;
 
-    oj_out_init_stack_buffer(&out, &buf);
+    oj_out_init(&out);
 
     out.omit_nil  = copts.dump_opts.omit_nil;
     // For obj.to_json or generate nan is not allowed but if called from dump

--- a/ext/oj/oj.h
+++ b/ext/oj/oj.h
@@ -186,6 +186,7 @@ typedef struct _rOptTable {
 } * ROptTable;
 
 typedef struct _out {
+    char       stack_buffer[4096];
     char *     buf;
     char *     end;
     char *     cur;

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -897,7 +897,7 @@ static VALUE protect_dump(VALUE ov) {
 }
 
 static VALUE encode(VALUE obj, ROptTable ropts, Options opts, int argc, VALUE *argv) {
-    char            buf[4096];
+    stack_buffer    buf;
     struct _out     out;
     struct _options copts = *opts;
     volatile VALUE  rstr  = Qnil;
@@ -914,9 +914,9 @@ static VALUE encode(VALUE obj, ROptTable ropts, Options opts, int argc, VALUE *a
     } else {
         copts.escape_mode = RailsEsc;
     }
-    out.buf       = buf;
-    out.end       = buf + sizeof(buf) - 10;
-    out.allocated = false;
+
+    oj_out_init_stack_buffer(&out, &buf);
+
     out.omit_nil  = copts.dump_opts.omit_nil;
     out.caller    = 0;
     out.cur       = out.buf;
@@ -952,9 +952,9 @@ static VALUE encode(VALUE obj, ROptTable ropts, Options opts, int argc, VALUE *a
     if (Yes == copts.circular) {
         oj_cache8_delete(out.circ_cache);
     }
-    if (out.allocated) {
-        xfree(out.buf);
-    }
+
+    oj_out_free(&out);
+
     if (0 != line) {
         rb_jump_tag(line);
     }

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -897,7 +897,6 @@ static VALUE protect_dump(VALUE ov) {
 }
 
 static VALUE encode(VALUE obj, ROptTable ropts, Options opts, int argc, VALUE *argv) {
-    stack_buffer    buf;
     struct _out     out;
     struct _options copts = *opts;
     volatile VALUE  rstr  = Qnil;
@@ -915,7 +914,7 @@ static VALUE encode(VALUE obj, ROptTable ropts, Options opts, int argc, VALUE *a
         copts.escape_mode = RailsEsc;
     }
 
-    oj_out_init_stack_buffer(&out, &buf);
+    oj_out_init(&out);
 
     out.omit_nil  = copts.dump_opts.omit_nil;
     out.caller    = 0;

--- a/ext/oj/string_writer.c
+++ b/ext/oj/string_writer.c
@@ -48,13 +48,8 @@ void oj_str_writer_init(StrWriter sw, int buf_size) {
     *sw->types     = '\0';
     sw->keyWritten = 0;
 
-    if (0 == buf_size) {
-        buf_size = 4096;
-    } else if (buf_size < 1024) {
-        buf_size = 1024;
-    }
-
-    oj_out_init_allocate_n(&sw->out, buf_size);
+    oj_out_init(&sw->out);
+    assure_size(&sw->out, buf_size);
 
     sw->out.cur        = sw->out.buf;
     *sw->out.cur       = '\0';

--- a/ext/oj/string_writer.c
+++ b/ext/oj/string_writer.c
@@ -53,9 +53,9 @@ void oj_str_writer_init(StrWriter sw, int buf_size) {
     } else if (buf_size < 1024) {
         buf_size = 1024;
     }
-    sw->out.buf        = ALLOC_N(char, buf_size);
-    sw->out.end        = sw->out.buf + buf_size - BUFFER_EXTRA;
-    sw->out.allocated  = true;
+
+    oj_out_init_allocate_n(&sw->out, buf_size);
+
     sw->out.cur        = sw->out.buf;
     *sw->out.cur       = '\0';
     sw->out.circ_cache = NULL;
@@ -229,7 +229,9 @@ static void str_writer_free(void *ptr) {
         return;
     }
     sw = (StrWriter)ptr;
-    xfree(sw->out.buf);
+
+    oj_out_free(&sw->out);
+
     xfree(sw->types);
     xfree(ptr);
 }


### PR DESCRIPTION
Currently there are quite a few places where a stack allocated buffer of `N + 10` bytes are allocated instead of `N + 64`. This can become problematic when the buffer is grown and `N + 64` bytes are read, causing the application to read past the actual buffer bounds.

As there are quite a few places where these allocations occur, I've tried to abstract over them by creating the functions `oj_out_init_*` for various stack and heap allocations, as well as an `oj_out_free` function for performing the cleanup. I have placed them in dump.c but there may be a more preferable place to put them. I also did some other small refactoring where I saw that existing functions can be reused.

I am submitting this patch on behalf of Oracle.