### PR TITLE
Fix SEGV in JSON.generate if to_json method returns invalid object

### DIFF
--- a/ext/oj/dump_compat.c
+++ b/ext/oj/dump_compat.c
@@ -117,6 +117,7 @@ dump_to_json(VALUE obj, Out out) {
     }
     TRACE(out->opts->trace, "to_json", obj, 0, TraceRubyOut);
 
+    StringValue(rs);
     s = RSTRING_PTR(rs);
     len = (int)RSTRING_LEN(rs);
 

--- a/test/json_gem/json_generator_test.rb
+++ b/test/json_gem/json_generator_test.rb
@@ -393,4 +393,15 @@ EOT
       assert_equal '["foo"]', JSON.generate([s.new('foo')])
     end
   end
+
+  def test_invalid_to_json
+    omit if REAL_JSON_GEM
+
+    data = Object.new
+    def data.to_json(*)
+      nil
+    end
+
+    assert_raises(TypeError) { JSON.generate(data) }
+  end
 end


### PR DESCRIPTION
This patch will raise TypeError exception in JSON.generate if  to_json method returns invalid object to avoid SEGV

### Test code
```ruby
require 'oj'
Oj.mimic_JSON

class Foo
  def to_json
    nil
  end
end

obj = { foo: Foo.new }
puts JSON.generate(obj)
```

Similar: https://github.com/ohler55/oj/pull/836