### PR TITLE
Fix build error with SSE 4.2 flag

### DIFF
--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -16,6 +16,10 @@
 #include "rxclass.h"
 #include "val_stack.h"
 
+#ifdef OJ_USE_SSE4_2
+#include <nmmintrin.h>
+#endif
+
 // Workaround in case INFINITY is not defined in math.h or if the OS is CentOS
 #define OJ_INFINITY (1.0 / 0.0)
 


### PR DESCRIPTION
This patch will fix follwing build error at installation:

```
$ gem install oj -- --with-sse42
Building native extensions with: '--with-sse42'
This could take a while...
ERROR:  Error installing oj:
        ERROR: Failed to build gem native extension.

    current directory: /home/watson/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/oj-3.13.23/ext/oj
/home/watson/.rbenv/versions/3.1.3/bin/ruby -I /home/watson/.rbenv/versions/3.1.3/lib/ruby/3.1.0 extconf.rb --with-sse42
>>>>> Creating Makefile for ruby version 3.1.3 on x86_64-linux <<<<<
checking for rb_gc_mark_movable()... yes
checking for stpcpy()... yes
checking for pthread_mutex_init()... yes
checking for rb_enc_interned_str()... yes
checking for rb_ext_ractor_safe() in ruby.h... yes
checking for rb_hash_bulk_insert() in ruby.h... yes
creating Makefile

current directory: /home/watson/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/oj-3.13.23/ext/oj
make DESTDIR\= sitearchdir\=./.gem.20221204-68498-j3f6nt sitelibdir\=./.gem.20221204-68498-j3f6nt clean

current directory: /home/watson/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/oj-3.13.23/ext/oj
make DESTDIR\= sitearchdir\=./.gem.20221204-68498-j3f6nt sitelibdir\=./.gem.20221204-68498-j3f6nt
compiling cache.c
compiling cache8.c
compiling circarray.c
compiling code.c
compiling compat.c
compiling custom.c
compiling debug.c
compiling dump.c
compiling dump_compat.c
compiling dump_leaf.c
compiling dump_object.c
compiling dump_strict.c
compiling encoder.c
compiling err.c
compiling fast.c
compiling intern.c
compiling mimic_json.c
compiling object.c
compiling odd.c
compiling oj.c
compiling parse.c
parse.c: In function 'scan_string_SIMD':
parse.c:198:11: error: unknown type name '__m128i'
  198 |     const __m128i terminate = _mm_loadu_si128((const __m128i *)&chars[0]);
      |           ^~~~~~~
parse.c:198:31: warning: implicit declaration of function '_mm_loadu_si128' [-Wimplicit-function-declaration]
  198 |     const __m128i terminate = _mm_loadu_si128((const __m128i *)&chars[0]);
      |                               ^~~~~~~~~~~~~~~
parse.c:198:54: error: unknown type name '__m128i'
  198 |     const __m128i terminate = _mm_loadu_si128((const __m128i *)&chars[0]);
      |                                                      ^~~~~~~
parse.c:202:15: error: unknown type name '__m128i'
  202 |         const __m128i string = _mm_loadu_si128((const __m128i *)str);
      |               ^~~~~~~
parse.c:202:55: error: unknown type name '__m128i'
  202 |         const __m128i string = _mm_loadu_si128((const __m128i *)str);
      |                                                       ^~~~~~~
parse.c:203:23: warning: implicit declaration of function '_mm_cmpestri' [-Wimplicit-function-declaration]
  203 |         const int r = _mm_cmpestri(terminate, 3, string, 16, _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_ANY | _SIDD_LEAST_SIGNIFICANT);
      |                       ^~~~~~~~~~~~
parse.c:203:62: error: '_SIDD_UBYTE_OPS' undeclared (first use in this function)
  203 |         const int r = _mm_cmpestri(terminate, 3, string, 16, _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_ANY | _SIDD_LEAST_SIGNIFICANT);
      |                                                              ^~~~~~~~~~~~~~~
parse.c:203:62: note: each undeclared identifier is reported only once for each function it appears in
parse.c:203:80: error: '_SIDD_CMP_EQUAL_ANY' undeclared (first use in this function)
  203 |         const int r = _mm_cmpestri(terminate, 3, string, 16, _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_ANY | _SIDD_LEAST_SIGNIFICANT);
      |                                                                                ^~~~~~~~~~~~~~~~~~~
parse.c:203:102: error: '_SIDD_LEAST_SIGNIFICANT' undeclared (first use in this function)
  203 |         const int r = _mm_cmpestri(terminate, 3, string, 16, _SIDD_UBYTE_OPS | _SIDD_CMP_EQUAL_ANY | _SIDD_LEAST_SIGNIFICANT);
      |                                                                                                      ^~~~~~~~~~~~~~~~~~~~~~~
At top level:
cc1: note: unrecognized command-line option '-Wno-self-assign' may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option '-Wno-parentheses-equality' may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option '-Wno-constant-logical-operand' may have been intended to silence earlier diagnostics
make: *** [Makefile:247: parse.o] Error 1

make failed, exit code 2

Gem files will remain installed in /home/watson/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/oj-3.13.23 for inspection.
Results logged to /home/watson/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/extensions/x86_64-linux/3.1.0/oj-3.13.23/gem_make.out
```