### PR TITLE
Don't flood stdout with debug output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.13.13 - <not released>
+
+- Fixed flooding stdout with debug output when dumping.
+
 ## 3.13.12 - 2022-05-20
 
 - Fixed crash on no arguments to pretty_generate. Now raises an exception.

--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -951,7 +951,6 @@ void oj_grow_out(Out out, size_t len) {
     long   pos  = out->cur - out->buf;
     char  *buf  = out->buf;
 
-    printf("*** grow %ld\n", len);
     size *= 2;
     if (size <= len * 2 + pos) {
         size += len;


### PR DESCRIPTION
Fixes #761.

Remove accidentally committed debug output statement.