### PR TITLE
Fix SEGV if to_s method returns invalid object

### DIFF
--- a/ext/oj/custom.c
+++ b/ext/oj/custom.c
@@ -24,20 +24,20 @@ static void dump_obj_str(VALUE obj, int depth, Out out) {
         {"s", 1, Qnil},
         {NULL, 0, Qnil},
     };
-    attrs->value = rb_funcall(obj, oj_to_s_id, 0);
+    attrs->value = oj_safe_string_convert(obj);
 
     oj_code_attrs(obj, attrs, depth, out, Yes == out->opts->create_ok);
 }
 
 static void dump_obj_as_str(VALUE obj, int depth, Out out) {
-    volatile VALUE rstr = rb_funcall(obj, oj_to_s_id, 0);
+    volatile VALUE rstr = oj_safe_string_convert(obj);
     const char    *str  = RSTRING_PTR(rstr);
 
     oj_dump_cstr(str, RSTRING_LEN(rstr), 0, 0, out);
 }
 
 static void bigdecimal_dump(VALUE obj, int depth, Out out) {
-    volatile VALUE rstr = rb_funcall(obj, oj_to_s_id, 0);
+    volatile VALUE rstr = oj_safe_string_convert(obj);
     const char    *str  = RSTRING_PTR(rstr);
     int            len  = (int)RSTRING_LEN(rstr);
 
@@ -305,7 +305,7 @@ static int hash_cb(VALUE key, VALUE value, VALUE ov) {
     switch (rb_type(key)) {
     case T_STRING: oj_dump_str(key, 0, out, false); break;
     case T_SYMBOL: oj_dump_sym(key, 0, out, false); break;
-    default: oj_dump_str(rb_funcall(key, oj_to_s_id, 0), 0, out, false); break;
+    default: oj_dump_str(oj_safe_string_convert(key), 0, out, false); break;
     }
     if (!out->opts->dump_opts.use) {
         *out->cur++ = ':';
@@ -506,7 +506,7 @@ static VALUE dump_common(VALUE obj, int depth, Out out) {
         TRACE(out->opts->trace, "as_json", obj, depth + 1, TraceRubyOut);
         // Catch the obvious brain damaged recursive dumping.
         if (aj == obj) {
-            volatile VALUE rstr = rb_funcall(obj, oj_to_s_id, 0);
+            volatile VALUE rstr = oj_safe_string_convert(obj);
 
             oj_dump_cstr(RSTRING_PTR(rstr), (int)RSTRING_LEN(rstr), false, false, out);
         } else {

--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -463,7 +463,7 @@ void oj_dump_time(VALUE obj, Out out, int withZone) {
 }
 
 void oj_dump_ruby_time(VALUE obj, Out out) {
-    volatile VALUE rstr = rb_funcall(obj, oj_to_s_id, 0);
+    volatile VALUE rstr = oj_safe_string_convert(obj);
 
     oj_dump_cstr(RSTRING_PTR(rstr), (int)RSTRING_LEN(rstr), 0, 0, out);
 }
@@ -928,7 +928,7 @@ void oj_dump_class(VALUE obj, int depth, Out out, bool as_ok) {
 }
 
 void oj_dump_obj_to_s(VALUE obj, Out out) {
-    volatile VALUE rstr = rb_funcall(obj, oj_to_s_id, 0);
+    volatile VALUE rstr = oj_safe_string_convert(obj);
 
     oj_dump_cstr(RSTRING_PTR(rstr), (int)RSTRING_LEN(rstr), 0, 0, out);
 }
@@ -1169,7 +1169,7 @@ void oj_dump_float(VALUE obj, int depth, Out out, bool as_ok) {
     } else if (d == (double)(long long int)d) {
         cnt = snprintf(buf, sizeof(buf), "%.1f", d);
     } else if (0 == out->opts->float_prec) {
-        volatile VALUE rstr = rb_funcall(obj, oj_to_s_id, 0);
+        volatile VALUE rstr = oj_safe_string_convert(obj);
 
         cnt = (int)RSTRING_LEN(rstr);
         if ((int)sizeof(buf) <= cnt) {
@@ -1191,7 +1191,7 @@ int oj_dump_float_printf(char *buf, size_t blen, VALUE obj, double d, const char
     // Round off issues at 16 significant digits so check for obvious ones of
     // 0001 and 9999.
     if (17 <= cnt && (0 == strcmp("0001", buf + cnt - 4) || 0 == strcmp("9999", buf + cnt - 4))) {
-        volatile VALUE rstr = rb_funcall(obj, oj_to_s_id, 0);
+        volatile VALUE rstr = oj_safe_string_convert(obj);
 
         strcpy(buf, RSTRING_PTR(rstr));
         cnt = (int)RSTRING_LEN(rstr);

--- a/ext/oj/dump_compat.c
+++ b/ext/oj/dump_compat.c
@@ -295,7 +295,7 @@ datetime_alt(VALUE obj, int depth, Out out) {
     attrs[3].value = rb_funcall(obj, hour_id, 0);
     attrs[4].value = rb_funcall(obj, min_id, 0);
     attrs[5].value = rb_funcall(obj, sec_id, 0);
-    attrs[6].value = rb_funcall(rb_funcall(obj, offset_id, 0), oj_to_s_id, 0);
+    attrs[6].value = oj_safe_string_convert(rb_funcall(obj, offset_id, 0));
     attrs[7].value = rb_funcall(obj, start_id, 0);
 
     oj_code_attrs(obj, attrs, depth, out, true);
@@ -602,7 +602,7 @@ dump_float(VALUE obj, int depth, Out out, bool as_ok) {
     } else if (oj_rails_float_opt) {
 	cnt = oj_dump_float_printf(buf, sizeof(buf), obj, d, "%0.16g");
     } else {
-	volatile VALUE	rstr = rb_funcall(obj, oj_to_s_id, 0);
+	volatile VALUE	rstr = oj_safe_string_convert(obj);
 
 	strcpy(buf, RSTRING_PTR(rstr));
 	cnt = (int)RSTRING_LEN(rstr);
@@ -644,7 +644,7 @@ hash_cb(VALUE key, VALUE value, VALUE ov) {
 	break;
     default:
 	/*rb_raise(rb_eTypeError, "In :compat mode all Hash keys must be Strings or Symbols, not %s.\n", rb_class2name(rb_obj_class(key)));*/
-	oj_dump_str(rb_funcall(key, oj_to_s_id, 0), 0, out, false);
+	oj_dump_str(oj_safe_string_convert(key), 0, out, false);
 	break;
     }
     if (!out->opts->dump_opts.use) {
@@ -829,7 +829,7 @@ dump_bignum(VALUE obj, int depth, Out out, bool as_ok) {
     if (use_bignum_alt) {
 	rs = rb_big2str(obj, 10);
     } else {
-	rs = rb_funcall(obj, oj_to_s_id, 0);
+	rs = oj_safe_string_convert(obj);
     }
     rb_check_type(rs, T_STRING);
     cnt = (int)RSTRING_LEN(rs);

--- a/ext/oj/dump_object.c
+++ b/ext/oj/dump_object.c
@@ -30,7 +30,7 @@ static void dump_data(VALUE obj, int depth, Out out, bool as_ok) {
         *out->cur   = '\0';
     } else {
         if (oj_bigdecimal_class == clas) {
-            volatile VALUE rstr = rb_funcall(obj, oj_to_s_id, 0);
+            volatile VALUE rstr = oj_safe_string_convert(obj);
             const char *   str  = RSTRING_PTR(rstr);
             int            len  = (int)RSTRING_LEN(rstr);
 
@@ -59,7 +59,7 @@ static void dump_obj(VALUE obj, int depth, Out out, bool as_ok) {
     VALUE clas = rb_obj_class(obj);
 
     if (oj_bigdecimal_class == clas) {
-        volatile VALUE rstr = rb_funcall(obj, oj_to_s_id, 0);
+        volatile VALUE rstr = oj_safe_string_convert(obj);
         const char *   str  = RSTRING_PTR(rstr);
         int            len  = (int)RSTRING_LEN(rstr);
 

--- a/ext/oj/dump_strict.c
+++ b/ext/oj/dump_strict.c
@@ -92,7 +92,7 @@ static void dump_float(VALUE obj, int depth, Out out, bool as_ok) {
         } else if (d == (double)(long long int)d) {
             cnt = snprintf(buf, sizeof(buf), "%.1f", d);
         } else if (0 == out->opts->float_prec) {
-            volatile VALUE rstr = rb_funcall(obj, oj_to_s_id, 0);
+            volatile VALUE rstr = oj_safe_string_convert(obj);
 
             cnt = (int)RSTRING_LEN(rstr);
             if ((int)sizeof(buf) <= cnt) {
@@ -290,7 +290,7 @@ static void dump_data_strict(VALUE obj, int depth, Out out, bool as_ok) {
     VALUE clas = rb_obj_class(obj);
 
     if (oj_bigdecimal_class == clas) {
-        volatile VALUE rstr = rb_funcall(obj, oj_to_s_id, 0);
+        volatile VALUE rstr = oj_safe_string_convert(obj);
 
         oj_dump_raw(RSTRING_PTR(rstr), (int)RSTRING_LEN(rstr), out);
     } else {
@@ -302,7 +302,7 @@ static void dump_data_null(VALUE obj, int depth, Out out, bool as_ok) {
     VALUE clas = rb_obj_class(obj);
 
     if (oj_bigdecimal_class == clas) {
-        volatile VALUE rstr = rb_funcall(obj, oj_to_s_id, 0);
+        volatile VALUE rstr = oj_safe_string_convert(obj);
 
         oj_dump_raw(RSTRING_PTR(rstr), (int)RSTRING_LEN(rstr), out);
     } else {

--- a/ext/oj/oj.h
+++ b/ext/oj/oj.h
@@ -379,6 +379,12 @@ extern bool oj_use_hash_alt;
 extern bool oj_use_array_alt;
 extern bool string_writer_optimized;
 
+static inline VALUE oj_safe_string_convert(VALUE obj) {
+    VALUE rstr = rb_funcall(obj, oj_to_s_id, 0);
+    StringValue(rstr);
+    return rstr;
+}
+
 #define APPEND_CHARS(buffer, chars, size) \
     { \
         memcpy(buffer, chars, size); \

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -198,7 +198,7 @@ static void dump_enumerable(VALUE obj, int depth, Out out, bool as_ok) {
 }
 
 static void dump_bigdecimal(VALUE obj, int depth, Out out, bool as_ok) {
-    volatile VALUE rstr = rb_funcall(obj, oj_to_s_id, 0);
+    volatile VALUE rstr = oj_safe_string_convert(obj);
     const char *   str  = RSTRING_PTR(rstr);
 
     if ('I' == *str || 'N' == *str || ('-' == *str && 'I' == str[1])) {
@@ -345,7 +345,7 @@ static void dump_timewithzone(VALUE obj, int depth, Out out, bool as_ok) {
 }
 
 static void dump_to_s(VALUE obj, int depth, Out out, bool as_ok) {
-    volatile VALUE rstr = rb_funcall(obj, oj_to_s_id, 0);
+    volatile VALUE rstr = oj_safe_string_convert(obj);
 
     oj_dump_cstr(RSTRING_PTR(rstr), (int)RSTRING_LEN(rstr), 0, 0, out);
 }
@@ -377,7 +377,7 @@ static StrLen columns_array(VALUE rcols, int *ccnt) {
     for (i = 0, cp = cols; i < cnt; i++, cp++) {
         v = RARRAY_AREF(rcols, i);
         if (T_STRING != rb_type(v)) {
-            v = rb_funcall(v, oj_to_s_id, 0);
+            v = oj_safe_string_convert(v);
         }
         cp->str = StringValuePtr(v);
         cp->len = (int)RSTRING_LEN(v);
@@ -1204,7 +1204,7 @@ static void dump_float(VALUE obj, int depth, Out out, bool as_ok) {
         } else if (oj_rails_float_opt) {
             cnt = oj_dump_float_printf(buf, sizeof(buf), obj, d, "%0.16g");
         } else {
-            volatile VALUE rstr = rb_funcall(obj, oj_to_s_id, 0);
+            volatile VALUE rstr = oj_safe_string_convert(obj);
 
             strcpy(buf, RSTRING_PTR(rstr));
             cnt = (int)RSTRING_LEN(rstr);
@@ -1297,7 +1297,7 @@ static int hash_cb(VALUE key, VALUE value, VALUE ov) {
         return ST_CONTINUE;
     }
     if (rtype != T_STRING && rtype != T_SYMBOL) {
-        key   = rb_funcall(key, oj_to_s_id, 0);
+        key   = oj_safe_string_convert(key);
         rtype = rb_type(key);
     }
     if (!out->opts->dump_opts.use) {

--- a/ext/oj/reader.c
+++ b/ext/oj/reader.c
@@ -75,7 +75,7 @@ void oj_reader_init(Reader reader, VALUE io, int fd, bool to_s) {
         reader->read_func = read_from_io;
         reader->io        = io;
     } else if (to_s) {
-        volatile VALUE rstr = rb_funcall(io, oj_to_s_id, 0);
+        volatile VALUE rstr = oj_safe_string_convert(io);
 
         reader->read_func = 0;
         reader->in_str    = StringValuePtr(rstr);

--- a/ext/oj/wab.c
+++ b/ext/oj/wab.c
@@ -226,13 +226,13 @@ static void dump_obj(VALUE obj, int depth, Out out, bool as_ok) {
     if (rb_cTime == clas) {
         dump_time(obj, out);
     } else if (oj_bigdecimal_class == clas) {
-        volatile VALUE rstr = rb_funcall(obj, oj_to_s_id, 0);
+        volatile VALUE rstr = oj_safe_string_convert(obj);
 
         oj_dump_raw(RSTRING_PTR(rstr), (int)RSTRING_LEN(rstr), out);
     } else if (resolve_wab_uuid_class() == clas) {
-        oj_dump_str(rb_funcall(obj, oj_to_s_id, 0), depth, out, false);
+        oj_dump_str(oj_safe_string_convert(obj), depth, out, false);
     } else if (resolve_uri_http_class() == clas) {
-        oj_dump_str(rb_funcall(obj, oj_to_s_id, 0), depth, out, false);
+        oj_dump_str(oj_safe_string_convert(obj), depth, out, false);
     } else {
         raise_wab(obj);
     }

--- a/test/test_compat.rb
+++ b/test/test_compat.rb
@@ -513,6 +513,15 @@ class CompatJuice < Minitest::Test
     assert_equal("aaaa\nbbbb\rcccc\tddd\feee\bf/\\ぴーたー             ", Oj.load(json))
   end
 
+  def test_invalid_to_s
+    obj = Object.new
+    def obj.to_s
+      nil
+    end
+
+    assert_raises(TypeError) { Oj.dump(obj, mode: :compat) }
+  end
+
   def dump_and_load(obj, trace=false)
     json = Oj.dump(obj)
     puts json if trace


### PR DESCRIPTION
Fix https://github.com/ohler55/oj/issues/834

In Ruby, it can easily override the `to_s` method and it may not return a string as expected (rarely).
This PR will check the object using `StringValue`  whether it is a string object as expected after calling `to_s`.