### PR TITLE
Remove test_files to reduce gem package size

### DIFF
--- a/oj.gemspec
+++ b/oj.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.4"
 
   s.files = Dir["{lib,ext,test}/**/*.{rb,h,c}"] + ['LICENSE', 'README.md', 'CHANGELOG.md', 'RELEASE_NOTES.md'] + Dir["pages/*.md"]
-  s.test_files = Dir["test/**/*.rb"]
   s.extensions = ["ext/oj/extconf.rb"]
 
   s.extra_rdoc_files = ['README.md', 'LICENSE', 'CHANGELOG.md', 'RELEASE_NOTES.md'] + Dir["pages/*.md"]


### PR DESCRIPTION
Seems that `test_files` attribute has been deprecated.
If we can remove it from gemspec file, it would reduce distribute gem package size.

Related:

- https://github.com/rubygems/guides/issues/90
- https://docs.rubocop.org/rubocop/cops_gemspec.html#gemspecdeprecatedattributeassignment