### PR TITLE
Fix build error on non SSE 4.2 environment

### DIFF
--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -363,7 +363,7 @@ static void read_str(ParseInfo pi) {
 #if defined(OJ_USE_SSE4_2)
     scan_string_SIMD(pi);
 #else
-    scan_string_noSIMD(pi, str);
+    scan_string_noSIMD(pi);
 #endif
     if (RB_UNLIKELY(pi->end <= pi->cur)) {
         oj_set_error_at(pi,


### PR DESCRIPTION
This will fix following error.

```
compiling ../../../../ext/oj/parse.c
../../../../ext/oj/parse.c:366:28: error: too many arguments to function call, expected single argument 'pi', have 2 arguments
    scan_string_noSIMD(pi, str);
    ~~~~~~~~~~~~~~~~~~     ^~~
../../../../ext/oj/parse.c:330:20: note: 'scan_string_noSIMD' declared here
static inline void scan_string_noSIMD(ParseInfo pi) {
```

When I made various changes along the way, I forgot to fix argument in https://github.com/ohler55/oj/pull/783 
Sorry