### PR TITLE
Suppress "old style definition" warning

### DIFF
--- a/ext/oj/mem.c
+++ b/ext/oj/mem.c
@@ -316,7 +316,7 @@ print_stats() {
 #endif
 
 void
-oj_mem_report() {
+oj_mem_report(void) {
 #ifdef MEM_DEBUG
     rb_gc();
     print_stats();


### PR DESCRIPTION
This patch will suppress following warning message when compile oj with GCC 12.

```
$ make
compiling cache.c
compiling cache8.c
compiling circarray.c
compiling code.c
compiling compat.c
compiling custom.c
compiling debug.c
compiling dump.c
compiling dump_compat.c
compiling dump_leaf.c
compiling dump_object.c
compiling dump_strict.c
compiling err.c
compiling fast.c
compiling intern.c
compiling mem.c
mem.c: In function 'oj_mem_report':
mem.c:319:1: warning: old-style function definition [-Wold-style-definition]
  319 | oj_mem_report() {
      | ^~~~~~~~~~~~~
At top level:
cc1: note: unrecognized command-line option '-Wno-self-assign' may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option '-Wno-parentheses-equality' may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option '-Wno-constant-logical-operand' may have been intended to silence earlier diagnostics
compiling mimic_json.c
compiling object.c
compiling odd.c
compiling oj.c
compiling parse.c
compiling parser.c
compiling rails.c
compiling reader.c
compiling resolve.c
compiling rxclass.c
compiling saj.c
compiling saj2.c
compiling scp.c
compiling sparse.c
compiling stream_writer.c
compiling strict.c
compiling string_writer.c
compiling trace.c
compiling usual.c
compiling util.c
compiling val_stack.c
compiling validate.c
compiling wab.c
linking shared-object oj/oj.so
```

Similer with https://github.com/ohler55/oj/pull/826