### PR TITLE
Move GC verification to end of process in tests

### DIFF
--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -221,13 +221,6 @@ class ObjectJuice < Minitest::Test
 
   def teardown
     Oj.default_options = @default_options
-#=begin
-    if '3.1.0' <= RUBY_VERSION && !(RbConfig::CONFIG['host_os'] =~ /(mingw|mswin)/)
-      #Oj::debug_odd("teardown before GC.verify_compaction_references")
-      verify_gc_compaction
-      #Oj::debug_odd("teardown after GC.verify_compaction_references")
-    end
-#=end
   end
 
   def test_nil

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -22,3 +22,12 @@ require 'test_rails'
 require 'test_wab'
 require 'test_writer'
 require 'test_integer_range'
+
+at_exit do
+  require 'helper'
+  if '3.1.0' <= RUBY_VERSION && !(RbConfig::CONFIG['host_os'] =~ /(mingw|mswin)/)
+    #Oj::debug_odd("teardown before GC.verify_compaction_references")
+    verify_gc_compaction
+    #Oj::debug_odd("teardown after GC.verify_compaction_references")
+  end
+end

--- a/test/tests_mimic.rb
+++ b/test/tests_mimic.rb
@@ -12,3 +12,12 @@ require 'json_generator_test'
 require 'json_generic_object_test'
 require 'json_parser_test'
 require 'json_string_matching_test'
+
+at_exit do
+  require 'helper'
+  if '3.1.0' <= RUBY_VERSION && !(RbConfig::CONFIG['host_os'] =~ /(mingw|mswin)/)
+    #Oj::debug_odd("teardown before GC.verify_compaction_references")
+    verify_gc_compaction
+    #Oj::debug_odd("teardown after GC.verify_compaction_references")
+  end
+end

--- a/test/tests_mimic_addition.rb
+++ b/test/tests_mimic_addition.rb
@@ -5,3 +5,12 @@ $: << File.dirname(__FILE__)
 $: << File.join(File.dirname(__FILE__), 'json_gem')
 
 require 'json_addition_test'
+
+at_exit do
+  require 'helper'
+  if '3.1.0' <= RUBY_VERSION && !(RbConfig::CONFIG['host_os'] =~ /(mingw|mswin)/)
+    #Oj::debug_odd("teardown before GC.verify_compaction_references")
+    verify_gc_compaction
+    #Oj::debug_odd("teardown after GC.verify_compaction_references")
+  end
+end


### PR DESCRIPTION
Since Ruby 3.2.0, `GC.verify_compaction_references` has the change.
https://github.com/ruby/ruby/commit/a6dd859affc42b667279e513bb94fb75cfb133c1

If `expand_heap` is present, It will certainly try to expand the heap area on each calling.
We are calling it many time on `teardown`, and then Ruby process try to allocate a large amount of memory.
When a large amount of memory space is allocated, it takes a very long time to expand it at next time.
Finally, the test fails with a timeout on CI.

I think it would be sufficient to perform GC validation on survived object at end of process.
This change should eliminate failures on Ruby 3.2 CI lane.