### PR TITLE
Provide a way to disable SSE 4.2 instructions

### DIFF
--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
 }
 SRC
 
-if try_run(src, '-msse4.2')
+if ENV['OJ_NO_SSE4_2'].nil? && try_run(src, '-msse4.2')
   $CPPFLAGS += ' -msse4.2'
   dflags['OJ_USE_SSE4_2'] = 1
 end


### PR DESCRIPTION
We often ship gems compiled on a SSE 4.2 machine, but some users run
on older hardware. To avoid an illegal instruction error, disable SSE
4.2 instructions by setting the `eOJ_NO_SSE4_2` environment variable.

Relates to https://github.com/ohler55/oj/issues/789