### PR TITLE
Perform runtime check for SSE 4.2 instructions

### DIFF
--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -36,7 +36,6 @@ dflags['OJ_DEBUG'] = true unless ENV['OJ_DEBUG'].nil?
 
 if try_cflags('-msse4.2')
   $CPPFLAGS += ' -msse4.2'
-  dflags['OJ_USE_SSE4_2'] = 1
 end
 
 dflags.each do |k,v|

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -2043,4 +2043,5 @@ void Init_oj(void) {
     oj_init_doc();
 
     oj_parser_init();
+    oj_scanner_init();
 }

--- a/ext/oj/parse.h
+++ b/ext/oj/parse.h
@@ -97,6 +97,8 @@ static inline void parse_info_init(ParseInfo pi) {
     memset(pi, 0, sizeof(struct _parseInfo));
 }
 
+extern void oj_scanner_init();
+
 static inline bool empty_ok(Options options) {
     switch (options->mode) {
     case ObjectMode:


### PR DESCRIPTION
If SSE 4.2 is not available on the system, don't attempt to use SIMD instructions.

Relates to https://github.com/ohler55/oj/issues/789