### PR TITLE
dump: Fix double free in oj_write_obj_to_file

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -614,7 +614,6 @@ void oj_write_obj_to_file(VALUE obj, const char *path, Options copts) {
 
     oj_out_free(&out);
 
-    fclose(f);
     if (!ok) {
         int err = ferror(f);
         fclose(f);


### PR DESCRIPTION
We encountered a segfault by dumping json in certain conditions. There seems to be an obsolete fclose which is likely caused by a merge / rebase fault.

Backtrace:

```gdb
#0  0x00007f00b459a00b in raise () from /lib/x86_64-linux-gnu/libc.so.6
#1  0x00007f00b4579859 in abort () from /lib/x86_64-linux-gnu/libc.so.6
#2  0x00007f00b45e426e in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#3  0x00007f00b45ec2fc in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#4  0x00007f00b45edf6d in ?? () from /lib/x86_64-linux-gnu/libc.so.6
#5  0x00007f00b45d8ec3 in fclose () from /lib/x86_64-linux-gnu/libc.so.6
#6  0x00007f00b001541e in oj_write_obj_to_file (obj=93852459311840, path=<optimized out>, copts=copts@entry=0x7ffd9c5debb0) at dump.c:624
#7  0x00007f00b002c9f6 in to_file (argc=<optimized out>, argv=0x7f00b3ed4ed0, self=<optimized out>) at oj.c:1364
#8  0x00007f00b4957026 in vm_call_cfunc_with_frame (empty_kw_splat=<optimized out>, cd=0x555bbaa578d0, calling=<optimized out>, reg_cfp=0x7f00b3fd2e90, 
    ec=0x555bb87dc600) at vm_insnhelper.c:2514
#9  vm_call_cfunc (ec=0x555bb87dc600, reg_cfp=0x7f00b3fd2e90, calling=<optimized out>, cd=0x555bbaa578d0) at vm_insnhelper.c:2539
#10 0x00007f00b4963dab in vm_call_method (ec=0x555bb87dc600, cfp=0x7f00b3fd2e90, calling=<optimized out>, cd=<optimized out>) at vm_insnhelper.c:3053
#11 0x00007f00b494a406 in vm_sendish (ec=ec@entry=0x555bb87dc600, reg_cfp=reg_cfp@entry=0x7f00b3fd2e90, cd=0x555bbaa578d0, 
    block_handler=block_handler@entry=0, method_explorer=method_explorer@entry=0x7f00b4950d80 <vm_search_method_wrap>) at vm_insnhelper.c:4023
#12 0x00007f00b495b0ba in vm_exec_core (ec=<optimized out>, initial=<optimized out>) at insns.def:801
#13 0x00007f00b4961870 in rb_vm_exec (ec=0x555bb87dc600, mjit_enable_p=1) at vm.c:2090
#14 0x00007f00b4965918 in vm_call0_body (ec=0x555bb87dc600, calling=0x7ffd9c5df1a0, cd=<optimized out>, argv=0x7ffd9c5df370) at vm_eval.c:136
...
```