### PR TITLE
Fix Ruby garbage collection deprecation warning

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -19,10 +19,16 @@ require 'pp'
 require 'oj'
 
 
-if defined?(GC.verify_compaction_references) == 'method'
+def verify_gc_compaction
   # This method was added in Ruby 3.0.0. Calling it this way asks the GC to
   # move objects around, helping to find object movement bugs.
-  GC.verify_compaction_references(double_heap: true, toward: :empty)
+  if defined?(GC.verify_compaction_references) == 'method' && !(RbConfig::CONFIG['host_os'] =~ /(mingw|mswin)/)
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.2.0")
+      GC.verify_compaction_references(expand_heap: true, toward: :empty)
+    else
+      GC.verify_compaction_references(double_heap: true, toward: :empty)
+    end
+  end
 end
 
 

--- a/test/json_gem/test_helper.rb
+++ b/test/json_gem/test_helper.rb
@@ -15,10 +15,14 @@ else
   require 'oj'
   Oj.mimic_JSON
 
+  # This method was added in Ruby 3.0.0. Calling it this way asks the GC to
+  # move objects around, helping to find object movement bugs.
   if defined?(GC.verify_compaction_references) == 'method'
-    # This method was added in Ruby 3.0.0. Calling it this way asks the GC to
-    # move objects around, helping to find object movement bugs.
-    GC.verify_compaction_references(double_heap: true, toward: :empty)
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("3.2.0")
+      GC.verify_compaction_references(expand_heap: true, toward: :empty)
+    else
+      GC.verify_compaction_references(double_heap: true, toward: :empty)
+    end
   end
 end
 

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -224,7 +224,7 @@ class ObjectJuice < Minitest::Test
 #=begin
     if '3.1.0' <= RUBY_VERSION && !(RbConfig::CONFIG['host_os'] =~ /(mingw|mswin)/)
       #Oj::debug_odd("teardown before GC.verify_compaction_references")
-      GC.verify_compaction_references(double_heap: true, toward: :empty)
+      verify_gc_compaction
       #Oj::debug_odd("teardown after GC.verify_compaction_references")
     end
 #=end


### PR DESCRIPTION
The Ruby interpreter deprecated the `double_heap` option in favor of
`expand_heap` (https://github.com/ruby/ruby/commit/a6dd859affc42b667279e513bb94fb75cfb133c1).