### PR TITLE
Use SSE instruction to copy the data of structure

### DIFF
--- a/ext/oj/compat.c
+++ b/ext/oj/compat.c
@@ -10,6 +10,7 @@
 #include "parse.h"
 #include "resolve.h"
 #include "trace.h"
+#include "util.h"
 
 static void hash_set_cstr(ParseInfo pi, Val kval, const char *str, size_t len, const char *orig) {
     const char *   key    = kval->key;
@@ -225,7 +226,7 @@ oj_compat_parse(int argc, VALUE *argv, VALUE self) {
     struct _parseInfo pi;
 
     parse_info_init(&pi);
-    pi.options              = oj_default_options;
+    oj_memcpy(&pi.options, &oj_default_options, sizeof(struct _options));
     pi.handler              = Qnil;
     pi.err_class            = Qnil;
     pi.max_depth            = 0;
@@ -246,7 +247,7 @@ oj_compat_load(int argc, VALUE *argv, VALUE self) {
     struct _parseInfo pi;
 
     parse_info_init(&pi);
-    pi.options              = oj_default_options;
+    oj_memcpy(&pi.options, &oj_default_options, sizeof(struct _options));
     pi.handler              = Qnil;
     pi.err_class            = Qnil;
     pi.max_depth            = 0;
@@ -267,7 +268,7 @@ oj_compat_parse_cstr(int argc, VALUE *argv, char *json, size_t len) {
     struct _parseInfo pi;
 
     parse_info_init(&pi);
-    pi.options           = oj_default_options;
+    oj_memcpy(&pi.options, &oj_default_options, sizeof(struct _options));
     pi.handler           = Qnil;
     pi.err_class         = Qnil;
     pi.max_depth         = 0;

--- a/ext/oj/custom.c
+++ b/ext/oj/custom.c
@@ -1092,7 +1092,7 @@ oj_custom_parse(int argc, VALUE *argv, VALUE self) {
     struct _parseInfo pi;
 
     parse_info_init(&pi);
-    pi.options           = oj_default_options;
+    oj_memcpy(&pi.options, &oj_default_options, sizeof(struct _options));
     pi.handler           = Qnil;
     pi.err_class         = Qnil;
     pi.max_depth         = 0;
@@ -1112,7 +1112,7 @@ oj_custom_parse_cstr(int argc, VALUE *argv, char *json, size_t len) {
     struct _parseInfo pi;
 
     parse_info_init(&pi);
-    pi.options           = oj_default_options;
+    oj_memcpy(&pi.options, &oj_default_options, sizeof(struct _options));
     pi.handler           = Qnil;
     pi.err_class         = Qnil;
     pi.max_depth         = 0;

--- a/ext/oj/mimic_json.c
+++ b/ext/oj/mimic_json.c
@@ -5,6 +5,7 @@
 #include "encode.h"
 #include "oj.h"
 #include "parse.h"
+#include "util.h"
 
 extern const char oj_json_class[];
 
@@ -199,9 +200,11 @@ static int mimic_limit_arg(VALUE a) {
  */
 static VALUE mimic_dump(int argc, VALUE *argv, VALUE self) {
     struct _out     out;
-    struct _options copts = oj_default_options;
+    struct _options copts;
     VALUE           rstr;
     VALUE           active_hack[1];
+
+    oj_memcpy(&copts, &oj_default_options, sizeof(struct _options));
 
     copts.str_rx.head = NULL;
     copts.str_rx.tail = NULL;
@@ -435,7 +438,9 @@ static VALUE mimic_generate_core(int argc, VALUE *argv, Options copts) {
  */
 VALUE
 oj_mimic_generate(int argc, VALUE *argv, VALUE self) {
-    struct _options copts = oj_default_options;
+    struct _options copts;
+
+    oj_memcpy(&copts, &oj_default_options, sizeof(struct _options));
 
     copts.str_rx.head = NULL;
     copts.str_rx.tail = NULL;
@@ -453,9 +458,11 @@ oj_mimic_generate(int argc, VALUE *argv, VALUE self) {
  */
 VALUE
 oj_mimic_pretty_generate(int argc, VALUE *argv, VALUE self) {
-    struct _options copts = oj_default_options;
+    struct _options copts;
     VALUE           rargs[2];
     volatile VALUE  h;
+
+    oj_memcpy(&copts, &oj_default_options, sizeof(struct _options));
 
     // Some (all?) json gem to_json methods need a State instance and not just
     // a Hash. I haven't dug deep enough to find out why but using a State
@@ -560,7 +567,7 @@ static VALUE mimic_parse_core(int argc, VALUE *argv, VALUE self, bool bang) {
     pi.err_class = oj_json_parser_error_class;
     // pi.err_class = Qnil;
 
-    pi.options               = oj_default_options;
+    oj_memcpy(&pi.options, &oj_default_options, sizeof(struct _options));
     pi.options.auto_define   = No;
     pi.options.quirks_mode   = Yes;
     pi.options.allow_invalid = Yes;
@@ -755,7 +762,9 @@ static struct _options mimic_object_to_json_options = {0,              // indent
 static VALUE mimic_object_to_json(int argc, VALUE *argv, VALUE self) {
     struct _out     out;
     VALUE           rstr;
-    struct _options copts = oj_default_options;
+    struct _options copts;
+
+    oj_memcpy(&copts, &oj_default_options, sizeof(struct _options));
 
     copts.str_rx.head = NULL;
     copts.str_rx.tail = NULL;

--- a/ext/oj/object.c
+++ b/ext/oj/object.c
@@ -700,7 +700,7 @@ oj_object_parse(int argc, VALUE *argv, VALUE self) {
     struct _parseInfo pi;
 
     parse_info_init(&pi);
-    pi.options   = oj_default_options;
+    oj_memcpy(&pi.options, &oj_default_options, sizeof(struct _options));
     pi.handler   = Qnil;
     pi.err_class = Qnil;
     oj_set_object_callbacks(&pi);
@@ -717,7 +717,7 @@ oj_object_parse_cstr(int argc, VALUE *argv, char *json, size_t len) {
     struct _parseInfo pi;
 
     parse_info_init(&pi);
-    pi.options   = oj_default_options;
+    oj_memcpy(&pi.options, &oj_default_options, sizeof(struct _options));
     pi.handler   = Qnil;
     pi.err_class = Qnil;
     oj_set_strict_callbacks(&pi);

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -17,6 +17,7 @@
 #include "odd.h"
 #include "parse.h"
 #include "rails.h"
+#include "util.h"
 
 typedef struct _yesNoOpt {
     VALUE sym;
@@ -1121,7 +1122,7 @@ static VALUE load_file(int argc, VALUE *argv, VALUE self) {
     }
     Check_Type(*argv, T_STRING);
     parse_info_init(&pi);
-    pi.options   = oj_default_options;
+    oj_memcpy(&pi.options, &oj_default_options, sizeof(struct _options));
     pi.handler   = Qnil;
     pi.err_class = Qnil;
     pi.max_depth = 0;
@@ -1195,9 +1196,9 @@ static VALUE safe_load(VALUE self, VALUE doc) {
     VALUE             args[1];
 
     parse_info_init(&pi);
+    oj_memcpy(&pi.options, &oj_default_options, sizeof(struct _options));
     pi.err_class           = Qnil;
     pi.max_depth           = 0;
-    pi.options             = oj_default_options;
     pi.options.auto_define = No;
     pi.options.sym_key     = No;
     pi.options.mode        = StrictMode;
@@ -1272,7 +1273,9 @@ static VALUE dump_ensure(VALUE a) {
 static VALUE dump(int argc, VALUE *argv, VALUE self) {
     struct dump_arg arg;
     struct _out     out;
-    struct _options copts = oj_default_options;
+    struct _options copts;
+
+    oj_memcpy(&copts, &oj_default_options, sizeof(struct _options));
 
     if (1 > argc) {
         rb_raise(rb_eArgError, "wrong number of arguments (0 for 1).");
@@ -1325,8 +1328,10 @@ static VALUE dump(int argc, VALUE *argv, VALUE self) {
  */
 static VALUE to_json(int argc, VALUE *argv, VALUE self) {
     struct _out     out;
-    struct _options copts = oj_default_options;
+    struct _options copts;
     VALUE           rstr;
+
+    oj_memcpy(&copts, &oj_default_options, sizeof(struct _options));
 
     if (1 > argc) {
         rb_raise(rb_eArgError, "wrong number of arguments (0 for 1).");
@@ -1368,7 +1373,9 @@ static VALUE to_json(int argc, VALUE *argv, VALUE self) {
  *   - *:circular* [_Boolean_] allow circular references, default: false
  */
 static VALUE to_file(int argc, VALUE *argv, VALUE self) {
-    struct _options copts = oj_default_options;
+    struct _options copts;
+
+    oj_memcpy(&copts, &oj_default_options, sizeof(struct _options));
 
     if (3 == argc) {
         oj_parse_options(argv[2], &copts);
@@ -1390,7 +1397,9 @@ static VALUE to_file(int argc, VALUE *argv, VALUE self) {
  *   - *:circular* [_Boolean_] allow circular references, default: false
  */
 static VALUE to_stream(int argc, VALUE *argv, VALUE self) {
-    struct _options copts = oj_default_options;
+    struct _options copts;
+
+    oj_memcpy(&copts, &oj_default_options, sizeof(struct _options));
 
     if (3 == argc) {
         oj_parse_options(argv[2], &copts);

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -669,7 +669,7 @@ static void encoder_mark(void *ptr) {
 static VALUE encoder_new(int argc, VALUE *argv, VALUE self) {
     Encoder e = ALLOC(struct _encoder);
 
-    e->opts = oj_default_options;
+    oj_memcpy(&e->opts, &oj_default_options, sizeof(struct _options));
     e->arg  = Qnil;
     copy_opts(&ropts, &e->ropts);
 

--- a/ext/oj/scp.c
+++ b/ext/oj/scp.c
@@ -12,6 +12,7 @@
 #include "intern.h"
 #include "oj.h"
 #include "parse.h"
+#include "util.h"
 
 static VALUE noop_start(ParseInfo pi) {
     return Qnil;
@@ -138,9 +139,9 @@ oj_sc_parse(int argc, VALUE *argv, VALUE self) {
     VALUE             input = argv[1];
 
     parse_info_init(&pi);
+    oj_memcpy(&pi.options, &oj_default_options, sizeof(struct _options));
     pi.err_class = Qnil;
     pi.max_depth = 0;
-    pi.options   = oj_default_options;
     if (3 == argc) {
         oj_parse_options(argv[2], &pi.options);
     }

--- a/ext/oj/strict.c
+++ b/ext/oj/strict.c
@@ -12,6 +12,7 @@
 #include "oj.h"
 #include "parse.h"
 #include "trace.h"
+#include "util.h"
 
 VALUE oj_cstr_to_value(const char *str, size_t len, size_t cache_str) {
     volatile VALUE rstr = Qnil;
@@ -195,7 +196,7 @@ oj_strict_parse(int argc, VALUE *argv, VALUE self) {
     struct _parseInfo pi;
 
     parse_info_init(&pi);
-    pi.options   = oj_default_options;
+    oj_memcpy(&pi.options, &oj_default_options, sizeof(struct _options));
     pi.handler   = Qnil;
     pi.err_class = Qnil;
     oj_set_strict_callbacks(&pi);
@@ -212,7 +213,7 @@ oj_strict_parse_cstr(int argc, VALUE *argv, char *json, size_t len) {
     struct _parseInfo pi;
 
     parse_info_init(&pi);
-    pi.options   = oj_default_options;
+    oj_memcpy(&pi.options, &oj_default_options, sizeof(struct _options));
     pi.handler   = Qnil;
     pi.err_class = Qnil;
     oj_set_strict_callbacks(&pi);

--- a/ext/oj/string_writer.c
+++ b/ext/oj/string_writer.c
@@ -3,6 +3,7 @@
 
 #include "dump.h"
 #include "encode.h"
+#include "util.h"
 
 extern VALUE Oj;
 
@@ -41,7 +42,7 @@ static void maybe_comma(StrWriter sw) {
 
 // Used by stream writer also.
 void oj_str_writer_init(StrWriter sw, int buf_size) {
-    sw->opts       = oj_default_options;
+    oj_memcpy(&sw->opts, &oj_default_options, sizeof(struct _options));
     sw->depth      = 0;
     sw->types      = ALLOC_N(char, 256);
     sw->types_end  = sw->types + 256;

--- a/ext/oj/util.c
+++ b/ext/oj/util.c
@@ -134,3 +134,24 @@ void sec_as_time(int64_t secs, TimeInfo ti) {
     secs     = secs - (int64_t)ti->min * 60LL;
     ti->sec  = (int)secs;
 }
+
+#if defined(OJ_USE_SSE4_2)
+#include <emmintrin.h>
+void oj_memcpy(void *dest, const void *src, size_t len) {
+    char *d = dest;
+    const char *s = src;
+    const char *end = s + len - 16;
+
+    for(; s <= end; d += 16, s += 16) {
+        __m128i buf = _mm_loadu_si128((const __m128i*)s);
+        _mm_storeu_si128((__m128i*)d, buf);
+    }
+
+    len = len - (size_t)(s - (const char *)src);
+    memcpy(d, s, len);
+}
+#else
+void oj_memcpy(void *dest, const void *src, size_t len) {
+    memcpy(dest, src, len);
+}
+#endif

--- a/ext/oj/util.h
+++ b/ext/oj/util.h
@@ -5,6 +5,7 @@
 #define OJ_UTIL_H
 
 #include <stdint.h>
+#include <stddef.h>
 
 typedef struct _timeInfo {
     int sec;
@@ -16,5 +17,6 @@ typedef struct _timeInfo {
 } * TimeInfo;
 
 extern void sec_as_time(int64_t secs, TimeInfo ti);
+extern void oj_memcpy(void *dest, const void *src, size_t len);
 
 #endif /* OJ_UTIL_H */

--- a/ext/oj/wab.c
+++ b/ext/oj/wab.c
@@ -591,7 +591,7 @@ oj_wab_parse(int argc, VALUE *argv, VALUE self) {
     struct _parseInfo pi;
 
     parse_info_init(&pi);
-    pi.options   = oj_default_options;
+    oj_memcpy(&pi.options, &oj_default_options, sizeof(struct _options));
     pi.handler   = Qnil;
     pi.err_class = Qnil;
     oj_set_wab_callbacks(&pi);
@@ -608,7 +608,7 @@ oj_wab_parse_cstr(int argc, VALUE *argv, char *json, size_t len) {
     struct _parseInfo pi;
 
     parse_info_init(&pi);
-    pi.options   = oj_default_options;
+    oj_memcpy(&pi.options, &oj_default_options, sizeof(struct _options));
     pi.handler   = Qnil;
     pi.err_class = Qnil;
     oj_set_wab_callbacks(&pi);


### PR DESCRIPTION
When compiled with gcc, the data is copied by the `rep movsq` instruction at the point where the structure is assigned and the 8 bytes are copied at a time.

```
       │    parse_info_init(&pi);
       │    pi.options   = oj_default_options;
  1.29 │      mov  oj_default_options@@Base-0x1748,%rsi
  0.12 │      mov  $0x2b,%ecx
       │      lea  0x10f8(%rsp),%rdi
 82.95 │      rep  movsq %ds:(%rsi),%es:(%rdi)
```

(The perf command shows the above result in my environment.)

The SSE instruction can be used to increase the size of the copy at a time.

−       | before | after  | result
--       | --     | --     | --
Oj.load  | 4.975M | 5.215M | 1.048x

### Environment
- Linux
  - Manjaro Linux x86_64
  - Kernel: 5.18.0-1-rt11-MANJARO
  - AMD Ryzen 7 5700G
  - gcc version 12.1.0
  - Ruby 3.1.2

### Before
```
Warming up --------------------------------------
             Oj.load   495.911k i/100ms
Calculating -------------------------------------
             Oj.load      4.975M (± 0.2%) i/s -     50.087M in  10.068529s
```

### After
```
Warming up --------------------------------------
             Oj.load   521.707k i/100ms
Calculating -------------------------------------
             Oj.load      5.215M (± 0.2%) i/s -     52.171M in  10.004304s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

json = "42"

Benchmark.ips do |x|
  x.time = 10

  x.report('Oj.load') do |times|
    i = 0
    while i < times
      Oj.load(json)
      i += 1
    end
  end
end
```