### PR TITLE
Fix use-after-free in file pointer

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -622,12 +622,13 @@ void oj_write_obj_to_file(VALUE obj, const char *path, Options copts) {
     if (out.allocated) {
         xfree(out.buf);
     }
-    fclose(f);
     if (!ok) {
         int err = ferror(f);
+        fclose(f);
 
         rb_raise(rb_eIOError, "Write failed. [%d:%s]", err, strerror(err));
     }
+    fclose(f);
 }
 
 #if !IS_WINDOWS


### PR DESCRIPTION
GCC 12 reports use-after-free warning at compilation.

```
dump.c: In function ‘oj_write_obj_to_file’:
dump.c:627:19: warning: pointer ‘f’ may be used after ‘fclose’ [-Wuse-after-free]
  627 |         int err = ferror(f);
      |                   ^~~~~~~~~
dump.c:625:5: note: call to ‘fclose’ here
  625 |     fclose(f);
      |     ^~~~~~~~~
```

This patch will fix this warning.