### PR TITLE
Remove `wwtd` dependency

### DIFF
--- a/oj.gemspec
+++ b/oj.gemspec
@@ -32,5 +32,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake-compiler', '>= 0.9', '< 2.0'
   s.add_development_dependency 'minitest', '~> 5'
   s.add_development_dependency 'test-unit', '~> 3.0'
-  s.add_development_dependency 'wwtd', '~> 0'
 end


### PR DESCRIPTION
Since removing the `.travis.yml` file and migrating to GitHub actions,
this dependency is no longer used. (At least that's my assumption.)
