### PR TITLE
Fix seg faults in SAJ parser

### DIFF
--- a/ext/oj/saj2.c
+++ b/ext/oj/saj2.c
@@ -289,7 +289,7 @@ static void add_float_key_loc(ojParser p) {
 }
 
 static void add_big(ojParser p) {
-    rb_funcall((VALUE)p->ctx,
+    rb_funcall(((Delegate)p->ctx)->handler,
                oj_add_value_id,
                2,
                rb_funcall(rb_cObject, oj_bigdecimal_id, 1, rb_str_new(buf_str(&p->buf), buf_len(&p->buf))),
@@ -297,7 +297,7 @@ static void add_big(ojParser p) {
 }
 
 static void add_big_loc(ojParser p) {
-    rb_funcall((VALUE)p->ctx,
+    rb_funcall(((Delegate)p->ctx)->handler,
                oj_add_value_id,
                4,
                rb_funcall(rb_cObject, oj_bigdecimal_id, 1, rb_str_new(buf_str(&p->buf), buf_len(&p->buf))),
@@ -307,7 +307,7 @@ static void add_big_loc(ojParser p) {
 }
 
 static void add_big_key(ojParser p) {
-    rb_funcall((VALUE)p->ctx,
+    rb_funcall(((Delegate)p->ctx)->handler,
                oj_add_value_id,
                2,
                rb_funcall(rb_cObject, oj_bigdecimal_id, 1, rb_str_new(buf_str(&p->buf), buf_len(&p->buf))),


### PR DESCRIPTION
Previously if `add_big_*()` were called, Ruby code would seg fault:

```
-- C level backtrace information -------------------------------------------
/opt/gitlab/embedded/lib/libruby.so.2.7(rb_vm_bugreport+0x561) [0x7ff955dd2da1] vm_dump.c:755
[0x7ff955bf5e61]
/opt/gitlab/embedded/lib/libruby.so.2.7(sigsegv+0x59) [0x7ff955d2eca9] signal.c:946
/lib/x86_64-linux-gnu/libc.so.6(0x7ff9559700c0) [0x7ff9559700c0]
/opt/gitlab/embedded/lib/libruby.so.2.7(rb_id_table_lookup+0x7) [0x7ff955d6e727] symbol.h:72
/opt/gitlab/embedded/lib/libruby.so.2.7(lookup_method_table+0x14) [0x7ff955da6a5c] vm_method.c:188
/opt/gitlab/embedded/lib/libruby.so.2.7(method_entry_get) vm_method.c:747
/opt/gitlab/embedded/lib/libruby.so.2.7(rb_callable_method_entry+0x20) [0x7ff955daea70] vm_method.c:891
/opt/gitlab/embedded/lib/libruby.so.2.7(rb_call0+0x145) [0x7ff955dc5115] vm_eval.c:654
/opt/gitlab/embedded/lib/libruby.so.2.7(rb_funcallv+0x38) [0x7ff955dc5c68] vm_eval.c:718
/opt/gitlab/embedded/lib/ruby/gems/2.7.0/gems/oj-3.13.18/lib/oj/oj.so(add_big_loc+0xac) [0x7ff9491815cc] saj2.c:300
/opt/gitlab/embedded/lib/ruby/gems/2.7.0/gems/oj-3.13.18/lib/oj/oj.so(calc_num+0xf0) [0x7ff949172e40] parser.c:531
/opt/gitlab/embedded/lib/ruby/gems/2.7.0/gems/oj-3.13.18/lib/oj/oj.so(parse+0x336) [0x7ff949174136] parser.c:713
/opt/gitlab/embedded/lib/ruby/gems/2.7.0/gems/oj-3.13.18/lib/oj/oj.so(parser_parse+0x9b) [0x7ff94917691b] parser.c:1344
[0x7ff955daaebd]
```

This appears to be happening due to improper pointer casting.