### PR TITLE
Fix another seg fault in SAJ parser

### DIFF
--- a/ext/oj/saj2.c
+++ b/ext/oj/saj2.c
@@ -315,7 +315,7 @@ static void add_big_key(ojParser p) {
 }
 
 static void add_big_key_loc(ojParser p) {
-    rb_funcall((VALUE)p->ctx,
+    rb_funcall(((Delegate)p->ctx)->handler,
                oj_add_value_id,
                4,
                rb_funcall(rb_cObject, oj_bigdecimal_id, 1, rb_str_new(buf_str(&p->buf), buf_len(&p->buf))),

--- a/test/test_parser_saj.rb
+++ b/test/test_parser_saj.rb
@@ -160,6 +160,32 @@ class SajTest < Minitest::Test
     assert_equal(-118999, (handler.calls[0][1] * 10000).to_i)
   end
 
+  def test_bignum_loc
+    handler = LocSaj.new()
+    json = <<~JSON
+      {
+        "width": 192.33800000000002,
+        "xaxis": {
+          "anchor": "y"
+        }
+      }
+    JSON
+
+    p = Oj::Parser.new(:saj)
+    p.handler = handler
+    p.parse(json)
+    assert_equal(6, handler.calls.size)
+    assert_equal(1_923_380, (handler.calls[1][1] * 10000).to_i)
+    handler.calls[1][1] = 1_923_380
+    assert_equal([[:hash_start, nil, 1, 1],
+                  [:add_value, 1923380, 'width', 2, 30],
+                  [:hash_start, 'xaxis', 3, 12],
+                  [:add_value, 'y', 'anchor', 4, 17],
+                  [:hash_end, 'xaxis', 5, 3],
+                  [:hash_end, nil, 6, 1]],
+                 handler.calls)
+  end
+
   def test_array_empty
     handler = AllSaj.new()
     json = %{[]}


### PR DESCRIPTION
This seg fault only occurred if the SAJ parser handler tracked locations of hashes with Bignum values with inputs such as:

```json
          {
            "width": 192.33800000000002,
            "xaxis": {
              "anchor": "y"
            }
          }
```

This was missed in #799.