### PR TITLE
Add RB_UNLIKELY hint in dump method for tracing log

### DIFF
--- a/ext/oj/custom.c
+++ b/ext/oj/custom.c
@@ -484,7 +484,7 @@ static VALUE dump_common(VALUE obj, int depth, Out out) {
         const char *   s;
         int            len;
 
-        if (Yes == out->opts->trace) {
+        if (RB_UNLIKELY(Yes == out->opts->trace)) {
             oj_trace("to_json", obj, __FILE__, __LINE__, depth + 1, TraceRubyIn);
         }
         if (0 == rb_obj_method_arity(obj, oj_to_json_id)) {
@@ -492,7 +492,7 @@ static VALUE dump_common(VALUE obj, int depth, Out out) {
         } else {
             rs = rb_funcall2(obj, oj_to_json_id, out->argc, out->argv);
         }
-        if (Yes == out->opts->trace) {
+        if (RB_UNLIKELY(Yes == out->opts->trace)) {
             oj_trace("to_json", obj, __FILE__, __LINE__, depth + 1, TraceRubyOut);
         }
         s   = RSTRING_PTR(rs);
@@ -504,7 +504,7 @@ static VALUE dump_common(VALUE obj, int depth, Out out) {
     } else if (Yes == out->opts->as_json && rb_respond_to(obj, oj_as_json_id)) {
         volatile VALUE aj;
 
-        if (Yes == out->opts->trace) {
+        if (RB_UNLIKELY(Yes == out->opts->trace)) {
             oj_trace("as_json", obj, __FILE__, __LINE__, depth + 1, TraceRubyIn);
         }
         // Some classes elect to not take an options argument so check the arity
@@ -514,7 +514,7 @@ static VALUE dump_common(VALUE obj, int depth, Out out) {
         } else {
             aj = rb_funcall2(obj, oj_as_json_id, out->argc, out->argv);
         }
-        if (Yes == out->opts->trace) {
+        if (RB_UNLIKELY(Yes == out->opts->trace)) {
             oj_trace("as_json", obj, __FILE__, __LINE__, depth + 1, TraceRubyOut);
         }
         // Catch the obvious brain damaged recursive dumping.
@@ -885,7 +885,7 @@ static DumpFunc custom_funcs[] = {
 void oj_dump_custom_val(VALUE obj, int depth, Out out, bool as_ok) {
     int type = rb_type(obj);
 
-    if (Yes == out->opts->trace) {
+    if (RB_UNLIKELY(Yes == out->opts->trace)) {
         oj_trace("dump", obj, __FILE__, __LINE__, depth, TraceIn);
     }
     if (MAX_DEPTH < depth) {
@@ -896,14 +896,14 @@ void oj_dump_custom_val(VALUE obj, int depth, Out out, bool as_ok) {
 
         if (NULL != f) {
             f(obj, depth, out, true);
-            if (Yes == out->opts->trace) {
+            if (RB_UNLIKELY(Yes == out->opts->trace)) {
                 oj_trace("dump", obj, __FILE__, __LINE__, depth, TraceOut);
             }
             return;
         }
     }
     oj_dump_nil(Qnil, depth, out, false);
-    if (Yes == out->opts->trace) {
+    if (RB_UNLIKELY(Yes == out->opts->trace)) {
         oj_trace("dump", Qnil, __FILE__, __LINE__, depth, TraceOut);
     }
 }

--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -736,11 +736,11 @@ void oj_dump_raw_json(VALUE obj, int depth, Out out) {
     } else {
         volatile VALUE jv;
 
-        if (Yes == out->opts->trace) {
+        if (RB_UNLIKELY(Yes == out->opts->trace)) {
             oj_trace("raw_json", obj, __FILE__, __LINE__, depth + 1, TraceRubyIn);
         }
         jv = rb_funcall(obj, oj_raw_json_id, 2, RB_INT2NUM(depth), RB_INT2NUM(out->indent));
-        if (Yes == out->opts->trace) {
+        if (RB_UNLIKELY(Yes == out->opts->trace)) {
             oj_trace("raw_json", obj, __FILE__, __LINE__, depth + 1, TraceRubyOut);
         }
         oj_dump_raw(RSTRING_PTR(jv), (size_t)RSTRING_LEN(jv), out);

--- a/ext/oj/dump_compat.c
+++ b/ext/oj/dump_compat.c
@@ -109,7 +109,7 @@ dump_to_json(VALUE obj, Out out) {
     const char		*s;
     int			len;
 
-    if (Yes == out->opts->trace) {
+    if (RB_UNLIKELY(Yes == out->opts->trace)) {
 	oj_trace("to_json", obj, __FILE__, __LINE__, 0, TraceRubyIn);
     }
     if (0 == rb_obj_method_arity(obj, oj_to_json_id)) {
@@ -117,7 +117,7 @@ dump_to_json(VALUE obj, Out out) {
     } else {
 	rs = rb_funcall2(obj, oj_to_json_id, out->argc, out->argv);
     }
-    if (Yes == out->opts->trace) {
+    if (RB_UNLIKELY(Yes == out->opts->trace)) {
 	oj_trace("to_json", obj, __FILE__, __LINE__, 0, TraceRubyOut);
     }
 
@@ -893,7 +893,7 @@ void
 oj_dump_compat_val(VALUE obj, int depth, Out out, bool as_ok) {
     int	type = rb_type(obj);
 
-    if (Yes == out->opts->trace) {
+    if (RB_UNLIKELY(Yes == out->opts->trace)) {
 	oj_trace("dump", obj, __FILE__, __LINE__, depth, TraceIn);
     }
     if (out->opts->dump_opts.max_depth <= depth) {
@@ -918,14 +918,14 @@ oj_dump_compat_val(VALUE obj, int depth, Out out, bool as_ok) {
 
 	if (NULL != f) {
 	    f(obj, depth, out, as_ok);
-	    if (Yes == out->opts->trace) {
+	    if (RB_UNLIKELY(Yes == out->opts->trace)) {
 		oj_trace("dump", obj, __FILE__, __LINE__, depth, TraceOut);
 	    }
 	    return;
 	}
     }
     oj_dump_nil(Qnil, depth, out, false);
-    if (Yes == out->opts->trace) {
+    if (RB_UNLIKELY(Yes == out->opts->trace)) {
 	oj_trace("dump", Qnil, __FILE__, __LINE__, depth, TraceOut);
     }
 }

--- a/ext/oj/dump_object.c
+++ b/ext/oj/dump_object.c
@@ -682,7 +682,7 @@ static DumpFunc obj_funcs[] = {
 void oj_dump_obj_val(VALUE obj, int depth, Out out) {
     int type = rb_type(obj);
 
-    if (Yes == out->opts->trace) {
+    if (RB_UNLIKELY(Yes == out->opts->trace)) {
         oj_trace("dump", obj, __FILE__, __LINE__, depth, TraceIn);
     }
     if (MAX_DEPTH < depth) {
@@ -693,14 +693,14 @@ void oj_dump_obj_val(VALUE obj, int depth, Out out) {
 
         if (NULL != f) {
             f(obj, depth, out, false);
-            if (Yes == out->opts->trace) {
+            if (RB_UNLIKELY(Yes == out->opts->trace)) {
                 oj_trace("dump", obj, __FILE__, __LINE__, depth, TraceOut);
             }
             return;
         }
     }
     oj_dump_nil(Qnil, depth, out, false);
-    if (Yes == out->opts->trace) {
+    if (RB_UNLIKELY(Yes == out->opts->trace)) {
         oj_trace("dump", Qnil, __FILE__, __LINE__, depth, TraceOut);
     }
 }

--- a/ext/oj/dump_strict.c
+++ b/ext/oj/dump_strict.c
@@ -338,7 +338,7 @@ static DumpFunc strict_funcs[] = {
 void oj_dump_strict_val(VALUE obj, int depth, Out out) {
     int type = rb_type(obj);
 
-    if (Yes == out->opts->trace) {
+    if (RB_UNLIKELY(Yes == out->opts->trace)) {
         oj_trace("dump", obj, __FILE__, __LINE__, depth, TraceIn);
     }
     if (MAX_DEPTH < depth) {
@@ -349,7 +349,7 @@ void oj_dump_strict_val(VALUE obj, int depth, Out out) {
 
         if (NULL != f) {
             f(obj, depth, out, false);
-            if (Yes == out->opts->trace) {
+            if (RB_UNLIKELY(Yes == out->opts->trace)) {
                 oj_trace("dump", obj, __FILE__, __LINE__, depth, TraceOut);
             }
             return;
@@ -386,7 +386,7 @@ static DumpFunc null_funcs[] = {
 void oj_dump_null_val(VALUE obj, int depth, Out out) {
     int type = rb_type(obj);
 
-    if (Yes == out->opts->trace) {
+    if (RB_UNLIKELY(Yes == out->opts->trace)) {
         oj_trace("dump", obj, __FILE__, __LINE__, depth, TraceOut);
     }
     if (MAX_DEPTH < depth) {
@@ -397,14 +397,14 @@ void oj_dump_null_val(VALUE obj, int depth, Out out) {
 
         if (NULL != f) {
             f(obj, depth, out, false);
-            if (Yes == out->opts->trace) {
+            if (RB_UNLIKELY(Yes == out->opts->trace)) {
                 oj_trace("dump", obj, __FILE__, __LINE__, depth, TraceOut);
             }
             return;
         }
     }
     oj_dump_nil(Qnil, depth, out, false);
-    if (Yes == out->opts->trace) {
+    if (RB_UNLIKELY(Yes == out->opts->trace)) {
         oj_trace("dump", Qnil, __FILE__, __LINE__, depth, TraceOut);
     }
 }

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -517,7 +517,7 @@ static void dump_as_string(VALUE obj, int depth, Out out, bool as_ok) {
 static void dump_as_json(VALUE obj, int depth, Out out, bool as_ok) {
     volatile VALUE ja;
 
-    if (Yes == out->opts->trace) {
+    if (RB_UNLIKELY(Yes == out->opts->trace)) {
         oj_trace("as_json", obj, __FILE__, __LINE__, depth + 1, TraceRubyIn);
     }
     // Some classes elect to not take an options argument so check the arity
@@ -527,7 +527,7 @@ static void dump_as_json(VALUE obj, int depth, Out out, bool as_ok) {
     } else {
         ja = rb_funcall2(obj, oj_as_json_id, out->argc, out->argv);
     }
-    if (Yes == out->opts->trace) {
+    if (RB_UNLIKELY(Yes == out->opts->trace)) {
         oj_trace("as_json", obj, __FILE__, __LINE__, depth + 1, TraceRubyOut);
     }
 
@@ -1464,7 +1464,7 @@ static DumpFunc rails_funcs[] = {
 static void dump_rails_val(VALUE obj, int depth, Out out, bool as_ok) {
     int type = rb_type(obj);
 
-    if (Yes == out->opts->trace) {
+    if (RB_UNLIKELY(Yes == out->opts->trace)) {
         oj_trace("dump", obj, __FILE__, __LINE__, depth, TraceIn);
     }
     if (MAX_DEPTH < depth) {
@@ -1475,14 +1475,14 @@ static void dump_rails_val(VALUE obj, int depth, Out out, bool as_ok) {
 
         if (NULL != f) {
             f(obj, depth, out, as_ok);
-            if (Yes == out->opts->trace) {
+            if (RB_UNLIKELY(Yes == out->opts->trace)) {
                 oj_trace("dump", obj, __FILE__, __LINE__, depth, TraceOut);
             }
             return;
         }
     }
     oj_dump_nil(Qnil, depth, out, false);
-    if (Yes == out->opts->trace) {
+    if (RB_UNLIKELY(Yes == out->opts->trace)) {
         oj_trace("dump", Qnil, __FILE__, __LINE__, depth, TraceOut);
     }
 }

--- a/ext/oj/wab.c
+++ b/ext/oj/wab.c
@@ -266,7 +266,7 @@ static DumpFunc wab_funcs[] = {
 void oj_dump_wab_val(VALUE obj, int depth, Out out) {
     int type = rb_type(obj);
 
-    if (Yes == out->opts->trace) {
+    if (RB_UNLIKELY(Yes == out->opts->trace)) {
         oj_trace("dump", obj, __FILE__, __LINE__, depth, TraceIn);
     }
     if (MAX_DEPTH < depth) {
@@ -277,7 +277,7 @@ void oj_dump_wab_val(VALUE obj, int depth, Out out) {
 
         if (NULL != f) {
             f(obj, depth, out, false);
-            if (Yes == out->opts->trace) {
+            if (RB_UNLIKELY(Yes == out->opts->trace)) {
                 oj_trace("dump", obj, __FILE__, __LINE__, depth, TraceOut);
             }
             return;


### PR DESCRIPTION
If the compiler supports it, the UNLIKELY hint might speed up the conditional branching slightly.
Ref. https://github.com/ohler55/oj/pull/782

−       | before  | after   | result
--       | --      | --      | --
Oj.dump  | 11.754M | 11.775M | -

### Environment
- Linux
  - Manjaro Linux x86_64
  - Kernel: 5.18.12-3-MANJARO
  - AMD Ryzen 7 5700G
  - gcc version 12.1.0
  - Ruby 3.1.2

### Before
```
Warming up --------------------------------------
             Oj.dump     1.166M i/100ms
Calculating -------------------------------------
             Oj.dump     11.754M (± 0.2%) i/s -    177.254M in  15.080998s
```

### After
```
Warming up --------------------------------------
             Oj.dump     1.184M i/100ms
Calculating -------------------------------------
             Oj.dump     11.775M (± 0.2%) i/s -    177.612M in  15.084141s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

data = 42

Benchmark.ips do |x|
  x.warmup = 5
  x.time = 15

  x.report('Oj.dump') do |times|
    i = 0
    while i < times
      Oj.dump(data)
      i += 1
    end
  end
end
```