### PR TITLE
Format Markdown files with Markdownlint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 ## 3.13.8 - 2021-09-27
 
 - Fix `Oj::Doc` behaviour for inexisting path.
+
   ```ruby
   Oj::Doc.open('{"foo":1}') do |doc|
     doc.fetch('/foo/bar') # used to give `1`, now gives `nil`
@@ -364,153 +365,153 @@ Remove license from code.
 
 ## 3.7.7 - 2019-01-14
 
-  - Exception with other than a single argument initializer can now be decoded.
+- Exception with other than a single argument initializer can now be decoded.
 
-  - StreamWriter bug fixed that forces UTF-8 when appending to a stream. Ruby likes to convert to ASCII-8BIT but forcing the append to be UTF-8 avoids that issue.
+- StreamWriter bug fixed that forces UTF-8 when appending to a stream. Ruby likes to convert to ASCII-8BIT but forcing the append to be UTF-8 avoids that issue.
 
 ## 3.7.6 - 2018-12-30
 
-  - Changed time encoding for 32 bit to work around a Ruby bug in `rb_time_timespec()` that fails for times before 1970.
+- Changed time encoding for 32 bit to work around a Ruby bug in `rb_time_timespec()` that fails for times before 1970.
 
-  - Addressed issue #514 by changing reserved identifiers.
+- Addressed issue #514 by changing reserved identifiers.
 
-  - Addressed issue #515 by adding return value checks on `strdup()` and `pthread_mutex_init()`.
+- Addressed issue #515 by adding return value checks on `strdup()` and `pthread_mutex_init()`.
 
 ## 3.7.5 - 2018-12-27
 
-  - Address issue #517 with a special escape table for mimicking the JSON gem.
+- Address issue #517 with a special escape table for mimicking the JSON gem.
 
 ## 3.7.4 - 2018-11-29
 
-  - Allow `+` in front of numbers in parse as well as stream parse **EXCEPT** when mimicking the JSON gem.
+- Allow `+` in front of numbers in parse as well as stream parse **EXCEPT** when mimicking the JSON gem.
 
 ## 3.7.3 - 2018-11-29
 
-  - Allow `+` in front of numbers in parse as well as stream parse.
+- Allow `+` in front of numbers in parse as well as stream parse.
 
 ## 3.7.2 - 2018-11-29
 
-  - More tolerant float parsing to allow `123.`.
+- More tolerant float parsing to allow `123.`.
 
-  - Parse exceptions raised by user code now preserve the message content of the exception.
+- Parse exceptions raised by user code now preserve the message content of the exception.
 
 ## 3.7.1 - 2018-11-09
 
-  - Updated to support TruffleRuby.
+- Updated to support TruffleRuby.
 
 ## 3.7.0 - 2018-10-29
 
-  - Thanks to Ziaw for adding a integer range where integers outside that range are written as strings.
+- Thanks to Ziaw for adding a integer range where integers outside that range are written as strings.
 
 ## 3.6.13 - 2018-10-25
 
-  - Fixed issue where exceptions were not being cleared on parsing.
+- Fixed issue where exceptions were not being cleared on parsing.
 
-  - Added addition unicode dump error information.
+- Added addition unicode dump error information.
 
 ## 3.6.12 - 2018-10-16
 
-  - Fixed random `:omit_nil` setting with StringWriter and StreamWriter.
+- Fixed random `:omit_nil` setting with StringWriter and StreamWriter.
 
 ## 3.6.11 - 2018-09-26
 
-  - Added the JSON path to parse error messages.
+- Added the JSON path to parse error messages.
 
-  - BigDecimal parse errors now return Oj::ParseError instead of ArgumentError.
+- BigDecimal parse errors now return Oj::ParseError instead of ArgumentError.
 
 ## 3.6.10 - 2018-09-13
 
-  - Additional occurrences of `SYM2ID(sym)` replaced.
+- Additional occurrences of `SYM2ID(sym)` replaced.
 
 ## 3.6.9 - 2018-09-12
 
-  - `SYM2ID(sym)` causes a memory leak. A work around is now used.
+- `SYM2ID(sym)` causes a memory leak. A work around is now used.
 
 ## 3.6.8 - 2018-09-08
 
-  - Stopped setting the default options when optimize rails is called as the documentation has indicated.
+- Stopped setting the default options when optimize rails is called as the documentation has indicated.
 
-  - In custom mode `Date` and `DateTime` instances default to use the `:time_format` option is the `:create_additions` option is false.
+- In custom mode `Date` and `DateTime` instances default to use the `:time_format` option is the `:create_additions` option is false.
 
 ## 3.6.7 - 2018-08-26
 
-  - Fixed incorrect check in StreamWriter when adding raw JSON.
+- Fixed incorrect check in StreamWriter when adding raw JSON.
 
 ## 3.6.6 - 2018-08-16
 
-  - Fixed Debian build issues on several platforms.
+- Fixed Debian build issues on several platforms.
 
-  - `oj_slash_string` is now frozen.
+- `oj_slash_string` is now frozen.
 
 ## 3.6.5 - 2018-07-26
 
-  - Fixed GC issue with Oj::Doc.
+- Fixed GC issue with Oj::Doc.
 
-  - Fixed issue with time encoding with Windows.
+- Fixed issue with time encoding with Windows.
 
 ## 3.6.4 - 2018-07-10
 
-  - JSON.generate() now sets the `to_json` option as expected.
+- JSON.generate() now sets the `to_json` option as expected.
 
-  - Show `:create_additions` in the default options. It did not appear before.
+- Show `:create_additions` in the default options. It did not appear before.
 
 ## 3.6.3 - 2018-06-21
 
-  - Fixed compat dump compilation error on Windows.
+- Fixed compat dump compilation error on Windows.
 
 ## 3.6.2 - 2018-05-30
 
-  - Regex encoded correctly for rails when using `to_json`.
+- Regex encoded correctly for rails when using `to_json`.
 
-  - ActiveSupport::TimeWithZone optimization fixed.
+- ActiveSupport::TimeWithZone optimization fixed.
 
 ## 3.6.1 - 2018-05-16
 
-  - Fixed realloc bug in rails dump.
+- Fixed realloc bug in rails dump.
 
 ## 3.6.0 - 2018-05-01
 
-  - Add optimization for Rails ActiveRecord::Result encoding.
+- Add optimization for Rails ActiveRecord::Result encoding.
 
 ## 3.5.1 - 2018-04-14
 
-  - Fixed issue with \u0000 terminating keys early.
+- Fixed issue with \u0000 terminating keys early.
 
-  - Add trace for calls to `to_json` and 'as_json`.
+- Add trace for calls to `to_json` and 'as_json`.
 
 ## 3.5.0 - 2018-03-04
 
-  - A trace option is now available in all modes. The format roughly follows the Ruby trace format.
+- A trace option is now available in all modes. The format roughly follows the Ruby trace format.
 
 ## 3.4.0 - 2018-01-24
 
-  - Option to ignore specific classes in :object and :custom mode added.
+- Option to ignore specific classes in :object and :custom mode added.
 
 ## 3.3.10 - 2017-12-30
 
-  - Re-activated the bigdecimal_as_decimal option in custom mode and made the selection active for Rails mode.
+- Re-activated the bigdecimal_as_decimal option in custom mode and made the selection active for Rails mode.
 
-  - Fixed bug in optimize_rails that did not optimize all classes as expected.
+- Fixed bug in optimize_rails that did not optimize all classes as expected.
 
-  - Fixed warnings for Ruby 2.5.0.
+- Fixed warnings for Ruby 2.5.0.
 
 ## 3.3.9 - 2017-10-27
 
-  - Fixed bug where empty strings were sometimes marked as invalid.
+- Fixed bug where empty strings were sometimes marked as invalid.
 
 ## 3.3.8 - 2017-10-04
 
-  - Fixed Rail mimic precision bug.
+- Fixed Rail mimic precision bug.
 
 ## 3.3.7 - 2017-10-02
 
-  - Handle invalid unicode characters better for single byte strings.
+- Handle invalid unicode characters better for single byte strings.
 
-  - Parsers for empty strings handle errors more consistently.
+- Parsers for empty strings handle errors more consistently.
 
 ## 3.3.6 - 2017-09-22
 
-  - Numerous fixes and cleanup to support Ruby 2.4.2.
+- Numerous fixes and cleanup to support Ruby 2.4.2.
 
 ## 3.3.5 - 2017-08-11
 
@@ -1256,7 +1257,6 @@ Remove license from code.
 
 ## 1.2.9 - 2012-05-29
 
-
 ## 1.2.8 - 2012-05-03
 
 - Included a contribution by nevans to fix a math.h issue with an old fedora linux machine.
@@ -1369,7 +1369,6 @@ Remove license from code.
 - This is the first release sith a version of 0.5 indicating it is only half done. Basic load() and dump() is supported for Hash, Array, NilClass, TrueClass, FalseClass, Fixnum, Float, Symbol, and String Objects.
 
 ## 0.5.1 - 2012-02-19
-
 
 ## 0.5 - 2012-02-19
 

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ puts "Same? #{h == h2}"
 
 ## Installation
 
-```
+```bash
 gem install oj
 ```
 
 or in Bundler:
 
-```
+```Gemfile
 gem 'oj'
 ```
 
@@ -87,7 +87,7 @@ See [{file:CHANGELOG.md}](CHANGELOG.md) and [{file:RELEASE_NOTES.md}](RELEASE_NO
 
 Follow [@peterohler on Twitter](http://twitter.com/peterohler) for announcements and news about the Oj gem.
 
-#### Performance Comparisons
+## Performance Comparisons
 
 - [Oj Strict Mode Performance](http://www.ohler.com/dev/oj_misc/performance_strict.html) compares Oj strict mode parser performance to other JSON parsers.
 
@@ -97,7 +97,7 @@ Follow [@peterohler on Twitter](http://twitter.com/peterohler) for announcements
 
 - [Oj Callback Performance](http://www.ohler.com/dev/oj_misc/performance_callback.html) compares Oj callback parser performance to other JSON parsers.
 
-#### Links of Interest
+## Links of Interest
 
 - *Fast XML parser and marshaller on RubyGems*: <https://rubygems.org/gems/ox>
 
@@ -113,7 +113,7 @@ Follow [@peterohler on Twitter](http://twitter.com/peterohler) for announcements
 
 - *oj-introspect, an example of creating an Oj parser extension in C*: <https://github.com/meinac/oj-introspect>
 
-#### Contributing
+## Contributing
 
 - Provide a Pull Request off the `develop` branch.
 - Report a bug

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ puts "Same? #{h == h2}"
 ```
 
 ## Installation
+
 ```
 gem install oj
 ```
@@ -61,16 +62,16 @@ will automatically prefer Oj if it is installed.
 For more details on options, modes, advanced features, and more follow these
 links.
 
- - [{file:Options.md}](pages/Options.md) for parse and dump options.
- - [{file:Modes.md}](pages/Modes.md) for details on modes for strict JSON compliance, mimicking the JSON gem, and mimicking Rails and ActiveSupport behavior.
- - [{file:JsonGem.md}](pages/JsonGem.md) includes more details on json gem compatibility and use.
- - [{file:Rails.md}](pages/Rails.md) includes more details on Rails and ActiveSupport compatibility and use.
- - [{file:Custom.md}](pages/Custom.md) includes more details on Custom mode.
- - [{file:Encoding.md}](pages/Encoding.md) describes the :object encoding format.
- - [{file:Compatibility.md}](pages/Compatibility.md) lists current compatibility with Rubys and Rails.
- - [{file:Advanced.md}](pages/Advanced.md) for fast parser and marshalling features.
- - [{file:Security.md}](pages/Security.md) for security considerations.
- - [{file:InstallOptions.md}](pages/InstallOptions.md) for install option.
+- [{file:Options.md}](pages/Options.md) for parse and dump options.
+- [{file:Modes.md}](pages/Modes.md) for details on modes for strict JSON compliance, mimicking the JSON gem, and mimicking Rails and ActiveSupport behavior.
+- [{file:JsonGem.md}](pages/JsonGem.md) includes more details on json gem compatibility and use.
+- [{file:Rails.md}](pages/Rails.md) includes more details on Rails and ActiveSupport compatibility and use.
+- [{file:Custom.md}](pages/Custom.md) includes more details on Custom mode.
+- [{file:Encoding.md}](pages/Encoding.md) describes the :object encoding format.
+- [{file:Compatibility.md}](pages/Compatibility.md) lists current compatibility with Rubys and Rails.
+- [{file:Advanced.md}](pages/Advanced.md) for fast parser and marshalling features.
+- [{file:Security.md}](pages/Security.md) for security considerations.
+- [{file:InstallOptions.md}](pages/InstallOptions.md) for install option.
 
 ## Releases
 
@@ -78,43 +79,43 @@ See [{file:CHANGELOG.md}](CHANGELOG.md) and [{file:RELEASE_NOTES.md}](RELEASE_NO
 
 ## Links
 
-- *Documentation*: http://www.ohler.com/oj/doc, http://rubydoc.info/gems/oj
+- *Documentation*: <http://www.ohler.com/oj/doc>, <http://rubydoc.info/gems/oj>
 
-- *GitHub* *repo*: https://github.com/ohler55/oj
+- *GitHub* *repo*: <https://github.com/ohler55/oj>
 
-- *RubyGems* *repo*: https://rubygems.org/gems/oj
+- *RubyGems* *repo*: <https://rubygems.org/gems/oj>
 
 Follow [@peterohler on Twitter](http://twitter.com/peterohler) for announcements and news about the Oj gem.
 
 #### Performance Comparisons
 
- - [Oj Strict Mode Performance](http://www.ohler.com/dev/oj_misc/performance_strict.html) compares Oj strict mode parser performance to other JSON parsers.
+- [Oj Strict Mode Performance](http://www.ohler.com/dev/oj_misc/performance_strict.html) compares Oj strict mode parser performance to other JSON parsers.
 
- - [Oj Compat Mode Performance](http://www.ohler.com/dev/oj_misc/performance_compat.html) compares Oj compat mode parser performance to other JSON parsers.
+- [Oj Compat Mode Performance](http://www.ohler.com/dev/oj_misc/performance_compat.html) compares Oj compat mode parser performance to other JSON parsers.
 
- - [Oj Object Mode Performance](http://www.ohler.com/dev/oj_misc/performance_object.html) compares Oj object mode parser performance to other marshallers.
+- [Oj Object Mode Performance](http://www.ohler.com/dev/oj_misc/performance_object.html) compares Oj object mode parser performance to other marshallers.
 
- - [Oj Callback Performance](http://www.ohler.com/dev/oj_misc/performance_callback.html) compares Oj callback parser performance to other JSON parsers.
+- [Oj Callback Performance](http://www.ohler.com/dev/oj_misc/performance_callback.html) compares Oj callback parser performance to other JSON parsers.
 
 #### Links of Interest
 
- - *Fast XML parser and marshaller on RubyGems*: https://rubygems.org/gems/ox
+- *Fast XML parser and marshaller on RubyGems*: <https://rubygems.org/gems/ox>
 
- - *Fast XML parser and marshaller on GitHub*: https://github.com/ohler55/ox
+- *Fast XML parser and marshaller on GitHub*: <https://github.com/ohler55/ox>
 
- - [Need for Speed](http://www.ohler.com/dev/need_for_speed/need_for_speed.html) for an overview of how Oj::Doc was designed.
+- [Need for Speed](http://www.ohler.com/dev/need_for_speed/need_for_speed.html) for an overview of how Oj::Doc was designed.
 
- - *OjC, a C JSON parser*: https://www.ohler.com/ojc also at https://github.com/ohler55/ojc
+- *OjC, a C JSON parser*: <https://www.ohler.com/ojc> also at <https://github.com/ohler55/ojc>
 
- - *Agoo, a high performance Ruby web server supporting GraphQL on GitHub*: https://github.com/ohler55/agoo
+- *Agoo, a high performance Ruby web server supporting GraphQL on GitHub*: <https://github.com/ohler55/agoo>
 
- - *Agoo-C, a high performance C web server supporting GraphQL on GitHub*: https://github.com/ohler55/agoo-c
+- *Agoo-C, a high performance C web server supporting GraphQL on GitHub*: <https://github.com/ohler55/agoo-c>
 
- - *oj-introspect, an example of creating an Oj parser extension in C*: https://github.com/meinac/oj-introspect
+- *oj-introspect, an example of creating an Oj parser extension in C*: <https://github.com/meinac/oj-introspect>
 
 #### Contributing
 
-+ Provide a Pull Request off the `develop` branch.
-+ Report a bug
-+ Suggest an idea
-+ Code is now formatted with the clang-format tool with the configuration file in the root of the repo.
+- Provide a Pull Request off the `develop` branch.
+- Report a bug
+- Suggest an idea
+- Code is now formatted with the clang-format tool with the configuration file in the root of the repo.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,3 @@
 # Oj
 
- <a href="https://github.com/ohler55/oj"><img style="position: absolute; top: 0; left: 0; border: 0;" src="https://camo.githubusercontent.com/82b228a364
-8bf44fc1163ef44c62fcc60081495e/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_red_aa0000.png"></a>
-
+<a href="https://github.com/ohler55/oj"><img style="position: absolute; top: 0; left: 0; border: 0;" src="https://camo.githubusercontent.com/82b228a3648bf44fc1163ef44c62fcc60081495e/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f6c6566745f7265645f6161303030302e706e67" alt="Fork me on GitHub" data-canonical-src="https://s3.amazonaws.com/github/ribbons/forkme_left_red_aa0000.png"></a>

--- a/pages/Compatibility.md
+++ b/pages/Compatibility.md
@@ -1,12 +1,12 @@
 # Compatibility
 
-**Ruby**
+## Ruby
 
 Oj is compatible with Ruby 2.4+ and RBX.
 Support for JRuby has been removed as JRuby no longer supports C extensions and
 there are bugs in the older versions that are not being fixed.
 
-**Rails**
+## Rails
 
 Although up until 4.1 Rails uses [multi_json](https://github.com/intridea/multi_json), an [issue in Rails](https://github.com/rails/rails/issues/9212) causes ActiveSupport to fail to make use Oj for JSON handling.
 There is a
@@ -17,7 +17,7 @@ another work around to the rails older and newer behavior.
 
 The latest ActiveRecord is able to work with Oj by simply using the line:
 
-```
+```ruby
 serialize :metadata, Oj
 ```
 

--- a/pages/Custom.md
+++ b/pages/Custom.md
@@ -20,4 +20,3 @@ encoding and decoding is used. These are more efficient than calling out to a
 have to exist for the `"^o"` behavior to be utilized. Any other `:create_id`
 value behaves similar to the json gem by calling `to_json` and `create_json`
 as appropriate.
-

--- a/pages/Encoding.md
+++ b/pages/Encoding.md
@@ -7,25 +7,25 @@ generates JSON that follows conventions which allow Class and other
 information such as Object IDs for circular reference detection to be encoded
 in a JSON document. The formatting follows these rules.
 
- * JSON native types, true, false, nil, String, Hash, Array, and Number are
+* JSON native types, true, false, nil, String, Hash, Array, and Number are
    encoded normally.
 
- * A Symbol is encoded as a JSON string with a preceding `':'` character.
+* A Symbol is encoded as a JSON string with a preceding `':'` character.
 
- * The `'^'` character denotes a special key value when in a JSON Object sequence.
+* The `'^'` character denotes a special key value when in a JSON Object sequence.
 
- * A Ruby String that starts with `':'`or the sequence `'^i'` or `'^r'` are
+* A Ruby String that starts with `':'`or the sequence `'^i'` or `'^r'` are
    encoded by excaping the first character so that it appears as `'\u005e'` or
    `'\u003a'` instead of `':'` or `'^'`.
 
- * A `"^c"` JSON Object key indicates the value should be converted to a Ruby
+* A `"^c"` JSON Object key indicates the value should be converted to a Ruby
    class. The sequence `{"^c":"Oj::Bag"}` is read as the Oj::Bag class.
 
- * A `"^t"` JSON Object key indicates the value should be converted to a Ruby
+* A `"^t"` JSON Object key indicates the value should be converted to a Ruby
    Time. The sequence `{"^t":1325775487.000000}` is read as Jan 5, 2012 at
    23:58:07.
 
- * A `"^o"` JSON Object key indicates the value should be converted to a Ruby
+* A `"^o"` JSON Object key indicates the value should be converted to a Ruby
    Object. The first entry in the JSON Object must be a class with the `"^o"`
    key. After that each entry is treated as a variable of the Object where the
    key is the variable name without the preceding `'@'`. An example is
@@ -33,33 +33,33 @@ in a JSON document. The formatting follows these rules.
    is for built in or odd classes that don't obey the normal Ruby
    rules. Examples are Rational, Date, and DateTime.
 
- * A `"^u"` JSON Object key indicates the value should be converted to a Ruby
+* A `"^u"` JSON Object key indicates the value should be converted to a Ruby
    Struct. The first entry in the JSON Object must be a class with the
    `"^u"` key. After that each entry is is given a numeric position in the
    struct and that is used as the key in the JSON Object. An example is
    `{"^u":["Range",1,7,false]}`.
 
- * When encoding an Object, if the variable name does not begin with an
+* When encoding an Object, if the variable name does not begin with an
    `'@'`character then the name preceded by a `'~'` character. This occurs in
    the Exception class. An example is `{"^o":"StandardError","~mesg":"A
    Message","~bt":[".\/tests.rb:345:in 'test_exception'"]}`.
 
- * If a Hash entry has a key that is not a String or Symbol then the entry is
+* If a Hash entry has a key that is not a String or Symbol then the entry is
    encoded with a key of the form `"^#n"` where n is a hex number. The value
    is an Array where the first element is the key in the Hash and the second
    is the value. An example is `{"^#3":[2,5]}`.
 
- * A `"^i"` JSON entry in either an Object or Array is the ID of the Ruby
+* A `"^i"` JSON entry in either an Object or Array is the ID of the Ruby
    Object being encoded. It is used when the :circular flag is set. It can
    appear in either a JSON Object or in a JSON Array. In an Object the
    `"^i"` key has a corresponding reference Fixnum. In an array the sequence
    will include an embedded reference number. An example is
    `{"^o":"Oj::Bag","^i":1,"x":["^i2",true],"me":"^r1"}`.
 
- * A `"^r"`JSON entry in an Object is a references to a Object or Array that
+* A `"^r"`JSON entry in an Object is a references to a Object or Array that
    already appears in the JSON String. It must match up with a previous
    `"^i"` ID. An example is `{"^o":"Oj::Bag","^i":1,"x":3,"me":"^r1"}`.
 
- * If an Array element is a String and starts with `"^i"` then the first
+* If an Array element is a String and starts with `"^i"` then the first
    character, the `'^'` is encoded as a hex character sequence. An example is
    `["\u005ei37",3]`.

--- a/pages/InstallOptions.md
+++ b/pages/InstallOptions.md
@@ -1,17 +1,17 @@
 # Oj Install Options
 
-### Enable trace log
+## Enable trace log
 
-```
+```bash
 gem install oj -- --enable-trace-log
 ```
 
 To enable Oj trace feature, it uses `--enable-trace-log` option when installing the gem.
 Then, the trace logs will be displayed when `:trace` option is set to `true`.
 
-### Enable SIMD instructions
+## Enable SIMD instructions
 
-```
+```bash
 gem install oj -- --with-sse42
 ```
 

--- a/pages/InstallOptions.md
+++ b/pages/InstallOptions.md
@@ -3,17 +3,16 @@
 ### Enable trace log
 
 ```
-$ gem install oj -- --enable-trace-log
+gem install oj -- --enable-trace-log
 ```
 
 To enable Oj trace feature, it uses `--enable-trace-log` option when installing the gem.
 Then, the trace logs will be displayed when `:trace` option is set to `true`.
 
-
 ### Enable SIMD instructions
 
 ```
-$ gem install oj -- --with-sse42
+gem install oj -- --with-sse42
 ```
 
 To enable the use of SIMD instructions in Oj, it uses the `--with-sse42` option when installing the gem.

--- a/pages/JsonGem.md
+++ b/pages/JsonGem.md
@@ -74,20 +74,20 @@ Oj.remove_to_json(Rational)
 
 The classes that can be added are:
 
- * Array
- * BigDecimal
- * Complex
- * Date
- * DateTime
- * Exception
- * Hash
- * Integer
- * OpenStruct
- * Range
- * Rational
- * Regexp
- * Struct
- * Time
+* Array
+* BigDecimal
+* Complex
+* Date
+* DateTime
+* Exception
+* Hash
+* Integer
+* OpenStruct
+* Range
+* Rational
+* Regexp
+* Struct
+* Time
 
 The compatibility target version is 2.0.3. The json gem unit tests were used
 to verify compatibility with a few changes to use Oj instead of the original

--- a/pages/JsonGem.md
+++ b/pages/JsonGem.md
@@ -13,7 +13,7 @@ json gem has been required.
 
 For more details and options, read on...
 
-# Oj JSON Gem Compatibility
+## Oj JSON Gem Compatibility
 
 The `:compat` mode mimics the json gem. The json gem is built around the use
 of the `to_json(*)` method defined for a class. Oj attempts to provide the

--- a/pages/Modes.md
+++ b/pages/Modes.md
@@ -7,12 +7,12 @@ without monkey patching the object classes. From that start other demands were
 made the were best met by giving Oj multiple modes of operation. The current
 modes are:
 
- - `:strict`
- - `:null`
- - `:compat` or `:json`
- - `:rails`
- - `:object`
- - `:custom`
+- `:strict`
+- `:null`
+- `:compat` or `:json`
+- `:rails`
+- `:object`
+- `:custom`
 
 Since modes determine what the JSON output will look like and alternatively
 what Oj expects when the `Oj.load()` method is called, mixing the output and
@@ -142,7 +142,7 @@ information.
     for Rails is as a string. Setting the value to true will encode a
     BigDecimal as a number which breaks compatibility.
     Note: after version 3.11.3 both `Oj.generate` and `JSON.generate`
-    will not honour this option in Rails Mode, detais on https://github.com/ohler55/oj/pull/716.
+    will not honour this option in Rails Mode, detais on <https://github.com/ohler55/oj/pull/716>.
 
  4. The integer indent value in the default options will be honored by since
     the json gem expects a String type the indent in calls to 'to_json()',

--- a/pages/Options.md
+++ b/pages/Options.md
@@ -60,15 +60,15 @@ If true dump BigDecimal as a decimal number otherwise as a String
 
 Determines how to load decimals.
 
- - `:bigdecimal` convert all decimal numbers to BigDecimal.
+- `:bigdecimal` convert all decimal numbers to BigDecimal.
 
- - `:float` convert all decimal numbers to Float.
+- `:float` convert all decimal numbers to Float.
 
- - `:auto` the most precise for the number of digits is used.
+- `:auto` the most precise for the number of digits is used.
 
- - `:fast` faster conversion to Float.
+- `:fast` faster conversion to Float.
 
- - `:ruby` convert to Float using the Ruby `to_f` conversion.
+- `:ruby` convert to Float using the Ruby `to_f` conversion.
 
 This can also be set with `:decimal_class` when used as a load or
 parse option to match the JSON gem. In that case either `Float`,
@@ -112,9 +112,9 @@ dynamically modifying classes or reloading classes then don't use this.
 
 Determines how to load decimals when in `:compat` mode.
 
- - `true` convert all decimal numbers to BigDecimal.
+- `true` convert all decimal numbers to BigDecimal.
 
- - `false` convert all decimal numbers to Float.
+- `false` convert all decimal numbers to Float.
 
 ### :create_additions
 
@@ -154,17 +154,17 @@ JSON.load(' ', nil, allow_blank: true) => raise
 Determines the characters to escape when dumping. Only the :ascii and
 :json modes are supported in :compat mode.
 
- - `:newline` allows unescaped newlines in the output.
+- `:newline` allows unescaped newlines in the output.
 
- - `:json` follows the JSON specification. This is the default mode.
+- `:json` follows the JSON specification. This is the default mode.
 
- - `:slash` escapes `/` characters.
+- `:slash` escapes `/` characters.
 
- - `:xss_safe` escapes HTML and XML characters such as `&` and `<`.
+- `:xss_safe` escapes HTML and XML characters such as `&` and `<`.
 
- - `:ascii` escapes all non-ascii or characters with the hi-bit set.
+- `:ascii` escapes all non-ascii or characters with the hi-bit set.
 
- - `:unicode_xss` escapes a special unicodes and is xss safe.
+- `:unicode_xss` escapes a special unicodes and is xss safe.
 
 ### :float_precision [Fixnum]
 
@@ -221,15 +221,15 @@ customization.
 How to dump Infinity, -Infinity, and NaN in :null, :strict, and :compat
 mode. Default is :auto but is ignored in the :compat and :rails modes.
 
- - `:null` places a null
+- `:null` places a null
 
- - `:huge` places a huge number
+- `:huge` places a huge number
 
- - `:word` places Infinity or NaN
+- `:word` places Infinity or NaN
 
- - `:raise` raises and exception
+- `:raise` raises and exception
 
- - `:auto` uses default for each mode which are `:raise` for `:strict`, `:null` for `:null`, and `:word` for `:compat`.
+- `:auto` uses default for each mode which are `:raise` for `:strict`, `:null` for `:null`, and `:word` for `:compat`.
 
 ### :nilnil [Boolean]
 
@@ -296,20 +296,19 @@ of blocks and of specific calls.
 
 The :time_format when dumping.
 
- - `:unix` time is output as a decimal number in seconds since epoch including fractions of a second.
+- `:unix` time is output as a decimal number in seconds since epoch including fractions of a second.
 
- - `:unix_zone` is similar to the `:unix` format but with the timezone encoded in
+- `:unix_zone` is similar to the `:unix` format but with the timezone encoded in
    the exponent of the decimal number of seconds since epoch.
 
- - `:xmlschema` time is output as a string that follows the XML schema definition.
+- `:xmlschema` time is output as a string that follows the XML schema definition.
 
- - `:ruby` time is output as a string formatted using the Ruby `to_s` conversion.
+- `:ruby` time is output as a string formatted using the Ruby `to_s` conversion.
 
 ### :use_as_json [Boolean]
 
 Call `as_json()` methods on dump, default is false. The option is ignored in
 the :compat and :rails modes.
-
 
 ### :use_raw_json [Boolean]
 

--- a/pages/Options.md
+++ b/pages/Options.md
@@ -14,7 +14,7 @@ efficient than setting the globals for many smaller JSON documents but does
 provide a more thread safe approach to using custom options for loading and
 dumping.
 
-### Options for serializer and parser
+## Options for serializer and parser
 
 ### :allow_blank [Boolean]
 
@@ -138,7 +138,7 @@ default_options will be honored for :null, :strict, and :custom modes. Ignored
 for :custom and :wab. The :compat has a more complex set of rules. The JSON
 gem compatibility is best described by examples.
 
-```
+```ruby
 JSON.parse('') => raise
 JSON.parse(' ') => raise
 JSON.load('') => nil

--- a/pages/Parser.md
+++ b/pages/Parser.md
@@ -240,7 +240,7 @@ Without a comparible parser that just validates a JSON document the
 comparison to the new `Oj::Parser.new(:validate)`. In that case the
 comparison is:
 
-```
+```console
              System  time (secs)  rate (ops/sec)
 -------------------  -----------  --------------
 Oj::Parser.validate       0.101      494369.136
@@ -257,7 +257,7 @@ processing the various element types in a JSON document. Comparing
 `Oj.saj_parse` to `Oj::Parser.new(:saj)` with a all callback methods
 implemented handler gives the following raw results:
 
-```
+```console
         System  time (secs)  rate (ops/sec)
 --------------  -----------  --------------
 Oj::Parser.saj       0.783       63836.986
@@ -272,7 +272,7 @@ Parsing to Ruby primitives and Array and Hash is possible with most
 parsers including the JSON gem parser. The raw results comparing
 `Oj.strict_load`, `Oj::Parser.new(:usual)`, and the JSON gem are:
 
-```
+```console
           System  time (secs)  rate (ops/sec)
 ----------------  -----------  --------------
 Oj::Parser.usual       0.452      110544.876
@@ -290,7 +290,7 @@ deserialization. Comparing to the JSON gem compatible mode
 `Oj.compat_load`, `Oj::Parser.new(:usual)`, and the JSON gem yields
 the following raw results:
 
-```
+```console
           System  time (secs)  rate (ops/sec)
 ----------------  -----------  --------------
 Oj::Parser.usual       0.071      703502.033

--- a/pages/Rails.md
+++ b/pages/Rails.md
@@ -10,7 +10,7 @@ Oj.optimize_rails()
 
 For more details and options, read on...
 
-# Oj Rails Compatibility
+## Oj Rails Compatibility
 
 The `:rails` mode mimics the ActiveSupport version 5 encoder. Rails and
 ActiveSupport are built around the use of the `as_json(*)` method defined for
@@ -152,13 +152,17 @@ gem 'oj', '3.7.12'
 
    For example:
 
-     ```
+     ```ruby
      require 'active_support/core_ext'
      require 'active_support/json'
      require 'oj'
      Oj.optimize_rails
      tracer.enable { Time.now.to_json }
-     # prints output including
+     ```
+
+     Prints output including:
+
+     ```console
      ....
      [20, :c_call, #<Class:Oj::Rails::Encoder>, :new]
      [20, :c_call, Oj::Rails::Encoder, :encode]

--- a/pages/Rails.md
+++ b/pages/Rails.md
@@ -46,10 +46,10 @@ instance of the Encoder class and provide options in the initializer.
 
 The globals that ActiveSupport uses for encoding are:
 
- * `ActiveSupport::JSON::Encoding.use_standard_json_time_format`
- * `ActiveSupport::JSON::Encoding.escape_html_entities_in_json`
- * `ActiveSupport::JSON::Encoding.time_precision`
- * `ActiveSupport::JSON::Encoding.json_encoder`
+* `ActiveSupport::JSON::Encoding.use_standard_json_time_format`
+* `ActiveSupport::JSON::Encoding.escape_html_entities_in_json`
+* `ActiveSupport::JSON::Encoding.time_precision`
+* `ActiveSupport::JSON::Encoding.json_encoder`
 
 Those globals are aliased to also be accessed from the ActiveSupport module
 directly so `ActiveSupport::JSON::Encoding.time_precision` can also be accessed
@@ -77,17 +77,17 @@ listed here.
 The classes that can be put in optimized mode and are optimized when
 `Oj::Rails.optimize` is called with no arguments are:
 
- * Array
- * BigDecimal
- * Float
- * Hash
- * Range
- * Regexp
- * Time
- * ActiveSupport::TimeWithZone
- * ActionController::Parameters
- * any class inheriting from ActiveRecord::Base
- * any other class where all attributes should be dumped
+* Array
+* BigDecimal
+* Float
+* Hash
+* Range
+* Regexp
+* Time
+* ActiveSupport::TimeWithZone
+* ActionController::Parameters
+* any class inheriting from ActiveRecord::Base
+* any other class where all attributes should be dumped
 
 The ActiveSupport decoder is the `JSON.parse()` method. Calling the
 `Oj::Rails.set_decoder()` method replaces that method with the Oj equivalent.
@@ -131,7 +131,7 @@ If you are using an older version of Ruby, you can pin `oj` to an earlier versio
 gem 'oj', '3.7.12'
 ```
 
-### Notes:
+### Notes
 
 1. Optimized Floats set the significant digits to 16. This is different than
    Ruby which is used by the json gem and by Rails. Ruby varies the

--- a/test/activesupport4/Readme.md
+++ b/test/activesupport4/Readme.md
@@ -1,1 +1,3 @@
+# ActiveSupport 4
+
 Tests copied from [rails/activesupport/test/json/](https://github.com/rails/rails/tree/v4.1.16/activesupport/test/json)

--- a/test/activesupport5/Readme.md
+++ b/test/activesupport5/Readme.md
@@ -1,3 +1,5 @@
+# ActiveSupport 5
+
 Tests copied from [rails/activesupport/test/json/],
 [rails/activesupport/lib/active_support], [rails/activesupport/test].
 

--- a/test/activesupport6/Readme.md
+++ b/test/activesupport6/Readme.md
@@ -1,3 +1,5 @@
+# ActiveSupport 6
+
 Tests copied from [rails/activesupport/test/json/],
 [rails/activesupport/lib/active_support], [rails/activesupport/test].
 

--- a/test/activesupport7/Readme.md
+++ b/test/activesupport7/Readme.md
@@ -1,3 +1,5 @@
+# ActiveSupport 7
+
 Tests copied from [rails/activesupport/test/json/],
 [rails/activesupport/lib/active_support], [rails/activesupport/test].
 


### PR DESCRIPTION
Took a quick pass over the files with Markdownlint-CLI2. Still 2 left over in docs/index.md for HTML elements.

Basic config of
```json
{
    "config": {
        "default": true,
        "MD013": false
    }
}
```

Leaves the last 2 messages:

```
$ markdownlint-cli2-fix "**/*.md"
markdownlint-cli2-fix v0.6.0 (markdownlint v0.27.0)
Finding: **/*.md
Linting: 22 file(s)
Summary: 2 error(s)
docs/index.md:3:1 MD033/no-inline-html Inline HTML [Element: a]
docs/index.md:3:41 MD033/no-inline-html Inline HTML [Element: img]
```