### PR TITLE
Suppress "old style definition" warning

### DIFF
--- a/ext/oj/parser.c
+++ b/ext/oj/parser.c
@@ -1263,7 +1263,7 @@ static VALUE parser_new(int argc, VALUE *argv, VALUE self) {
 // from this function. A delegate must be added before the parser can be
 // used. Optionally oj_parser_set_options can be called if the options are not
 // set directly.
-VALUE oj_parser_new() {
+VALUE oj_parser_new(void) {
     ojParser p = ALLOC(struct _ojParser);
 
 #if HAVE_RB_EXT_RACTOR_SAFE


### PR DESCRIPTION
This patch will suppress following warning message when compile oj with GCC 12.

```
$ cd ext/oj
$ ruby extconf.rb
$ gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-pc-linux-gnu/12.2.0/lto-wrapper
Target: x86_64-pc-linux-gnu
Configured with: /build/gcc/src/gcc/configure --enable-languages=c,c++,ada,fortran,go,lto,objc,obj-c++,d --enable-bootstrap --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://bugs.archlinux.org/ --with-build-config=bootstrap-lto --with-linker-hash-style=gnu --with-system-zlib --enable-__cxa_atexit --enable-cet=auto --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-default-ssp --enable-gnu-indirect-function --enable-gnu-unique-object --enable-libstdcxx-backtrace --enable-link-serialization=1 --enable-linker-build-id --enable-lto --enable-multilib --enable-plugin --enable-shared --enable-threads=posix --disable-libssp --disable-libstdcxx-pch --disable-werror
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 12.2.0 (GCC) 


$ make
compiling cache.c
compiling cache8.c
compiling circarray.c
compiling code.c
compiling compat.c
compiling custom.c
compiling debug.c
compiling dump.c
compiling dump_compat.c
compiling dump_leaf.c
compiling dump_object.c
compiling dump_strict.c
compiling err.c
compiling fast.c
compiling intern.c
compiling mimic_json.c
compiling object.c
compiling odd.c
compiling oj.c
compiling parse.c
compiling parser.c
parser.c: In function 'oj_parser_new':
parser.c:1266:7: warning: old-style function definition [-Wold-style-definition]
 1266 | VALUE oj_parser_new() {
      |       ^~~~~~~~~~~~~
At top level:
cc1: note: unrecognized command-line option '-Wno-self-assign' may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option '-Wno-parentheses-equality' may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option '-Wno-constant-logical-operand' may have been intended to silence earlier diagnostics
compiling rails.c
...

```