### PR TITLE
Use SSE 4.2 due to parse escaped string

### DIFF
--- a/ext/oj/buf.h
+++ b/ext/oj/buf.h
@@ -39,7 +39,7 @@ inline static const char *buf_str(Buf buf) {
 }
 
 inline static void buf_append_string(Buf buf, const char *s, size_t slen) {
-    if (0 >= slen) {
+    if (0 == slen) {
         return;
     }
 

--- a/ext/oj/buf.h
+++ b/ext/oj/buf.h
@@ -39,6 +39,10 @@ inline static const char *buf_str(Buf buf) {
 }
 
 inline static void buf_append_string(Buf buf, const char *s, size_t slen) {
+    if (0 >= slen) {
+        return;
+    }
+
     if (buf->end <= buf->tail + slen) {
         size_t len     = buf->end - buf->head;
         size_t toff    = buf->tail - buf->head;

--- a/test/test_compat.rb
+++ b/test/test_compat.rb
@@ -504,6 +504,15 @@ class CompatJuice < Minitest::Test
     assert_equal("ぴーたー", Oj.load(json)['a'])
   end
 
+  def test_parse_large_escaped_string
+    invalid_json = %|{"a":\"aaaa\\nbbbb\\rcccc\\tddd\\feee\\bf\/\\\\\\u3074\\u30fc\\u305f\\u30fc                             }|
+    error = assert_raises() { Oj.load(invalid_json) }
+    assert(error.message.include?('quoted string not terminated'))
+
+    json = "\"aaaa\\nbbbb\\rcccc\\tddd\\feee\\bf\/\\\\\\u3074\\u30fc\\u305f\\u30fc             \""
+    assert_equal("aaaa\nbbbb\rcccc\tddd\feee\bf/\\ぴーたー             ", Oj.load(json))
+  end
+
   def dump_and_load(obj, trace=false)
     json = Oj.dump(obj)
     puts json if trace


### PR DESCRIPTION
This patch will introduce SIMD instructions to improve the performance where the escaped string is parsed
using the same technique as https://github.com/ohler55/oj/pull/783

−       | before | after  | result
--       | --     | --     | --
Oj.load  | 1.530M | 2.052M | 1.341x

### Environment
- Linux
  - Manjaro Linux x86_64
  - Kernel: 5.18.0-1-rt11-MANJARO
  - AMD Ryzen 7 5700G
  - gcc version 12.1.0
  - Ruby 3.1.2

### Before
```
Warming up --------------------------------------
             Oj.load   153.339k i/100ms
Calculating -------------------------------------
             Oj.load      1.530M (± 0.4%) i/s -     15.334M in  10.025542s
```

### After
```
Warming up --------------------------------------
             Oj.load   205.971k i/100ms
Calculating -------------------------------------
             Oj.load      2.052M (± 0.3%) i/s -     20.597M in  10.037144s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

# Oj logo
json = '{"tag":"<img src=\"https://camo.githubusercontent.com/84f8b8f0f338be60020c2c999ff890fbcb9b5cada7ea8efd10ed912fba8de48b/687474703a2f2f7777772e6f686c65722e636f6d2f6465762f696d616765732f6f6a5f636f6d65745f36342e737667\">"}'

Benchmark.ips do |x|
  # x.warmup = 3
  x.time = 10

  x.report('Oj.load') do |times|
    i = 0
    while i < times
      Oj.load(json)
      i += 1
    end
  end
end
```