### PR TITLE
Add a guard for SSE 4.2 feature

### DIFF
--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -35,8 +35,12 @@ have_func('rb_hash_bulk_insert', 'ruby.h') unless '2' == version[0] && '6' == ve
 dflags['OJ_DEBUG'] = true unless ENV['OJ_DEBUG'].nil?
 
 if with_config('--with-sse42')
-  $CPPFLAGS += ' -msse4.2'
-  dflags['OJ_USE_SSE4_2'] = 1
+  if try_cflags('-msse4.2')
+    $CPPFLAGS += ' -msse4.2'
+    dflags['OJ_USE_SSE4_2'] = 1
+  else
+    warn 'SSE 4.2 is not supported on this platform.'
+  end
 end
 
 if enable_config('trace-log', false)


### PR DESCRIPTION
On platform using ARM CPU such as Apple M1/M2, it causes build error (see below logs) with ` --with-sse42`.
So this patch adds a guard for Apple M1/M2.

```
$ gem install pkg/oj-3.14.0.gem -- --with-sse42
Building native extensions with: '--with-sse42'
This could take a while...
ERROR:  Error installing pkg/oj-3.14.0.gem:
	ERROR: Failed to build gem native extension.

    current directory: /Users/watson/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/oj-3.14.0/ext/oj
/Users/watson/.rbenv/versions/3.2.0/bin/ruby -I /Users/watson/.rbenv/versions/3.2.0/lib/ruby/3.2.0 extconf.rb --with-sse42
>>>>> Creating Makefile for ruby version 3.2.0 on arm64-darwin22 <<<<<
checking for rb_gc_mark_movable()... yes
checking for stpcpy()... yes
checking for pthread_mutex_init()... yes
checking for rb_enc_interned_str()... yes
checking for rb_ext_ractor_safe() in ruby.h... yes
checking for rb_hash_bulk_insert() in ruby.h... yes
creating Makefile

current directory: /Users/watson/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/oj-3.14.0/ext/oj
make DESTDIR\= sitearchdir\=./.gem.20230121-12023-q5yos0 sitelibdir\=./.gem.20230121-12023-q5yos0 clean

current directory: /Users/watson/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/oj-3.14.0/ext/oj
make DESTDIR\= sitearchdir\=./.gem.20230121-12023-q5yos0 sitelibdir\=./.gem.20230121-12023-q5yos0
compiling cache.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
compiling cache8.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
compiling circarray.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
compiling code.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
compiling compat.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
compiling custom.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
compiling debug.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
compiling dump.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
compiling dump_compat.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
compiling dump_leaf.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
compiling dump_object.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
compiling dump_strict.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
compiling err.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
compiling fast.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
compiling intern.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
compiling mimic_json.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
compiling object.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
compiling odd.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
compiling oj.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
compiling parse.c
clang: warning: argument unused during compilation: '-msse4.2' [-Wunused-command-line-argument]
In file included from parse.c:20:
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/nmmintrin.h:14:2: error: "This header is only meant to be used on x86 and x64 architecture"
#error "This header is only meant to be used on x86 and x64 architecture"
 ^
In file included from parse.c:20:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/nmmintrin.h:19:
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/smmintrin.h:14:2: error: "This header is only meant to be used on x86 and x64 architecture"
#error "This header is only meant to be used on x86 and x64 architecture"
 ^
In file included from parse.c:20:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/nmmintrin.h:19:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/smmintrin.h:17:
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/tmmintrin.h:14:2: error: "This header is only meant to be used on x86 and x64 architecture"
#error "This header is only meant to be used on x86 and x64 architecture"
 ^
In file included from parse.c:20:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/nmmintrin.h:19:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/smmintrin.h:17:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/tmmintrin.h:17:
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/pmmintrin.h:14:2: error: "This header is only meant to be used on x86 and x64 architecture"
#error "This header is only meant to be used on x86 and x64 architecture"
 ^
In file included from parse.c:20:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/nmmintrin.h:19:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/smmintrin.h:17:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/tmmintrin.h:17:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/pmmintrin.h:17:
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:14:2: error: "This header is only meant to be used on x86 and x64 architecture"
#error "This header is only meant to be used on x86 and x64 architecture"
 ^
In file included from parse.c:20:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/nmmintrin.h:19:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/smmintrin.h:17:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/tmmintrin.h:17:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/pmmintrin.h:17:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:17:
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/xmmintrin.h:14:2: error: "This header is only meant to be used on x86 and x64 architecture"
#error "This header is only meant to be used on x86 and x64 architecture"
 ^
In file included from parse.c:20:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/nmmintrin.h:19:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/smmintrin.h:17:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/tmmintrin.h:17:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/pmmintrin.h:17:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/emmintrin.h:17:
In file included from /Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/xmmintrin.h:17:
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/mmintrin.h:14:2: error: "This header is only meant to be used on x86 and x64 architecture"
#error "This header is only meant to be used on x86 and x64 architecture"
 ^
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/mmintrin.h:54:12: error: invalid conversion between vector type '__m64' (vector of 1 'long long' value) and integer type 'int' of different size
    return (__m64)__builtin_ia32_vec_init_v2si(__i, 0);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/mmintrin.h:133:12: error: invalid conversion between vector type '__m64' (vector of 1 'long long' value) and integer type 'int' of different size
    return (__m64)__builtin_ia32_packsswb((__v4hi)__m1, (__v4hi)__m2);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/mmintrin.h:163:12: error: invalid conversion between vector type '__m64' (vector of 1 'long long' value) and integer type 'int' of different size
    return (__m64)__builtin_ia32_packssdw((__v2si)__m1, (__v2si)__m2);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/mmintrin.h:193:12: error: invalid conversion between vector type '__m64' (vector of 1 'long long' value) and integer type 'int' of different size
    return (__m64)__builtin_ia32_packuswb((__v4hi)__m1, (__v4hi)__m2);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/mmintrin.h:220:12: error: invalid conversion between vector type '__m64' (vector of 1 'long long' value) and integer type 'int' of different size
    return (__m64)__builtin_ia32_punpckhbw((__v8qi)__m1, (__v8qi)__m2);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/mmintrin.h:243:12: error: invalid conversion between vector type '__m64' (vector of 1 'long long' value) and integer type 'int' of different size
    return (__m64)__builtin_ia32_punpckhwd((__v4hi)__m1, (__v4hi)__m2);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/mmintrin.h:264:12: error: invalid conversion between vector type '__m64' (vector of 1 'long long' value) and integer type 'int' of different size
    return (__m64)__builtin_ia32_punpckhdq((__v2si)__m1, (__v2si)__m2);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/mmintrin.h:291:12: error: invalid conversion between vector type '__m64' (vector of 1 'long long' value) and integer type 'int' of different size
    return (__m64)__builtin_ia32_punpcklbw((__v8qi)__m1, (__v8qi)__m2);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/mmintrin.h:314:12: error: invalid conversion between vector type '__m64' (vector of 1 'long long' value) and integer type 'int' of different size
    return (__m64)__builtin_ia32_punpcklwd((__v4hi)__m1, (__v4hi)__m2);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/mmintrin.h:335:12: error: invalid conversion between vector type '__m64' (vector of 1 'long long' value) and integer type 'int' of different size
    return (__m64)__builtin_ia32_punpckldq((__v2si)__m1, (__v2si)__m2);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/mmintrin.h:356:12: error: invalid conversion between vector type '__m64' (vector of 1 'long long' value) and integer type 'int' of different size
    return (__m64)__builtin_ia32_paddb((__v8qi)__m1, (__v8qi)__m2);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode-14.2.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/clang/14.0.0/include/mmintrin.h:377:12: error: invalid conversion between vector type '__m64' (vector of 1 'long long' value) and integer type 'int' of different size
    return (__m64)__builtin_ia32_paddw((__v4hi)__m1, (__v4hi)__m2);
           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
make: *** [parse.o] Error 1

make failed, exit code 2

Gem files will remain installed in /Users/watson/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/oj-3.14.0 for inspection.
Results logged to /Users/watson/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/extensions/arm64-darwin-22/3.2.0/oj-3.14.0/gem_make.out
```