### PR TITLE
Fix new parser interface

### DIFF
--- a/ext/oj/parser.c
+++ b/ext/oj/parser.c
@@ -1259,7 +1259,7 @@ static VALUE parser_new(int argc, VALUE *argv, VALUE self) {
 // from this function. A delegate must be added before the parser can be
 // used. Optionally oj_parser_set_options can be called if the options are not
 // set directly.
-VALUE oj_parser_new() {
+VALUE oj_parser_new(void(*init_function)(ojParser parser)) {
     ojParser p = ALLOC(struct _ojParser);
 
 #if HAVE_RB_EXT_RACTOR_SAFE
@@ -1270,6 +1270,8 @@ VALUE oj_parser_new() {
     buf_init(&p->key);
     buf_init(&p->buf);
     p->map = value_map;
+
+    init_function(p);
 
     return Data_Wrap_Struct(parser_class, parser_mark, parser_free, p);
 }

--- a/ext/oj/parser.h
+++ b/ext/oj/parser.h
@@ -93,7 +93,7 @@ typedef struct _ojParser {
 // from this function. A delegate must be added before the parser can be
 // used. Optionally oj_parser_set_options can be called if the options are not
 // set directly.
-extern VALUE oj_parser_new();
+extern VALUE oj_parser_new(void(*init_function)(ojParser parser));
 
 // Set set the options from a hash (ropts).
 extern void oj_parser_set_option(ojParser p, VALUE ropts);


### PR DESCRIPTION
Looks like changing the struct members after calling `Data_Wrap_Struct` is causing segfaults. We can solve this by changing the method signature of `oj_parser_new` to inject the dependency(parser special init function).

The current bug can be reproduced by the following steps on the `oj-introspect` project;

- Pull the latest changes
- Run `./bin/console`
- Execute the following on console: `50_000.times { Oj::Introspect.new.parse('{}') }`