### PR TITLE
Remove some checking Ruby C APIs presence

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -381,7 +381,6 @@ void oj_dump_time(VALUE obj, Out out, int withZone) {
     long long sec;
     long long nsec;
 
-#ifdef HAVE_RB_TIME_TIMESPEC
     // rb_time_timespec as well as rb_time_timeeval have a bug that causes an
     // exception to be raised if a time is before 1970 on 32 bit systems so
     // check the timespec size and use the ruby calls if a 32 bit system.
@@ -394,10 +393,6 @@ void oj_dump_time(VALUE obj, Out out, int withZone) {
         sec  = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
         nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
     }
-#else
-    sec  = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
-    nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
-#endif
 
     *b-- = '\0';
     if (withZone) {
@@ -483,7 +478,6 @@ void oj_dump_xml_time(VALUE obj, Out out) {
     int              tzhour, tzmin;
     char             tzsign = '+';
 
-#ifdef HAVE_RB_TIME_TIMESPEC
     if (16 <= sizeof(struct timespec)) {
         struct timespec ts = rb_time_timespec(obj);
 
@@ -493,10 +487,6 @@ void oj_dump_xml_time(VALUE obj, Out out) {
         sec  = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
         nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
     }
-#else
-    sec  = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
-    nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
-#endif
 
     assure_size(out, 36);
     if (9 > out->opts->sec_prec) {

--- a/ext/oj/dump_compat.c
+++ b/ext/oj/dump_compat.c
@@ -444,7 +444,6 @@ time_alt(VALUE obj, int depth, Out out) {
     time_t	sec;
     long long	nsec;
 
-#ifdef HAVE_RB_TIME_TIMESPEC
     if (16 <= sizeof(struct timespec)) {
 	struct timespec	ts = rb_time_timespec(obj);
 
@@ -454,10 +453,6 @@ time_alt(VALUE obj, int depth, Out out) {
 	sec = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
 	nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
     }
-#else
-    sec = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
-    nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
-#endif
 
     attrs[0].num = sec;
     attrs[1].num = nsec;

--- a/ext/oj/dump_object.c
+++ b/ext/oj/dump_object.c
@@ -315,7 +315,6 @@ static void dump_hash_class(VALUE obj, VALUE clas, int depth, Out out) {
     *out->cur = '\0';
 }
 
-#ifdef HAVE_RB_IVAR_FOREACH
 static int dump_attr_cb(ID key, VALUE value, VALUE ov) {
     Out         out   = (Out)ov;
     int         depth = out->depth;
@@ -358,7 +357,6 @@ static int dump_attr_cb(ID key, VALUE value, VALUE ov) {
 
     return ST_CONTINUE;
 }
-#endif
 
 static void dump_hash(VALUE obj, int depth, Out out, bool as_ok) {
     dump_hash_class(obj, rb_obj_class(obj), depth, out);
@@ -524,52 +522,10 @@ static void dump_obj_attrs(VALUE obj, VALUE clas, slot_t id, int depth, Out out)
             }
         }
         out->depth = depth + 1;
-#ifdef HAVE_RB_IVAR_FOREACH
         rb_ivar_foreach(obj, dump_attr_cb, (VALUE)out);
         if (',' == *(out->cur - 1)) {
             out->cur--;  // backup to overwrite last comma
         }
-#else
-        size = d2 * out->indent + 1;
-        for (i = cnt; 0 < i; i--, np++) {
-            VALUE value;
-
-            vid  = rb_to_id(*np);
-            attr = rb_id2name(vid);
-            if (Yes == out->opts->ignore_under && '@' == *attr && '_' == attr[1]) {
-                continue;
-            }
-            value = rb_ivar_get(obj, vid);
-
-            if (dump_ignore(out->opts, value)) {
-                continue;
-            }
-            if (out->omit_nil && Qnil == value) {
-                continue;
-            }
-            if (first) {
-                first = 0;
-            } else {
-                *out->cur++ = ',';
-            }
-            assure_size(out, size);
-            fill_indent(out, d2);
-            if ('@' == *attr) {
-                attr++;
-                oj_dump_cstr(attr, strlen(attr), 0, 0, out);
-            } else {
-                char buf[32];
-
-                *buf = '~';
-                strncpy(buf + 1, attr, sizeof(buf) - 2);
-                buf[sizeof(buf) - 1] = '\0';
-                oj_dump_cstr(buf, strlen(attr) + 1, 0, 0, out);
-            }
-            *out->cur++ = ':';
-            oj_dump_obj_val(value, d2, out);
-            assure_size(out, 2);
-        }
-#endif
         if (rb_obj_is_kind_of(obj, rb_eException)) {
             volatile VALUE rv;
 

--- a/ext/oj/dump_object.c
+++ b/ext/oj/dump_object.c
@@ -510,19 +510,8 @@ static void dump_obj_attrs(VALUE obj, VALUE clas, slot_t id, int depth, Out out)
     default: break;
     }
     {
-        int cnt;
-#ifdef HAVE_RB_IVAR_COUNT
-        cnt = (int)rb_ivar_count(obj);
-#else
-        volatile VALUE vars = rb_funcall2(obj, oj_instance_variables_id, 0, 0);
-        VALUE *        np   = RARRAY_PTR(vars);
-        ID             vid;
-        const char *   attr;
-        int            i;
-        int            first = 1;
+        int cnt = (int)rb_ivar_count(obj);
 
-        cnt  = (int)RARRAY_LEN(vars);
-#endif
         if (Qundef != clas && 0 < cnt) {
             *out->cur++ = ',';
         }

--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -23,7 +23,6 @@ dflags = {
   'RSTRUCT_LEN_RETURNS_INTEGER_OBJECT' => ('ruby' == type && '2' == version[0] && '4' == version[1] && '1' >= version[2]) ? 1 : 0,
 }
 
-have_func('rb_ivar_foreach')
 # Support for compaction.
 have_func('rb_gc_mark_movable')
 have_func('stpcpy')

--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -23,7 +23,6 @@ dflags = {
   'RSTRUCT_LEN_RETURNS_INTEGER_OBJECT' => ('ruby' == type && '2' == version[0] && '4' == version[1] && '1' >= version[2]) ? 1 : 0,
 }
 
-have_func('rb_ivar_count')
 have_func('rb_ivar_foreach')
 # Support for compaction.
 have_func('rb_gc_mark_movable')

--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -23,7 +23,6 @@ dflags = {
   'RSTRUCT_LEN_RETURNS_INTEGER_OBJECT' => ('ruby' == type && '2' == version[0] && '4' == version[1] && '1' >= version[2]) ? 1 : 0,
 }
 
-have_func('rb_time_timespec')
 have_func('rb_ivar_count')
 have_func('rb_ivar_foreach')
 # Support for compaction.

--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -27,7 +27,6 @@ dflags = {
 have_func('rb_gc_mark_movable')
 have_func('stpcpy')
 have_func('pthread_mutex_init')
-have_func('rb_enc_associate')
 have_func('rb_enc_interned_str')
 have_func('rb_ext_ractor_safe', 'ruby.h')
 # rb_hash_bulk_insert is deep down in a header not included in normal build and that seems to fool have_func.

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -45,7 +45,6 @@ ID oj_hash_key_id;
 ID oj_hash_set_id;
 ID oj_hash_start_id;
 ID oj_iconv_id;
-ID oj_instance_variables_id;
 ID oj_json_create_id;
 ID oj_length_id;
 ID oj_new_id;
@@ -1828,7 +1827,6 @@ void Init_oj(void) {
     oj_hash_set_id           = rb_intern("hash_set");
     oj_hash_start_id         = rb_intern("hash_start");
     oj_iconv_id              = rb_intern("iconv");
-    oj_instance_variables_id = rb_intern("instance_variables");
     oj_json_create_id        = rb_intern("json_create");
     oj_length_id             = rb_intern("length");
     oj_new_id                = rb_intern("new");

--- a/ext/oj/oj.h
+++ b/ext/oj/oj.h
@@ -347,7 +347,6 @@ extern ID oj_hash_key_id;
 extern ID oj_hash_set_id;
 extern ID oj_hash_start_id;
 extern ID oj_iconv_id;
-extern ID oj_instance_variables_id;
 extern ID oj_json_create_id;
 extern ID oj_length_id;
 extern ID oj_new_id;

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -320,7 +320,6 @@ static void dump_time(VALUE obj, int depth, Out out, bool as_ok) {
     long long sec;
     long long nsec;
 
-#ifdef HAVE_RB_TIME_TIMESPEC
     if (16 <= sizeof(struct timespec)) {
         struct timespec ts = rb_time_timespec(obj);
 
@@ -330,10 +329,6 @@ static void dump_time(VALUE obj, int depth, Out out, bool as_ok) {
         sec  = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
         nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
     }
-#else
-    sec  = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
-    nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
-#endif
     dump_sec_nano(obj, sec, nsec, out);
 }
 

--- a/ext/oj/wab.c
+++ b/ext/oj/wab.c
@@ -194,7 +194,6 @@ static void dump_time(VALUE obj, Out out) {
     time_t           sec;
     long long        nsec;
 
-#ifdef HAVE_RB_TIME_TIMESPEC
     if (16 <= sizeof(struct timespec)) {
         struct timespec ts = rb_time_timespec(obj);
 
@@ -204,10 +203,6 @@ static void dump_time(VALUE obj, Out out) {
         sec  = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
         nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
     }
-#else
-    sec  = NUM2LL(rb_funcall2(obj, oj_tv_sec_id, 0, 0));
-    nsec = NUM2LL(rb_funcall2(obj, oj_tv_nsec_id, 0, 0));
-#endif
 
     assure_size(out, 36);
     // 2012-01-05T23:58:07.123456000Z


### PR DESCRIPTION
Currently, Oj gem supports Ruby 2.4 or later.

https://github.com/ohler55/oj/blob/f1e77489e03f0a47bdf296eac29e9b8d9b663d32/oj.gemspec#L23

Oj has been checking Ruby C APIs presence in extconf.rb, 
however, I think the some APIs are definitely present and can be checked off.


- rb_time_timespec
    - Since 1.9.3
    - Commit https://github.com/ruby/ruby/commit/92cb7d0ad49d5c681119471862698d9de00bd1a6
- rb_ivar_count
    - Since 1.9.2
    - Commit https://github.com/ruby/ruby/commit/1cc1ea378a0912bfcbe55399369da47a724427aa
- rb_ivar_foreach
    - Since 1.9.0
    - https://github.com/ruby/ruby/commit/5c0e68c39c3fc7717311826549a30d1615eb2007
- rb_enc_associate
    - Since 1.9.0
    - https://github.com/ruby/ruby/commit/000b6e22f463c560f695b460272395a492eface5
