### PR TITLE
Use SSE 4.2 to skip spaces

### DIFF
--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -34,6 +34,11 @@ have_func('rb_hash_bulk_insert', 'ruby.h') unless '2' == version[0] && '6' == ve
 
 dflags['OJ_DEBUG'] = true unless ENV['OJ_DEBUG'].nil?
 
+if try_cflags('-msse4.2')
+  $CPPFLAGS += ' -msse4.2'
+  dflags['OJ_USE_SSE4_2'] = 1
+end
+
 dflags.each do |k,v|
   if v.nil?
     $CPPFLAGS += " -D#{k}"


### PR DESCRIPTION
With the deep indentation, it take a time to skip the spaces.
So, this patch will introduce SIMD instructions to improve the skip performance.

![benchmark](https://user-images.githubusercontent.com/199156/176999474-d56efd21-fcc4-4180-b1b0-d8eab1fb9dd2.png)



### Environment
- Linux
  - Manjaro Linux x86_64
  - Kernel: 5.18.0-1-rt11-MANJARO 
  - AMD Ryzen 7 5700G
  - gcc version 12.1.0
  - Ruby 3.1.2

### Before
```
Warming up --------------------------------------
       Oj.load   [2]   182.014k i/100ms
       Oj.load   [4]   181.274k i/100ms
       Oj.load   [8]   178.790k i/100ms
       Oj.load  [16]   176.257k i/100ms
       Oj.load  [32]   172.816k i/100ms
       Oj.load  [64]   158.690k i/100ms
       Oj.load [128]   146.481k i/100ms
Calculating -------------------------------------
       Oj.load   [2]      1.817M (± 0.2%) i/s -     27.302M in  15.023755s
       Oj.load   [4]      1.820M (± 0.2%) i/s -     27.372M in  15.040775s
       Oj.load   [8]      1.797M (± 0.2%) i/s -     26.997M in  15.024145s
       Oj.load  [16]      1.773M (± 0.2%) i/s -     26.615M in  15.008911s
       Oj.load  [32]      1.723M (± 0.1%) i/s -     25.922M in  15.043170s
       Oj.load  [64]      1.614M (± 0.3%) i/s -     24.280M in  15.040513s
       Oj.load [128]      1.475M (± 0.5%) i/s -     22.265M in  15.098164s
```

### After
```
Warming up --------------------------------------
       Oj.load   [2]   182.543k i/100ms
       Oj.load   [4]   183.205k i/100ms
       Oj.load   [8]   182.345k i/100ms
       Oj.load  [16]   183.154k i/100ms
       Oj.load  [32]   183.664k i/100ms
       Oj.load  [64]   181.686k i/100ms
       Oj.load [128]   181.003k i/100ms
Calculating -------------------------------------
       Oj.load   [2]      1.822M (± 0.3%) i/s -     27.381M in  15.024753s
       Oj.load   [4]      1.823M (± 0.3%) i/s -     27.481M in  15.073223s
       Oj.load   [8]      1.821M (± 0.2%) i/s -     27.352M in  15.017978s
       Oj.load  [16]      1.829M (± 0.2%) i/s -     27.473M in  15.020092s
       Oj.load  [32]      1.823M (± 0.2%) i/s -     27.366M in  15.013281s
       Oj.load  [64]      1.800M (± 0.3%) i/s -     27.071M in  15.039148s
       Oj.load [128]      1.793M (± 0.2%) i/s -     26.969M in  15.045544s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

def json(indent)
  json =<<-JSON
{
#{indent}"name": "John Doe",
#{indent}"age": 42
}
JSON
end

json_2   = json(' ' *   2)
json_4   = json(' ' *   4)
json_8   = json(' ' *   8)
json_16  = json(' ' *  16)
json_32  = json(' ' *  32)
json_64  = json(' ' *  64)
json_128 = json(' ' * 128)

Benchmark.ips do |x|
  x.warmup = 5
  x.time = 15

  x.report('Oj.load   [2]') { Oj.load(json_2) }
  x.report('Oj.load   [4]') { Oj.load(json_4) }
  x.report('Oj.load   [8]') { Oj.load(json_8) }
  x.report('Oj.load  [16]') { Oj.load(json_16) }
  x.report('Oj.load  [32]') { Oj.load(json_32) }
  x.report('Oj.load  [64]') { Oj.load(json_64) }
  x.report('Oj.load [128]') { Oj.load(json_128) }
end
```