### PR TITLE
Revert max_nesting behavior when max_nesting option was not given

### DIFF
--- a/ext/oj/mimic_json.c
+++ b/ext/oj/mimic_json.c
@@ -536,14 +536,6 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE info) {
         }
     } else if (oj_decimal_class_sym == k) {
         pi->options.compat_bigdec = (oj_bigdecimal_class == v);
-    } else if (oj_max_nesting_sym == k) {
-        if (Qtrue == v) {
-            pi->max_depth = 100;
-        } else if (Qfalse == v || Qnil == v) {
-            pi->max_depth = 0;
-        } else if (T_FIXNUM == rb_type(v)) {
-            pi->max_depth = NUM2INT(v);
-        }
     }
     return ST_CONTINUE;
 }
@@ -573,11 +565,21 @@ static VALUE mimic_parse_core(int argc, VALUE *argv, VALUE self, bool bang) {
     pi.max_depth             = 100;
 
     if (Qnil != ropts) {
+        VALUE v;
+
         if (T_HASH != rb_type(ropts)) {
             rb_raise(rb_eArgError, "options must be a hash.");
         }
 
         rb_hash_foreach(ropts, parse_options_cb, (VALUE)&pi);
+        v = rb_hash_lookup(ropts, oj_max_nesting_sym);
+        if (Qtrue == v) {
+            pi.max_depth = 100;
+        } else if (Qfalse == v || Qnil == v) {
+            pi.max_depth = 0;
+        } else if (T_FIXNUM == rb_type(v)) {
+            pi.max_depth = NUM2INT(v);
+        }
         oj_parse_opt_match_string(&pi.options.str_rx, ropts);
         if (Yes == pi.options.create_ok && Yes == pi.options.sym_key) {
             rb_raise(rb_eArgError, ":symbolize_names and :create_additions can not both be true.");

--- a/test/json_gem/json_parser_test.rb
+++ b/test/json_gem/json_parser_test.rb
@@ -269,6 +269,13 @@ EOT
     assert_equal too_deep_ary, ok
     ok = JSON.parse too_deep, :max_nesting => 0
     assert_equal too_deep_ary, ok
+
+    unless ENV['REAL_JSON_GEM']
+      # max_nesting should be reset to 0 if not included in options
+      # This behavior is not compatible with Ruby standard JSON gem
+      ok = JSON.parse too_deep, {}
+      assert_equal too_deep_ary, ok
+    end
   end
 
   def test_backslash


### PR DESCRIPTION
Fix https://github.com/ohler55/oj/issues/770

Revert max_nesting behavior to v3.13.9, however, this behavior is not compatible with Ruby standard JSON gem.