### PR TITLE
Fix precision of float for Ruby compatibility

### DIFF
--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -25,7 +25,7 @@
 
 //#define EXP_MAX		1023
 #define EXP_MAX 100000
-#define DEC_MAX 15
+#define DEC_MAX 16
 
 static void next_non_white(ParseInfo pi) {
     for (; 1; pi->cur++) {

--- a/ext/oj/sparse.c
+++ b/ext/oj/sparse.c
@@ -23,7 +23,7 @@
 #define NUM_MAX (FIXNUM_MAX >> 8)
 #endif
 #define EXP_MAX 100000
-#define DEC_MAX 15
+#define DEC_MAX 16
 
 static void skip_comment(ParseInfo pi) {
     char c = reader_get(&pi->rd);

--- a/test/test_compat.rb
+++ b/test/test_compat.rb
@@ -136,6 +136,10 @@ class CompatJuice < Minitest::Test
     dump_and_load(73.4, false)
     dump_and_load(80.6, false)
     dump_and_load(-95.640172, false)
+    dump_and_load(43.418052999999986, false)
+    dump_and_load(-59.879722999999956, false)
+    dump_and_load(129.51779199999993, false)
+    dump_and_load(-124.65611299999989, false)
   end
 
   def test_string

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -91,6 +91,13 @@ class FileJuice < Minitest::Test
     dump_and_load(2.48e100 * 1.0e10, false)
     dump_and_load(-2.48e100 * 1.0e10, false)
     dump_and_load(1/0.0, false)
+
+    Oj.default_options = {:mode => :compat}
+    dump_and_load(43.418052999999986, false)
+    dump_and_load(-59.879722999999956, false)
+    dump_and_load(129.51779199999993, false)
+    dump_and_load(-124.65611299999989, false)
+
     Oj.default_options = {:mode => mode}
   end
 


### PR DESCRIPTION
The object class is incompatible with Ruby's JSON when parsing a float with many decimal places. This patch will fix this compatibility.

## Test code
```ruby
require 'oj'
require 'json'

data = [
  43.418052999999986,
  -59.879722999999956,
  -124.65611299999989,
  129.51779199999993,
]

data.each do |flo|
  json = flo.to_json
  d1 = JSON.parse(json)
  d2 = Oj.load(json)
  puts "[#{json.rjust(19)}] d1: #{d1.class} = #{d1.to_s.rjust(19)}, d2: #{d2.class} = #{d2.to_s.rjust(22)} :: same = #{d1 == d2}"
end
```

## Before
```
[ 43.418052999999986] d1: Float =  43.418052999999986, d2: BigDecimal =  0.43418052999999986e2 :: same = false
[-59.879722999999956] d1: Float = -59.879722999999956, d2: BigDecimal = -0.59879722999999956e2 :: same = false
[-124.65611299999989] d1: Float = -124.65611299999989, d2: BigDecimal = -0.12465611299999989e3 :: same = false
[ 129.51779199999993] d1: Float =  129.51779199999993, d2: BigDecimal =  0.12951779199999993e3 :: same = false
```

## After
```
[ 43.418052999999986] d1: Float =  43.418052999999986, d2: Float =     43.418052999999986 :: same = true
[-59.879722999999956] d1: Float = -59.879722999999956, d2: Float =    -59.879722999999956 :: same = true
[-124.65611299999989] d1: Float = -124.65611299999989, d2: Float =    -124.65611299999989 :: same = true
[ 129.51779199999993] d1: Float =  129.51779199999993, d2: Float =     129.51779199999993 :: same = true
```