### PR TITLE
Add TruffleRuby CI job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,6 +22,7 @@ jobs:
           - '2.7'
           - '2.6'
           - '2.5'
+          - truffleruby+graalvm
         os:
           - ubuntu
           - macos
@@ -35,6 +36,8 @@ jobs:
         exclude:
           - os: macos
             ruby: head
+          - os: macos
+            ruby: truffleruby+graalvm
           - ruby: head
             gemfile: rails_5
           - ruby: '3.0'
@@ -45,6 +48,8 @@ jobs:
             gemfile: rails_7
           - ruby: '2.6'
             gemfile: rails_7
+          - ruby: truffleruby
+            gemfile: rails_5
 
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile


### PR DESCRIPTION
This should help catch future Truffleruby regressions, such as #796.

Note that `truffleruby-head` hit a number of seg faults, while `truffleruby+graalvm` seems to work fine.   