### PR TITLE
Convert file path to wide char to handle unicode file path on Windows

### DIFF
--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -1148,7 +1148,17 @@ static VALUE load_file(int argc, VALUE *argv, VALUE self) {
         }
     }
     path = StringValuePtr(*argv);
-    if (0 == (fd = open(path, O_RDONLY))) {
+#ifdef _WIN32
+    {
+        WCHAR *wide_path;
+        wide_path = rb_w32_mbstr_to_wstr(CP_UTF8, path, -1, NULL);
+        fd = rb_w32_wopen(wide_path, O_RDONLY);
+        free(wide_path);
+    }
+#else
+    fd = open(path, O_RDONLY);
+#endif
+    if (0 == fd) {
         rb_raise(rb_eIOError, "%s", strerror(errno));
     }
     switch (mode) {

--- a/ext/oj/sparse.c
+++ b/ext/oj/sparse.c
@@ -953,7 +953,11 @@ CLEANUP:
     }
     stack_cleanup(&pi->stack);
     if (0 != fd) {
+#ifdef _WIN32
+        rb_w32_close(fd);
+#else
         close(fd);
+#endif
     }
     if (err_has(&pi->err)) {
         rb_set_errinfo(Qnil);

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -212,6 +212,24 @@ class FileJuice < Minitest::Test
     dump_and_load(DateTime.new(2012, 6, 19), false)
   end
 
+  def test_load_unicode_path
+    json =<<~JSON
+    {
+      "x":true,
+      "y":58,
+      "z": [1,2,3]
+    }
+    JSON
+
+    Tempfile.create('file_test_conceição1.json') do |f|
+      f.write(json)
+      f.close
+
+      objects = Oj.load_file(f.path)
+      assert_equal(Oj.load(json), objects)
+    end
+  end
+
   def dump_and_load(obj, trace=false)
     filename = File.join(File.dirname(__FILE__), 'file_test.json')
     File.open(filename, "w") { |f|


### PR DESCRIPTION
Seems that it need to convert file path to wide char to handle unicode file path on Windows using [MultiByteToWideChar ](https://docs.microsoft.com/en-us/windows/win32/api/stringapiset/nf-stringapiset-multibytetowidechar)

rb_w32_mbstr_to_wstr() will convert it well.


Fix https://github.com/ohler55/oj/issues/772