### PR TITLE
Simplify the loop for parsing Integer string

### DIFF
--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -503,33 +503,31 @@ static void read_num(ParseInfo pi) {
         int  dec_cnt = 0;
         bool zero1   = false;
 
+        // Skip leading zeros.
+        for (; '0' == *pi->cur; pi->cur++) {
+            zero1 = true;
+        }
+
         for (; '0' <= *pi->cur && *pi->cur <= '9'; pi->cur++) {
-            if (0 == ni.i && '0' == *pi->cur) {
-                zero1 = true;
-            }
-            if (0 < ni.i) {
+            int d = (*pi->cur - '0');
+
+            if (RB_LIKELY(0 != ni.i)) {
                 dec_cnt++;
             }
-            if (!ni.big) {
-                int d = (*pi->cur - '0');
-
-                if (0 < d) {
-                    if (zero1 && CompatMode == pi->options.mode) {
-                        oj_set_error_at(pi,
-                                        oj_parse_error_class,
-                                        __FILE__,
-                                        __LINE__,
-                                        "not a number");
-                        return;
-                    }
-                    zero1 = false;
-                }
-                ni.i = ni.i * 10 + d;
-                if (INT64_MAX <= ni.i || DEC_MAX < dec_cnt) {
-                    ni.big = 1;
-                }
-            }
+            ni.i = ni.i * 10 + d;
         }
+        if (RB_UNLIKELY(0 != ni.i && zero1 && CompatMode == pi->options.mode)) {
+            oj_set_error_at(pi,
+                            oj_parse_error_class,
+                            __FILE__,
+                            __LINE__,
+                            "not a number");
+            return;
+        }
+        if (INT64_MAX <= ni.i || DEC_MAX < dec_cnt) {
+            ni.big = true;
+        }
+
         if ('.' == *pi->cur) {
             pi->cur++;
             // A trailing . is not a valid decimal but if encountered allow it
@@ -549,25 +547,20 @@ static void read_num(ParseInfo pi) {
             for (; '0' <= *pi->cur && *pi->cur <= '9'; pi->cur++) {
                 int d = (*pi->cur - '0');
 
-                if (0 < ni.num || 0 < ni.i) {
+                if (RB_LIKELY(0 != ni.num || 0 != ni.i)) {
                     dec_cnt++;
                 }
-                if (INT64_MAX <= ni.div) {
-                    if (!ni.no_big) {
-                        ni.big = true;
-                    }
-                } else {
-                    ni.num = ni.num * 10 + d;
-                    ni.div *= 10;
-                    ni.di++;
-                    if (INT64_MAX <= ni.div || DEC_MAX < dec_cnt) {
-                        if (!ni.no_big) {
-                            ni.big = true;
-                        }
-                    }
-                }
+                ni.num = ni.num * 10 + d;
+                ni.div *= 10;
+                ni.di++;
             }
         }
+        if (INT64_MAX <= ni.div || DEC_MAX < dec_cnt) {
+            if (!ni.no_big) {
+                ni.big = true;
+            }
+        }
+
         if ('e' == *pi->cur || 'E' == *pi->cur) {
             int eneg = 0;
 


### PR DESCRIPTION
There are several branches in the loop that parse Integer string.
In order to speed up parsing, this patch will move unwanted branches out of the loop.

−       | before | after  | result
--       | --     | --     | --
integer  | 4.860M | 5.088M | 1.045x
float    | 4.845M | 5.084M | 1.049x

### Environment
- Linux
  - Manjaro Linux x86_64
  - Kernel: 5.18.12-3-MANJARO
  - AMD Ryzen 7 5700G
  - gcc version 12.1.0
  - Ruby 3.1.2

### Before
```
Warming up --------------------------------------
     Oj.load integer   488.037k i/100ms
       Oj.load float   485.863k i/100ms
Calculating -------------------------------------
     Oj.load integer      4.860M (± 0.1%) i/s -     48.804M in  10.042684s
       Oj.load float      4.845M (± 0.3%) i/s -     48.586M in  10.028592s
```

### After
```
Warming up --------------------------------------
     Oj.load integer   508.044k i/100ms
       Oj.load float   508.281k i/100ms
Calculating -------------------------------------
     Oj.load integer      5.088M (± 0.2%) i/s -     51.312M in  10.085310s
       Oj.load float      5.084M (± 0.2%) i/s -     51.336M in  10.098332s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

Benchmark.ips do |x|
  x.warmup = 3
  x.time = 10

  json_integer = Oj.dump(2 ** 30)
  x.report('Oj.load integer') do |times|
    i = 0
    while i < times
      Oj.load(json_integer)
      i += 1
    end
  end

  json_float = Oj.dump(1234.123456789)
  x.report('Oj.load float') do |times|
    i = 0
    while i < times
      Oj.load(json_integer)
      i += 1
    end
  end
end
```