### PR TITLE
Don't attempt SSE 4.2 runtime detection with Truffleruby

### DIFF
--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -211,6 +211,10 @@ static inline const char *scan_string_noSIMD(const char *str, const char *end) {
 #undef USE_SSE_DETECT
 #endif
 
+#if defined(TRUFFLERUBY)
+#undef USE_SSE_DETECT
+#endif
+
 #ifdef USE_SSE_DETECT
 #include <nmmintrin.h>
 


### PR DESCRIPTION
Use the `TRUFFLERUBY` preprocessor definition to check:
https://github.com/oracle/truffleruby/blob/master/doc/user/compatibility.md#identification

This eliminates the `External LLVMFunction __cpu_indicator_init` error:

```
ruby test/tests.rb -v && ruby test/tests_mimic.rb -v && ruby test/tests_mimic_addition.rb -v
/oj/ext/oj/parse.c:237:in `cpu_supports_sse42': External LLVMFunction __cpu_indicator_init cannot be found. (com.oracle.truffle.llvm.runtime.except.LLVMLinkerException) (RuntimeError)
Translated to internal error
	from /oj/ext/oj/parse.c:247:in `oj_scanner_init'
	from /oj/ext/oj/oj.c:2046:in `Init_oj'
	from /usr/local/lib/mri/rubygems/core_ext/kernel_require.rb:83:in `gem_original_require'
	from /usr/local/lib/mri/rubygems/core_ext/kernel_require.rb:83:in `require'
	from /oj/lib/oj.rb:13:in `<top (required)>'
	from <internal:core> core/kernel.rb:234:in `gem_original_require'
	from /usr/local/lib/mri/rubygems/core_ext/kernel_require.rb:83:in `require'
	from /oj/test/test_compat.rb:15:in `<top (required)>'
	from <internal:core> core/kernel.rb:260:in `require'
	from test/tests.rb:10:in `<main>'
```