### PR TITLE
Accept `nil` for `opts` in `pretty_generate`

### DIFF
--- a/ext/oj/mimic_json.c
+++ b/ext/oj/mimic_json.c
@@ -460,7 +460,7 @@ oj_mimic_pretty_generate(int argc, VALUE *argv, VALUE self) {
     if (0 == argc) {
         rb_raise(rb_eArgError, "wrong number of arguments (0))");
     }
-    if (1 == argc) {
+    if (1 == argc || T_NIL == TYPE(argv[1])) {
         h = rb_hash_new();
     } else  {
         h = argv[1];

--- a/ext/oj/mimic_json.c
+++ b/ext/oj/mimic_json.c
@@ -460,7 +460,7 @@ oj_mimic_pretty_generate(int argc, VALUE *argv, VALUE self) {
     if (0 == argc) {
         rb_raise(rb_eArgError, "wrong number of arguments (0))");
     }
-    if (1 == argc || T_NIL == TYPE(argv[1])) {
+    if (1 == argc || Qnil == argv[1]) {
         h = rb_hash_new();
     } else  {
         h = argv[1];

--- a/test/json_gem/json_generator_test.rb
+++ b/test/json_gem/json_generator_test.rb
@@ -72,6 +72,8 @@ EOT
     parsed_json = JSON.parse(json)
     assert_equal({"1"=>2}, parsed_json)
     assert_equal '666', JSON.pretty_generate(666)
+    json_nil_opts = JSON.pretty_generate({1=>2}, nil)
+    assert_equal json, json_nil_opts
   end
 
   def test_generate_custom


### PR DESCRIPTION
`nil` is a valid second argument to `JSON.pretty_generate`, in fact, it's the [default](https://github.com/flori/json/blob/5d9d8f3799f2f65ebaa7b485fd6078ce5c79818c/lib/json/common.rb#L390).

As a user of the `oj` gem, I would expect that after invoking `Oj.mimic_JSON`, this argument would still be valid.

However, at least on the current version (I didn't check earlier versions), a mimicked `JSON.pretty_generate` crashes ruby with a segmentation fault inside `oj_mimic_pretty_generate`.

This PR's first commit adds a test for this, which on my laptop ("ruby 2.7.5p203 (2021-11-24 revision f69aeb8314) [x86_64-linux]") also crashes with a segfault.

The second commit adds a check to `oj_mimic_pretty_generate` to handle a `nil` second argument exactly as if there were no second argument. I think I did this right, at least the test passes now, but I haven't written C for a ruby extension before so of course I hope you'll correct me if there's a better way to do that.

I haven't looked into other mimicked functions to see if there are similar issues.

I'd like to give credit to @antonivanopoulos in [this blog post](https://www.antonivanopoulos.com/hunting-down-spooky-json-module-redefinition-via-oj/) for uncovering this issue and doing a deep-dive explaining it thoroughly.

Thanks for your attention and for providing this open-source gem to the community!