### PR TITLE
Update ruby version compatibility in document

### DIFF
--- a/pages/Compatibility.md
+++ b/pages/Compatibility.md
@@ -2,7 +2,7 @@
 
 **Ruby**
 
-Oj is compatible with Ruby 2.0.0, 2.1, 2.2, 2.3, 2.4 and RBX.
+Oj is compatible with Ruby 2.4+ and RBX.
 Support for JRuby has been removed as JRuby no longer supports C extensions and
 there are bugs in the older versions that are not being fixed.
 


### PR DESCRIPTION
Now, Oj has been supported ruby 2.4 or later.

https://github.com/ohler55/oj/blob/72d5565c291ee59f8636f37f810a39bdeaad2696/oj.gemspec#L23