### PR TITLE
Remove unnessary volatile qualifier in Oj.load

### DIFF
--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -667,7 +667,7 @@ static void read_num(ParseInfo pi) {
 }
 
 static void array_start(ParseInfo pi) {
-    volatile VALUE v = pi->start_array(pi);
+    VALUE v = pi->start_array(pi);
 
     stack_push(&pi->stack, v, NEXT_ARRAY_NEW);
 }
@@ -691,13 +691,13 @@ static void array_end(ParseInfo pi) {
 }
 
 static void hash_start(ParseInfo pi) {
-    volatile VALUE v = pi->start_hash(pi);
+    VALUE v = pi->start_hash(pi);
 
     stack_push(&pi->stack, v, NEXT_HASH_NEW);
 }
 
 static void hash_end(ParseInfo pi) {
-    volatile Val hash = stack_peek(&pi->stack);
+    Val hash = stack_peek(&pi->stack);
 
     // leave hash on stack until just before
     if (0 == hash) {
@@ -884,7 +884,7 @@ static long double exp_plus[] = {
 
 VALUE
 oj_num_as_value(NumInfo ni) {
-    volatile VALUE rnum = Qnil;
+    VALUE rnum = Qnil;
 
     if (ni->infinity) {
         if (ni->neg) {
@@ -919,7 +919,7 @@ oj_num_as_value(NumInfo ni) {
         }
     } else {  // decimal
         if (ni->big) {
-            volatile VALUE bd = rb_str_new(ni->str, ni->len);
+            VALUE bd = rb_str_new(ni->str, ni->len);
 
             rnum = rb_rescue2(parse_big_decimal, bd, rescue_big_decimal, bd, rb_eException, 0);
             if (ni->no_big) {
@@ -947,7 +947,7 @@ oj_num_as_value(NumInfo ni) {
             }
             rnum = rb_float_new((double)ld);
         } else if (RubyDec == ni->bigdec_load) {
-            volatile VALUE sv = rb_str_new(ni->str, ni->len);
+            VALUE sv = rb_str_new(ni->str, ni->len);
 
             rnum = rb_funcall(sv, rb_intern("to_f"), 0);
         } else {
@@ -1042,7 +1042,7 @@ static VALUE protect_parse(VALUE pip) {
 
 extern int oj_utf8_index;
 
-static void oj_pi_set_input_str(ParseInfo pi, volatile VALUE *inputp) {
+static void oj_pi_set_input_str(ParseInfo pi, VALUE *inputp) {
     int idx = RB_ENCODING_GET(*inputp);
 
     if (oj_utf8_encoding_index != idx) {
@@ -1055,12 +1055,12 @@ static void oj_pi_set_input_str(ParseInfo pi, volatile VALUE *inputp) {
 
 VALUE
 oj_pi_parse(int argc, VALUE *argv, ParseInfo pi, char *json, size_t len, int yieldOk) {
-    char *         buf = 0;
-    volatile VALUE input;
-    volatile VALUE wrapped_stack;
-    volatile VALUE result    = Qnil;
-    int            line      = 0;
-    int            free_json = 0;
+    char * buf = 0;
+    VALUE  input;
+    VALUE  wrapped_stack;
+    VALUE  result    = Qnil;
+    int    line      = 0;
+    int    free_json = 0;
 
     if (argc < 1) {
         rb_raise(rb_eArgError, "Wrong number of arguments to parse.");
@@ -1096,8 +1096,8 @@ oj_pi_parse(int argc, VALUE *argv, ParseInfo pi, char *json, size_t len, int yie
             rb_raise(rb_eTypeError, "Nil is not a valid JSON source.");
         }
     } else {
-        VALUE          clas = rb_obj_class(input);
-        volatile VALUE s;
+        VALUE clas = rb_obj_class(input);
+        VALUE s;
 
         if (oj_stringio_class == clas) {
             s = rb_funcall2(input, oj_string_id, 0, 0);

--- a/test/test_gc.rb
+++ b/test/test_gc.rb
@@ -26,10 +26,12 @@ class GCTest < Minitest::Test
 
   def setup
     @default_options = Oj.default_options
+    GC.stress = true
   end
 
   def teardown
     Oj.default_options = @default_options
+    GC.stress = false
   end
 
   # if no crash then the GC marking is working
@@ -47,5 +49,14 @@ class GCTest < Minitest::Test
     100.times { |i| g = Goo.new(i, g) }
     json = Oj.dump(g, :mode => :object)
     Oj.object_load(json)
+  end
+
+  def test_parse_gc
+    json = '{"a":"Alpha","b":true,"c":12345,"d":[true,[false,[-123456789,null],3.9676,["Something else.",false],null]],"e":{"zero":null,"one":1,"two":2,"three":[3],"four":[0,1,2,3,4]},"f":null,"h":{"a":{"b":{"c":{"d":{"e":{"f":{"g":null}}}}}}},"i":[[[[[[[null]]]]]]]}'
+
+    50.times do
+      data = Oj.load(json)
+      assert_equal(json, Oj.dump(data))
+    end
   end
 end


### PR DESCRIPTION
When we use volatile qualifier, seems it has some performance penalty on GCC.
The volatile qualifier is unnecessary since the VALUE type object has been kept on the local stack.
(If we manage VALUE on the heap, we need to be careful.)

−       | before  | after   | result
--       | --      | --      | --
GCC      | 4.969M  | 5.165M  | 1.039x
Clang    | 5.054M  | 5.090M  | -


### Environment
- Linux
  - Manjaro Linux x86_64
  - Kernel: 5.18.12-3-MANJARO
  - AMD Ryzen 7 5700G
  - gcc version 12.1.0
  - clang version 14.0.6
  - Ruby 3.1.2

### GCC
#### Before
```
Warming up --------------------------------------
             Oj.load   497.783k i/100ms
Calculating -------------------------------------
             Oj.load      4.969M (± 0.1%) i/s -     49.778M in  10.017042s
```

#### After
```
Warming up --------------------------------------
             Oj.load   518.127k i/100ms
Calculating -------------------------------------
             Oj.load      5.165M (± 0.1%) i/s -     51.813M in  10.031075s
```

### Clang
#### Before
```
Warming up --------------------------------------
             Oj.load   503.712k i/100ms
Calculating -------------------------------------
             Oj.load      5.054M (± 0.1%) i/s -     50.875M in  10.067027s
```

#### After
```
Warming up --------------------------------------
             Oj.load   510.215k i/100ms
Calculating -------------------------------------
             Oj.load      5.090M (± 0.1%) i/s -     51.022M in  10.022973s
```

### Test code
```ruby
require 'benchmark/ips'
require 'oj'

json = Oj.dump(42)

Benchmark.ips do |x|
  x.warmup = 5
  x.time = 10

  x.report('Oj.load') do |times|
    i = 0
    while i < times
      Oj.load(json)
      i += 1
    end
  end
end
```