### PR TITLE
Use BUFFER_EXTRA constant where required

### DIFF
--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -13,6 +13,7 @@
 
 #include "encode.h"
 #include "oj.h"
+#include "dump.h"
 
 // maximum to allocate on the stack, arbitrary limit
 #define SMALL_JSON 65536
@@ -1614,7 +1615,7 @@ static VALUE doc_dump(int argc, VALUE *argv, VALUE self) {
             struct _out out;
 
             out.buf       = buf;
-            out.end       = buf + sizeof(buf) - 10;
+            out.end       = buf + sizeof(buf) - BUFFER_EXTRA;
             out.allocated = false;
             out.omit_nil  = oj_default_options.dump_opts.omit_nil;
             oj_dump_leaf_to_json(leaf, &oj_default_options, &out);

--- a/ext/oj/mimic_json.c
+++ b/ext/oj/mimic_json.c
@@ -207,7 +207,7 @@ static VALUE mimic_dump(int argc, VALUE *argv, VALUE self) {
     copts.str_rx.head = NULL;
     copts.str_rx.tail = NULL;
     out.buf           = buf;
-    out.end           = buf + sizeof(buf) - 10;
+    out.end           = buf + sizeof(buf) - BUFFER_EXTRA;
     out.allocated     = false;
     out.caller        = CALLER_DUMP;
     copts.escape_mode = JXEsc;
@@ -368,7 +368,7 @@ static VALUE mimic_generate_core(int argc, VALUE *argv, Options copts) {
     memset(buf, 0, sizeof(buf));
 
     out.buf       = buf;
-    out.end       = buf + sizeof(buf) - 10;
+    out.end       = buf + sizeof(buf) - BUFFER_EXTRA;
     out.allocated = false;
     out.omit_nil  = copts->dump_opts.omit_nil;
     out.caller    = CALLER_GENERATE;
@@ -754,7 +754,7 @@ static VALUE mimic_object_to_json(int argc, VALUE *argv, VALUE self) {
     copts.str_rx.head = NULL;
     copts.str_rx.tail = NULL;
     out.buf           = buf;
-    out.end           = buf + sizeof(buf) - 10;
+    out.end           = buf + sizeof(buf) - BUFFER_EXTRA;
     out.allocated     = false;
     out.omit_nil      = copts.dump_opts.omit_nil;
     copts.mode        = CompatMode;

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -1281,7 +1281,7 @@ static VALUE dump(int argc, VALUE *argv, VALUE self) {
     arg.argv  = argv;
 
     arg.out->buf       = buf;
-    arg.out->end       = buf + sizeof(buf) - 10;
+    arg.out->end       = buf + sizeof(buf) - BUFFER_EXTRA;
     arg.out->allocated = false;
     arg.out->omit_nil  = copts.dump_opts.omit_nil;
     arg.out->caller    = CALLER_DUMP;
@@ -1330,7 +1330,7 @@ static VALUE to_json(int argc, VALUE *argv, VALUE self) {
     copts.mode    = CompatMode;
     copts.to_json = Yes;
     out.buf       = buf;
-    out.end       = buf + sizeof(buf) - 10;
+    out.end       = buf + sizeof(buf) - BUFFER_EXTRA;
     out.allocated = false;
     out.omit_nil  = copts.dump_opts.omit_nil;
     // For obj.to_json or generate nan is not allowed but if called from dump

--- a/ext/oj/string_writer.c
+++ b/ext/oj/string_writer.c
@@ -54,7 +54,7 @@ void oj_str_writer_init(StrWriter sw, int buf_size) {
         buf_size = 1024;
     }
     sw->out.buf        = ALLOC_N(char, buf_size);
-    sw->out.end        = sw->out.buf + buf_size - 10;
+    sw->out.end        = sw->out.buf + buf_size - BUFFER_EXTRA;
     sw->out.allocated  = true;
     sw->out.cur        = sw->out.buf;
     *sw->out.cur       = '\0';


### PR DESCRIPTION
Replace incorrect stack constant with BUFFER_EXTRA macro as a quick fix to the full PR. See https://github.com/ohler55/oj/pull/757#issuecomment-1120103857.