### PR TITLE
Add RB_UNLIKELY hint for tracing log

### DIFF
--- a/ext/oj/compat.c
+++ b/ext/oj/compat.c
@@ -54,7 +54,7 @@ static void hash_set_cstr(ParseInfo pi, Val kval, const char *str, size_t len, c
         } else {
             rb_hash_aset(parent->val, rkey, rstr);
         }
-        if (Yes == pi->options.trace) {
+        if (RB_UNLIKELY(Yes == pi->options.trace)) {
             oj_trace_parse_call("set_string", pi, __FILE__, __LINE__, rstr);
         }
     }
@@ -68,7 +68,7 @@ static VALUE start_hash(ParseInfo pi) {
     } else {
         h = rb_hash_new();
     }
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_in("start_hash", pi, __FILE__, __LINE__);
     }
     return h;
@@ -93,7 +93,7 @@ static void end_hash(struct _parseInfo *pi) {
             parent->classname = 0;
         }
     }
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_hash_end(pi, __FILE__, __LINE__);
     }
 }
@@ -110,14 +110,14 @@ static void add_cstr(ParseInfo pi, const char *str, size_t len, const char *orig
         }
     }
     pi->stack.head->val = rstr;
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("add_string", pi, __FILE__, __LINE__, rstr);
     }
 }
 
 static void add_num(ParseInfo pi, NumInfo ni) {
     pi->stack.head->val = oj_num_as_value(ni);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("add_number", pi, __FILE__, __LINE__, pi->stack.head->val);
     }
 }
@@ -138,7 +138,7 @@ static void hash_set_num(struct _parseInfo *pi, Val parent, NumInfo ni) {
     } else {
         rb_hash_aset(stack_peek(&pi->stack)->val, oj_calc_hash_key(pi, parent), rval);
     }
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("set_number", pi, __FILE__, __LINE__, rval);
     }
 }
@@ -157,7 +157,7 @@ static void hash_set_value(ParseInfo pi, Val parent, VALUE value) {
     } else {
         rb_hash_aset(stack_peek(&pi->stack)->val, oj_calc_hash_key(pi, parent), value);
     }
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("set_value", pi, __FILE__, __LINE__, value);
     }
 }
@@ -166,7 +166,7 @@ static VALUE start_array(ParseInfo pi) {
     if (Qnil != pi->options.array_class) {
         return rb_class_new_instance(0, NULL, pi->options.array_class);
     }
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_in("start_array", pi, __FILE__, __LINE__);
     }
     return rb_ary_new();
@@ -184,7 +184,7 @@ static void array_append_num(ParseInfo pi, NumInfo ni) {
     } else {
         rb_ary_push(parent->val, rval);
     }
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("append_number", pi, __FILE__, __LINE__, rval);
     }
 }
@@ -201,7 +201,7 @@ static void array_append_cstr(ParseInfo pi, const char *str, size_t len, const c
         }
     }
     rb_ary_push(stack_peek(&pi->stack)->val, rstr);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("append_string", pi, __FILE__, __LINE__, rstr);
     }
 }

--- a/ext/oj/custom.c
+++ b/ext/oj/custom.c
@@ -959,7 +959,7 @@ static void hash_set_cstr(ParseInfo pi, Val kval, const char *str, size_t len, c
             break;
         default: break;
         }
-        if (Yes == pi->options.trace) {
+        if (RB_UNLIKELY(Yes == pi->options.trace)) {
             oj_trace_parse_call("set_string", pi, __FILE__, __LINE__, rstr);
         }
     }
@@ -978,7 +978,7 @@ static void end_hash(struct _parseInfo *pi) {
         }
         parent->clas = Qundef;
     }
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_hash_end(pi, __FILE__, __LINE__);
     }
 }
@@ -1032,7 +1032,7 @@ static void hash_set_num(struct _parseInfo *pi, Val kval, NumInfo ni) {
         break;
     default: break;
     }
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("set_string", pi, __FILE__, __LINE__, rval);
     }
 }
@@ -1045,7 +1045,7 @@ static void hash_set_value(ParseInfo pi, Val kval, VALUE value) {
     case T_HASH: rb_hash_aset(parent->val, oj_calc_hash_key(pi, kval), value); break;
     default: break;
     }
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("set_value", pi, __FILE__, __LINE__, value);
     }
 }
@@ -1055,7 +1055,7 @@ static void array_append_num(ParseInfo pi, NumInfo ni) {
     volatile VALUE rval   = oj_num_as_value(ni);
 
     rb_ary_push(parent->val, rval);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("append_number", pi, __FILE__, __LINE__, rval);
     }
 }
@@ -1072,7 +1072,7 @@ static void array_append_cstr(ParseInfo pi, const char *str, size_t len, const c
         }
     }
     rb_ary_push(stack_peek(&pi->stack)->val, rstr);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("append_string", pi, __FILE__, __LINE__, rstr);
     }
 }

--- a/ext/oj/object.c
+++ b/ext/oj/object.c
@@ -445,7 +445,7 @@ WHICH_TYPE:
                         rb_class2name(rb_obj_class(parent->val)));
         return;
     }
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("set_string", pi, __FILE__, __LINE__, rval);
     }
 }
@@ -516,7 +516,7 @@ WHICH_TYPE:
                         rb_class2name(rb_obj_class(parent->val)));
         return;
     }
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("add_number", pi, __FILE__, __LINE__, rval);
     }
 }
@@ -602,13 +602,13 @@ WHICH_TYPE:
                         rb_class2name(rb_obj_class(parent->val)));
         return;
     }
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("add_value", pi, __FILE__, __LINE__, value);
     }
 }
 
 static VALUE start_hash(ParseInfo pi) {
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_in("start_hash", pi, __FILE__, __LINE__);
     }
     return Qnil;
@@ -626,7 +626,7 @@ static void end_hash(ParseInfo pi) {
         oj_odd_free(oa);
         parent->odd_args = NULL;
     }
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_hash_end(pi, __FILE__, __LINE__);
     }
 }
@@ -654,7 +654,7 @@ static void array_append_cstr(ParseInfo pi, const char *str, size_t len, const c
     }
     rval = str_to_value(pi, str, len, orig);
     rb_ary_push(stack_peek(&pi->stack)->val, rval);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("append_string", pi, __FILE__, __LINE__, rval);
     }
 }
@@ -663,21 +663,21 @@ static void array_append_num(ParseInfo pi, NumInfo ni) {
     volatile VALUE rval = oj_num_as_value(ni);
 
     rb_ary_push(stack_peek(&pi->stack)->val, rval);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("append_number", pi, __FILE__, __LINE__, rval);
     }
 }
 
 static void add_cstr(ParseInfo pi, const char *str, size_t len, const char *orig) {
     pi->stack.head->val = str_to_value(pi, str, len, orig);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("add_string", pi, __FILE__, __LINE__, pi->stack.head->val);
     }
 }
 
 static void add_num(ParseInfo pi, NumInfo ni) {
     pi->stack.head->val = oj_num_as_value(ni);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("add_num", pi, __FILE__, __LINE__, pi->stack.head->val);
     }
 }

--- a/ext/oj/strict.c
+++ b/ext/oj/strict.c
@@ -50,13 +50,13 @@ VALUE oj_calc_hash_key(ParseInfo pi, Val parent) {
 }
 
 static void hash_end(ParseInfo pi) {
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_hash_end(pi, __FILE__, __LINE__);
     }
 }
 
 static void array_end(ParseInfo pi) {
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_array_end(pi, __FILE__, __LINE__);
     }
 }
@@ -66,7 +66,7 @@ static VALUE noop_hash_key(ParseInfo pi, const char *key, size_t klen) {
 }
 
 static void add_value(ParseInfo pi, VALUE val) {
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("add_value", pi, __FILE__, __LINE__, val);
     }
     pi->stack.head->val = val;
@@ -76,7 +76,7 @@ static void add_cstr(ParseInfo pi, const char *str, size_t len, const char *orig
     volatile VALUE rstr = oj_cstr_to_value(str, len, (size_t)pi->options.cache_str);
 
     pi->stack.head->val = rstr;
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("add_string", pi, __FILE__, __LINE__, rstr);
     }
 }
@@ -86,7 +86,7 @@ static void add_num(ParseInfo pi, NumInfo ni) {
         oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "not a number or other value");
     }
     pi->stack.head->val = oj_num_as_value(ni);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("add_number", pi, __FILE__, __LINE__, pi->stack.head->val);
     }
 }
@@ -95,7 +95,7 @@ static VALUE start_hash(ParseInfo pi) {
     if (Qnil != pi->options.hash_class) {
         return rb_class_new_instance(0, NULL, pi->options.hash_class);
     }
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_in("start_hash", pi, __FILE__, __LINE__);
     }
     return rb_hash_new();
@@ -107,7 +107,7 @@ static void hash_set_cstr(ParseInfo pi, Val parent, const char *str, size_t len,
     rb_hash_aset(stack_peek(&pi->stack)->val,
                  oj_calc_hash_key(pi, parent),
                  rstr);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("set_string", pi, __FILE__, __LINE__, rstr);
     }
 }
@@ -122,7 +122,7 @@ static void hash_set_num(ParseInfo pi, Val parent, NumInfo ni) {
     rb_hash_aset(stack_peek(&pi->stack)->val,
                  oj_calc_hash_key(pi, parent),
                  v);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("set_number", pi, __FILE__, __LINE__, v);
     }
 }
@@ -131,13 +131,13 @@ static void hash_set_value(ParseInfo pi, Val parent, VALUE value) {
     rb_hash_aset(stack_peek(&pi->stack)->val,
                  oj_calc_hash_key(pi, parent),
                  value);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("set_value", pi, __FILE__, __LINE__, value);
     }
 }
 
 static VALUE start_array(ParseInfo pi) {
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_in("start_array", pi, __FILE__, __LINE__);
     }
     return rb_ary_new();
@@ -147,7 +147,7 @@ static void array_append_cstr(ParseInfo pi, const char *str, size_t len, const c
     volatile VALUE rstr = oj_cstr_to_value(str, len, (size_t)pi->options.cache_str);
 
     rb_ary_push(stack_peek(&pi->stack)->val, rstr);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("append_string", pi, __FILE__, __LINE__, rstr);
     }
 }
@@ -160,14 +160,14 @@ static void array_append_num(ParseInfo pi, NumInfo ni) {
     }
     v = oj_num_as_value(ni);
     rb_ary_push(stack_peek(&pi->stack)->val, v);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("append_number", pi, __FILE__, __LINE__, v);
     }
 }
 
 static void array_append_value(ParseInfo pi, VALUE value) {
     rb_ary_push(stack_peek(&pi->stack)->val, value);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("append_value", pi, __FILE__, __LINE__, value);
     }
 }

--- a/ext/oj/wab.c
+++ b/ext/oj/wab.c
@@ -312,13 +312,13 @@ static VALUE calc_hash_key(ParseInfo pi, Val parent) {
 }
 
 static void hash_end(ParseInfo pi) {
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_hash_end(pi, __FILE__, __LINE__);
     }
 }
 
 static void array_end(ParseInfo pi) {
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_array_end(pi, __FILE__, __LINE__);
     }
 }
@@ -328,7 +328,7 @@ static VALUE noop_hash_key(ParseInfo pi, const char *key, size_t klen) {
 }
 
 static void add_value(ParseInfo pi, VALUE val) {
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("add_value", pi, __FILE__, __LINE__, val);
     }
     pi->stack.head->val = val;
@@ -478,7 +478,7 @@ static VALUE cstr_to_rstr(ParseInfo pi, const char *str, size_t len) {
 
 static void add_cstr(ParseInfo pi, const char *str, size_t len, const char *orig) {
     pi->stack.head->val = cstr_to_rstr(pi, str, len);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("add_string", pi, __FILE__, __LINE__, pi->stack.head->val);
     }
 }
@@ -488,13 +488,13 @@ static void add_num(ParseInfo pi, NumInfo ni) {
         oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "not a number or other value");
     }
     pi->stack.head->val = oj_num_as_value(ni);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("add_number", pi, __FILE__, __LINE__, pi->stack.head->val);
     }
 }
 
 static VALUE start_hash(ParseInfo pi) {
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_in("start_hash", pi, __FILE__, __LINE__);
     }
     if (Qnil != pi->options.hash_class) {
@@ -507,7 +507,7 @@ static void hash_set_cstr(ParseInfo pi, Val parent, const char *str, size_t len,
     volatile VALUE rval = cstr_to_rstr(pi, str, len);
 
     rb_hash_aset(stack_peek(&pi->stack)->val, calc_hash_key(pi, parent), rval);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("set_string", pi, __FILE__, __LINE__, rval);
     }
 }
@@ -520,20 +520,20 @@ static void hash_set_num(ParseInfo pi, Val parent, NumInfo ni) {
     }
     rval = oj_num_as_value(ni);
     rb_hash_aset(stack_peek(&pi->stack)->val, calc_hash_key(pi, parent), rval);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("set_number", pi, __FILE__, __LINE__, rval);
     }
 }
 
 static void hash_set_value(ParseInfo pi, Val parent, VALUE value) {
     rb_hash_aset(stack_peek(&pi->stack)->val, calc_hash_key(pi, parent), value);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("set_value", pi, __FILE__, __LINE__, value);
     }
 }
 
 static VALUE start_array(ParseInfo pi) {
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_in("start_array", pi, __FILE__, __LINE__);
     }
     return rb_ary_new();
@@ -543,7 +543,7 @@ static void array_append_cstr(ParseInfo pi, const char *str, size_t len, const c
     volatile VALUE rval = cstr_to_rstr(pi, str, len);
 
     rb_ary_push(stack_peek(&pi->stack)->val, rval);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("set_value", pi, __FILE__, __LINE__, rval);
     }
 }
@@ -556,14 +556,14 @@ static void array_append_num(ParseInfo pi, NumInfo ni) {
     }
     rval = oj_num_as_value(ni);
     rb_ary_push(stack_peek(&pi->stack)->val, rval);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("append_number", pi, __FILE__, __LINE__, rval);
     }
 }
 
 static void array_append_value(ParseInfo pi, VALUE value) {
     rb_ary_push(stack_peek(&pi->stack)->val, value);
-    if (Yes == pi->options.trace) {
+    if (RB_UNLIKELY(Yes == pi->options.trace)) {
         oj_trace_parse_call("append_value", pi, __FILE__, __LINE__, value);
     }
 }


### PR DESCRIPTION
I think that `Yes == pi->options.trace` will be false in most cases.
If the compiler supports it, the UNLIKELY hint might speed up the conditional branching slightly.


−       | before   | after   | result
--       | --       | --      | --
Oj.load  | 374.821k |383.001k | 1.022x

### Environment
- Linux
  - Manjaro Linux x86_64
  - Kernel: 5.18.0-1-rt11-MANJARO 
  - AMD Ryzen 7 5700G
  - gcc version 12.1.0
  - Ruby 3.1.2

### Before
```
Warming up --------------------------------------
             Oj.load    37.784k i/100ms
Calculating -------------------------------------
             Oj.load    374.821k (± 0.5%) i/s -      7.519M in  20.060807s
```

### After
```
Warming up --------------------------------------
             Oj.load    38.599k i/100ms
Calculating -------------------------------------
             Oj.load    383.001k (± 0.5%) i/s -      7.681M in  20.055707s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

json =<<-EOF
{
  "$id": "https://example.com/person.schema.json",
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "title": "Person",
  "type": "object",
  "properties": {
    "firstName": {
      "type": "string",
      "description": "The person's first name."
    },
    "lastName": {
      "type": "string",
      "description": "The person's last name."
    },
    "age": {
      "description": "Age in years which must be equal to or greater than zero.",
      "type": "integer",
      "minimum": 0
    }
  }
}
EOF

Benchmark.ips do |x|
  x.warmup = 10
  x.time = 20

  x.report('Oj.load') { Oj.load(json) }
end
```