### PR TITLE
Fix oj_scanner_init prototype

### DIFF
--- a/ext/oj/parse.h
+++ b/ext/oj/parse.h
@@ -97,7 +97,7 @@ static inline void parse_info_init(ParseInfo pi) {
     memset(pi, 0, sizeof(struct _parseInfo));
 }
 
-extern void oj_scanner_init();
+extern void oj_scanner_init(void);
 
 static inline bool empty_ok(Options options) {
     switch (options->mode) {


### PR DESCRIPTION
Ensure the parameters are void to be consistent with the implementation.

This was identified in https://github.com/ohler55/oj/issues/796.