### PR TITLE
Don't test Rails 5 with `ruby-head`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,6 +35,8 @@ jobs:
         exclude:
           - os: macos
             ruby: head
+          - ruby: head
+            gemfile: rails_5
           - ruby: '3.0'
             gemfile: rails_5
           - ruby: '3.0'


### PR DESCRIPTION
These are definitely not compatible, see: https://github.com/rails/rails/issues/40938.

I also saw that the Rails 6/Ruby 3.0 combination is excluded, but I _think_ Rails 6.0.x added Ruby 3 support, but I couldn't find anything related to it. But since Ruby 3.1 support is also possible, I believe: https://gist.github.com/yahonda/2776d8d7b6ea7045359f38c10449937b#rails-60z, Ruby 3.0 should also work.

Rails 6.1 is not tested at all I believe, but since 6.1.5 also supports Ruby 3.1: https://github.com/rails/rails/issues/44090#issuecomment-1064906664