### PR TITLE
Update the URL of build status badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # [![{}j](http://www.ohler.com/dev/images/oj_comet_64.svg)](http://www.ohler.com/oj) gem
 
-[![Build Status](https://img.shields.io/github/workflow/status/ohler55/oj/CI?logo=github)](https://github.com/ohler55/oj/actions/workflows/CI.yml)
+[![CI](https://github.com/ohler55/oj/actions/workflows/CI.yml/badge.svg)](https://github.com/ohler55/oj/actions/workflows/CI.yml)
 ![Gem](https://img.shields.io/gem/v/oj.svg)
 ![Gem](https://img.shields.io/gem/dt/oj.svg)
 [![SemVer compatibility](https://api.dependabot.com/badges/compatibility_score?dependency-name=oj&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=oj&package-manager=bundler&version-scheme=semver)


### PR DESCRIPTION
This PR will fix following error in built status 
![Screenshot_20230128_163513](https://user-images.githubusercontent.com/199156/215253583-149d78ce-4879-429a-851e-8b0531c2b47d.png)


Ref. https://github.com/badges/shields/issues/8671


The URL in this PR was generated by `Create Status badge` in https://github.com/ohler55/oj/actions/workflows/CI.yml

![image](https://user-images.githubusercontent.com/199156/215253709-0d6dd5cd-3061-4e5c-88ba-ce0d6bf7aee7.png)
