### PR TITLE
Use SSE 4.2 due to scan string in read_str()

### DIFF
--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -34,6 +34,11 @@ have_func('rb_hash_bulk_insert', 'ruby.h') unless '2' == version[0] && '6' == ve
 
 dflags['OJ_DEBUG'] = true unless ENV['OJ_DEBUG'].nil?
 
+if try_cflags('-msse4.2')
+  $CPPFLAGS += ' -msse4.2'
+  dflags['OJ_USE_SSE4_2'] = 1
+end
+
 dflags.each do |k,v|
   if v.nil?
     $CPPFLAGS += " -D#{k}"

--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -365,7 +365,7 @@ static void read_str(ParseInfo pi) {
 #else
     scan_string_noSIMD(pi, str);
 #endif
-    if (pi->end <= pi->cur) {
+    if (RB_UNLIKELY(pi->end <= pi->cur)) {
         oj_set_error_at(pi,
                         oj_parse_error_class,
                         __FILE__,
@@ -373,7 +373,7 @@ static void read_str(ParseInfo pi) {
                         "quoted string not terminated");
         return;
     }
-    if ('\0' == *pi->cur) {
+    if (RB_UNLIKELY('\0' == *pi->cur)) {
         oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "NULL byte in string");
         return;
     }

--- a/test/test_compat.rb
+++ b/test/test_compat.rb
@@ -488,6 +488,22 @@ class CompatJuice < Minitest::Test
     assert_equal([1,2], Oj.load(s, :mode => :compat))
   end
 
+  def test_parse_large_string
+    error = assert_raises() { Oj.load(%|{"a":"aaaaaaaaaa\0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}|) }
+    assert(error.message.include?('NULL byte in string'))
+
+    error = assert_raises() { Oj.load(%|{"a":"aaaaaaaaaaaaaaaaaaaa                       }|) }
+    assert(error.message.include?('quoted string not terminated'))
+
+    json =<<~JSON
+    {
+      "a": "\\u3074\\u30fc\\u305f\\u30fc",
+      "b": "aaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+    JSON
+    assert_equal("ぴーたー", Oj.load(json)['a'])
+  end
+
   def dump_and_load(obj, trace=false)
     json = Oj.dump(obj)
     puts json if trace


### PR DESCRIPTION
In the case of long strings, it takes time to scan the string up to double quotes.
So, this patch will introduce SIMD instructions to improve the performance.

−            | before | after  |  result
--            | --     | --     | --
Oj.load   [0] | 4.131M | 4.153M | 1.005x
Oj.load  [64] | 3.244M | 3.591M | 1.107x
Oj.load [128] | 2.829M | 3.382M | 1.195x

### Environment
- Linux
  - Manjaro Linux x86_64
  - Kernel: 5.18.0-1-rt11-MANJARO
  - AMD Ryzen 7 5700G
  - gcc version 12.1.0
  - Ruby 3.1.2

### Before
```
Warming up --------------------------------------
       Oj.load   [0]   413.265k i/100ms
       Oj.load  [64]   326.361k i/100ms
       Oj.load [128]   283.154k i/100ms
Calculating -------------------------------------
       Oj.load   [0]      4.131M (± 0.2%) i/s -     82.653M in  20.007292s
       Oj.load  [64]      3.244M (± 0.6%) i/s -     64.946M in  20.019564s
       Oj.load [128]      2.829M (± 0.7%) i/s -     56.631M in  20.017253s
```

### After
```
Warming up --------------------------------------
       Oj.load   [0]   412.226k i/100ms
       Oj.load  [64]   361.499k i/100ms
       Oj.load [128]   342.480k i/100ms
Calculating -------------------------------------
       Oj.load   [0]      4.153M (± 0.2%) i/s -     83.270M in  20.051981s
       Oj.load  [64]      3.591M (± 0.6%) i/s -     71.938M in  20.034623s
       Oj.load [128]      3.382M (± 0.8%) i/s -     67.811M in  20.051748s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

def json(string)
  "\"#{string}\""
end

Benchmark.ips do |x|
  x.warmup = 5
  x.time = 20

  json_0   = json('a' *   0)
  json_64  = json('a' *  64)
  json_128 = json('a' * 128)

  x.report('Oj.load   [0]') { Oj.load(json_0) }
  x.report('Oj.load  [64]') { Oj.load(json_64) }
  x.report('Oj.load [128]') { Oj.load(json_128) }
end
```