### PR TITLE
Disable SSE 4.2 compile instructions by default

### DIFF
--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -34,21 +34,9 @@ have_func('rb_hash_bulk_insert', 'ruby.h') unless '2' == version[0] && '6' == ve
 
 dflags['OJ_DEBUG'] = true unless ENV['OJ_DEBUG'].nil?
 
-src =<<~SRC
-#include <string.h>
-#include <nmmintrin.h>
-int main(int argc, char **argv) {
-    const char *str = "hello               ";
-    const char chars[16] = "\x00\\\"";
-    const __m128i terminate = _mm_loadu_si128((const __m128i *)&chars[0]);
-    const __m128i string = _mm_loadu_si128((const __m128i *)str);
-    int r = _mm_cmpestri(terminate, 3, string, 16, _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_ANY | _SIDD_LEAST_SIGNIFICANT);
-    return r == 16 ? 0 : 1;
-}
-SRC
-
-if try_run(src, '-msse4.2')
+if with_config('--with-sse42')
   $CPPFLAGS += ' -msse4.2'
+  dflags['OJ_USE_SSE4_2'] = 1
 end
 
 dflags.each do |k,v|


### PR DESCRIPTION
Compiling with `-msse4.2` is problematic because it may cause a number
of other SSE instructions to be used. For example:

```
$ ./elfx86exts oj.so
MODE64 (call)
CMOV (cmovne)
SSE2 (movq)
SSE41 (pinsrq)
SSE1 (movups)
SSSE3 (pshufb)
SSE3 (movddup)
SSE42 (pcmpestri)
CPU Generation: Unknown
```

The runtime check in #795 is therefore not sufficient to prevent SSE
instructions from leaking elsewhere in the shared library. As a
result, loading Oj on older machines with these libraries will result
in a "illegal instruction" crash.

Introduce a `--with-sse42` flag that can be used to configure this
gem.