### PR TITLE
Remove most skips on TruffleRuby

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -83,7 +83,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '22.2.0' ]
+        ruby: [ 'head' ]
 
     env:
       BUNDLE_GEMFILE: gemfiles/no_rails.gemfile

--- a/Rakefile
+++ b/Rakefile
@@ -22,10 +22,6 @@ task :test_all => [:clean, :compile] do
   status = 0
 
   cmds = "ruby test/tests.rb -v && ruby test/tests_mimic.rb -v && ruby test/tests_mimic_addition.rb -v"
-  if RUBY_ENGINE == 'truffleruby'
-    # FIXME: Seems TruffleRuby doesn't load the library with `Oj.mimic_JSON` properly. Skip tests_mimic so far.
-    cmds = "ruby test/tests.rb -v"
-  end
 
   STDOUT.syswrite "\n#{'#'*90}\n#{cmds}\n"
   Bundler.with_original_env do

--- a/lib/oj/state.rb
+++ b/lib/oj/state.rb
@@ -80,7 +80,7 @@ module JSON
           # @param [Symbol] m method symbol
           # @return [Boolean] true for any method that matches an instance
           #                   variable reader, otherwise false.
-          def respond_to?(m)
+          def respond_to?(m, include_all = false)
             return true if super
             return true if has_key?(key)
             return true if has_key?(key.to_s)

--- a/test/json_gem/json_generator_test.rb
+++ b/test/json_gem/json_generator_test.rb
@@ -294,7 +294,9 @@ EOT
     assert_equal '2', state.indent
   end
 
-  if defined?(JSON::Ext::Generator)
+  if defined?(JSON::Ext::Generator) && Process.respond_to?(:fork)
+    # forking to avoid modifying core class of a parent process and
+    # introducing race conditions of tests are run in parallel
     def test_broken_bignum # [ruby-core:38867]
       pid = fork do
         x = 1 << 64
@@ -311,9 +313,6 @@ EOT
       end
       _, status = Process.waitpid2(pid)
       assert status.success?
-    rescue NotImplementedError
-      # forking to avoid modifying core class of a parent process and
-      # introducing race conditions of tests are run in parallel
     end
   end
 

--- a/test/json_gem/json_parser_test.rb
+++ b/test/json_gem/json_parser_test.rb
@@ -24,8 +24,6 @@ class JSONParserTest < Test::Unit::TestCase
   end if defined?(Encoding::UTF_16)
 
   def test_error_message_encoding
-    omit 'TruffleRuby causes NameError(<uninitialized constant JSON::Ext>)' if RUBY_ENGINE == 'truffleruby'
-
     bug10705 = '[ruby-core:67386] [Bug #10705]'
     json = ".\"\xE2\x88\x9A\"".force_encoding(Encoding::UTF_8)
     e = assert_raise(JSON::ParserError) {
@@ -33,7 +31,7 @@ class JSONParserTest < Test::Unit::TestCase
     }
     assert_equal(Encoding::UTF_8, e.message.encoding, bug10705)
     assert_include(e.message, json, bug10705)
-  end if defined?(Encoding::UTF_8)
+  end if defined?(Encoding::UTF_8) and defined?(JSON::Ext::Parser)
 
   def test_parsing
     parser = JSON::Parser.new('"test"')

--- a/test/test_custom.rb
+++ b/test/test_custom.rb
@@ -405,15 +405,11 @@ class CustomJuice < Minitest::Test
   end
 
   def test_range
-    skip 'TruffleRuby fails this spec' if RUBY_ENGINE == 'truffleruby'
-
     obj = 3..8
     dump_and_load(obj, false, :create_id => "^o", :create_additions => true)
   end
 
   def test_date
-    skip 'TruffleRuby causes SEGV' if RUBY_ENGINE == 'truffleruby'
-
     obj = Date.new(2017, 1, 5)
     dump_and_load(obj, false, :create_id => "^o", :create_additions => true)
   end
@@ -443,8 +439,6 @@ class CustomJuice < Minitest::Test
   end
 
   def test_datetime
-    skip 'TruffleRuby causes SEGV' if RUBY_ENGINE == 'truffleruby'
-
     obj = DateTime.new(2017, 1, 5, 10, 20, 30)
     dump_and_load(obj, false, :create_id => "^o", :create_additions => true)
   end

--- a/test/test_custom.rb
+++ b/test/test_custom.rb
@@ -260,8 +260,6 @@ class CustomJuice < Minitest::Test
   end
 
   def test_object
-    skip 'TruffleRuby fails this spec with `RuntimeError: rb_ivar_foreach not implemented`' if RUBY_ENGINE == 'truffleruby'
-
     obj = Jeez.new(true, 58)
     json = Oj.dump(obj, create_id: "^o", use_to_json: false, use_as_json: false, use_to_hash: false)
     assert_equal(%|{"x":true,"y":58,"_z":"true"}|, json)

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -125,15 +125,12 @@ class FileJuice < Minitest::Test
 
   # Time
   def test_time_object
-    skip 'TruffleRuby fails this spec' if RUBY_ENGINE == 'truffleruby'
-
     t = Time.now()
     Oj.default_options = { :mode => :object, :time_format => :unix_zone }
     dump_and_load(t, false)
   end
   def test_time_object_early
     skip 'Windows does not support dates before 1970.' if RbConfig::CONFIG['host_os'] =~ /(mingw|mswin)/
-    skip 'TruffleRuby fails this spec' if RUBY_ENGINE == 'truffleruby'
 
     t = Time.xmlschema("1954-01-05T00:00:00.123456")
     Oj.default_options = { :mode => :object, :time_format => :unix_zone }
@@ -165,14 +162,10 @@ class FileJuice < Minitest::Test
   def test_range_object
     Oj.default_options = { :mode => :object }
     json = Oj.dump(1..7, :mode => :object, :indent => 0)
-    if 'rubinius' == $ruby
-      assert(%{{"^O":"Range","begin":1,"end":7,"exclude_end?":false}} == json)
-    elsif 'jruby' == $ruby
-      assert(%{{"^O":"Range","begin":1,"end":7,"exclude_end?":false}} == json)
-    elsif 'truffleruby' == $ruby
-      assert(%{{"^O":"Range","begin":1,"end":7,"exclude_end?":false}} == json)
-    else
+    if $ruby == 'ruby'
       assert_equal(%{{"^u":["Range",1,7,false]}}, json)
+    else
+      assert(%{{"^O":"Range","begin":1,"end":7,"exclude_end?":false}} == json)
     end
     dump_and_load(1..7, false)
     dump_and_load(1..1, false)

--- a/test/test_gc.rb
+++ b/test/test_gc.rb
@@ -43,8 +43,6 @@ class GCTest < Minitest::Test
   end
 
   def test_parse_object_gc
-    skip 'TruffleRuby fails this spec with `RuntimeError: rb_ivar_foreach not implemented`' if RUBY_ENGINE == 'truffleruby'
-
     g = Goo.new(0, nil)
     100.times { |i| g = Goo.new(i, g) }
     json = Oj.dump(g, :mode => :object)

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -672,8 +672,6 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_json_anonymous_struct
-    skip 'TruffleRuby fails this spec with `TypeError: allocator undefined for Class`' if RUBY_ENGINE == 'truffleruby'
-
     s = Struct.new(:x, :y)
     obj = s.new(1, 2)
     json = Oj.dump(obj, :indent => 2, :mode => :object)
@@ -830,12 +828,10 @@ class ObjectJuice < Minitest::Test
   def test_range_object
     Oj.default_options = { :mode => :object }
     json = Oj.dump(1..7, :mode => :object, :indent => 0)
-    if 'rubinius' == $ruby
-      assert(%{{"^O":"Range","begin":1,"end":7,"exclude_end?":false}} == json)
-    elsif 'truffleruby' == $ruby
-      assert(%{{"^O":"Range","begin":1,"end":7,"exclude_end?":false}} == json)
-    else
+    if 'ruby' == $ruby
       assert_equal(%{{"^u":["Range",1,7,false]}}, json)
+    else
+      assert(%{{"^O":"Range","begin":1,"end":7,"exclude_end?":false}} == json)
     end
     dump_and_load(1..7, false)
     dump_and_load(1..1, false)

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -461,8 +461,6 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_json_module_object
-    skip 'TruffleRuby fails this spec with `RuntimeError: rb_ivar_foreach not implemented`' if RUBY_ENGINE == 'truffleruby'
-
     obj = One::Two::Three::Deep.new()
     dump_and_load(obj, false)
   end
@@ -633,15 +631,11 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_json_object
-    skip 'TruffleRuby fails this spec with `RuntimeError: rb_ivar_foreach not implemented`' if RUBY_ENGINE == 'truffleruby'
-
     obj = Jeez.new(true, 58)
     dump_and_load(obj, false)
   end
 
   def test_json_object_create_deep
-    skip 'TruffleRuby fails this spec with `RuntimeError: rb_ivar_foreach not implemented`' if RUBY_ENGINE == 'truffleruby'
-
     obj = One::Two::Three::Deep.new()
     dump_and_load(obj, false)
   end
@@ -702,8 +696,6 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_json_object_object
-    skip 'TruffleRuby fails this spec with `RuntimeError: rb_ivar_foreach not implemented`' if RUBY_ENGINE == 'truffleruby'
-
     obj = Jeez.new(true, 58)
     json = Oj.dump(obj, mode: :object, indent: 2, ignore_under: true)
     assert(%{{
@@ -723,8 +715,6 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_to_hash_object_object
-    skip 'TruffleRuby fails this spec with `RuntimeError: rb_ivar_foreach not implemented`' if RUBY_ENGINE == 'truffleruby'
-
     obj = Jazz.new(true, 58)
     json = Oj.dump(obj, :mode => :object, :indent => 2)
     assert(%{{
@@ -744,8 +734,6 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_as_json_object_object
-    skip 'TruffleRuby fails this spec with `RuntimeError: rb_ivar_foreach not implemented`' if RUBY_ENGINE == 'truffleruby'
-
     obj = Orange.new(true, 58)
     json = Oj.dump(obj, :mode => :object, :indent => 2)
     assert(%{{
@@ -765,8 +753,6 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_object_object_no_cache
-    skip 'TruffleRuby fails this spec with `RuntimeError: rb_ivar_foreach not implemented`' if RUBY_ENGINE == 'truffleruby'
-
     obj = Jam.new(true, 58)
     json = Oj.dump(obj, :mode => :object, :indent => 2)
     assert(%{{
@@ -795,8 +781,6 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_exception
-    skip 'TruffleRuby fails this spec with `RuntimeError: rb_ivar_foreach not implemented`' if RUBY_ENGINE == 'truffleruby'
-
     err = nil
     begin
       raise StandardError.new('A Message')
@@ -827,8 +811,6 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_exception_subclass
-    skip 'TruffleRuby fails this spec with `RuntimeError: rb_ivar_foreach not implemented`' if RUBY_ENGINE == 'truffleruby'
-
     err = nil
     begin
       raise SubX.new
@@ -917,8 +899,6 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_circular_object
-    skip 'TruffleRuby fails this spec with `RuntimeError: rb_ivar_foreach not implemented`' if RUBY_ENGINE == 'truffleruby'
-
     obj = Jeez.new(nil, 58)
     obj.x = obj
     json = Oj.dump(obj, :mode => :object, :indent => 2, :circular => true)
@@ -927,8 +907,6 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_circular_object2
-    skip 'TruffleRuby fails this spec with `RuntimeError: rb_ivar_foreach not implemented`' if RUBY_ENGINE == 'truffleruby'
-
     obj = Jam.new(nil, 58)
     obj.x = obj
     json = Oj.dump(obj, :mode => :object, :indent => 2, :circular => true)
@@ -951,8 +929,6 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_circular
-    skip 'TruffleRuby fails this spec with `RuntimeError: rb_ivar_foreach not implemented`' if RUBY_ENGINE == 'truffleruby'
-
     h = { 'a' => 7 }
     obj = Jeez.new(h, 58)
     obj.x['b'] = obj
@@ -963,8 +939,6 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_circular2
-    skip 'TruffleRuby fails this spec with `RuntimeError: rb_ivar_foreach not implemented`' if RUBY_ENGINE == 'truffleruby'
-
     h = { 'a' => 7 }
     obj = Jam.new(h, 58)
     obj.x['b'] = obj
@@ -977,8 +951,6 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_omit_nil
-    skip 'TruffleRuby fails this spec with `RuntimeError: rb_ivar_foreach not implemented`' if RUBY_ENGINE == 'truffleruby'
-
     jam = Jam.new({'a' => 1, 'b' => nil }, nil)
 
     json = Oj.dump(jam, :omit_nil => true, :mode => :object)
@@ -1033,22 +1005,16 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_auto_string
-    skip 'TruffleRuby fails this spec with `RuntimeError: rb_ivar_foreach not implemented`' if RUBY_ENGINE == 'truffleruby'
-
     s = AutoStrung.new("Pete", true)
     dump_and_load(s, false)
   end
 
   def test_auto_array
-    skip 'TruffleRuby fails this spec with `RuntimeError: rb_ivar_foreach not implemented`' if RUBY_ENGINE == 'truffleruby'
-
     a = AutoArray.new([1, 'abc', nil], true)
     dump_and_load(a, false)
   end
 
   def test_auto_hash
-    skip 'TruffleRuby fails this spec with `RuntimeError: rb_ivar_foreach not implemented`' if RUBY_ENGINE == 'truffleruby'
-
     h = AutoHash.new(nil, true)
     h['a'] = 1
     h['b'] = 2

--- a/test/test_scp.rb
+++ b/test/test_scp.rb
@@ -320,8 +320,7 @@ class ScpTest < Minitest::Test
   end
 
   def test_pipe
-    skip ' Windows does not support fork' if RbConfig::CONFIG['host_os'] =~ /(mingw|mswin)/
-    skip 'TruffleRuby fails this spec with `NotImplementedError: fork is not available`' if RUBY_ENGINE == 'truffleruby'
+    skip 'needs fork' unless Process.respond_to?(:fork)
 
     handler = AllHandler.new()
     json = %{{"one":true,"two":false}}
@@ -357,8 +356,7 @@ class ScpTest < Minitest::Test
   end
 
   def test_pipe_close
-    skip 'Windows does not support fork' if RbConfig::CONFIG['host_os'] =~ /(mingw|mswin)/
-    skip 'TruffleRuby fails this spec with `NotImplementedError: fork is not available`' if RUBY_ENGINE == 'truffleruby'
+    skip 'needs fork' unless Process.respond_to?(:fork)
 
     json = %{{"one":true,"two":false}}
     IO.pipe do |read_io, write_io|

--- a/test/test_various.rb
+++ b/test/test_various.rb
@@ -559,9 +559,6 @@ class Juice < Minitest::Test
   end
 
   def test_io_file
-    # Windows does not support fork
-    return if RbConfig::CONFIG['host_os'] =~ /(mingw|mswin)/
-
     src = { 'x' => true, 'y' => 58, 'z' => [1, 2, 3]}
     filename = File.join(File.dirname(__FILE__), 'open_file_test.json')
     File.open(filename, "w") { |f|
@@ -574,6 +571,8 @@ class Juice < Minitest::Test
   end
 
   def test_io_stream
+    skip 'needs fork' unless Process.respond_to?(:fork)
+
     IO.pipe do |r, w|
       if fork
 	r.close


### PR DESCRIPTION
From https://github.com/oracle/truffleruby/issues/2701 and https://github.com/ohler55/oj/pull/804.

Now the only skips on TruffleRuby are the 3 `test_deep_nest` and `CustomJuice#test_time` (different rounding).