### PR TITLE
Autofix Rubocop Lint - Batch 3

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -460,17 +460,6 @@ Layout/TrailingWhitespace:
     - 'test/test_hash.rb'
     - 'test/test_writer.rb'
 
-# Offense count: 11
-# This cop supports safe autocorrection (--autocorrect).
-Lint/AmbiguousOperatorPrecedence:
-  Exclude:
-    - 'test/perf.rb'
-    - 'test/perf_file.rb'
-    - 'test/sample.rb'
-    - 'test/test_custom.rb'
-    - 'test/test_strict.rb'
-    - 'test/test_wab.rb'
-
 # Offense count: 3
 # This cop supports safe autocorrection (--autocorrect).
 Lint/AmbiguousRegexpLiteral:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -526,15 +526,6 @@ Lint/RaiseException:
   Exclude:
     - 'test/test_wab.rb'
 
-# Offense count: 4
-# This cop supports safe autocorrection (--autocorrect).
-Lint/RedundantRequireStatement:
-  Exclude:
-    - 'test/files.rb'
-    - 'test/helper.rb'
-    - 'test/sample.rb'
-    - 'test/sample_json.rb'
-
 # Offense count: 1
 # This cop supports safe autocorrection (--autocorrect).
 Lint/RedundantStringCoercion:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -460,12 +460,6 @@ Layout/TrailingWhitespace:
     - 'test/test_hash.rb'
     - 'test/test_writer.rb'
 
-# Offense count: 5
-# This cop supports safe autocorrection (--autocorrect).
-Lint/AmbiguousOperator:
-  Exclude:
-    - 'test/json_gem/json_parser_test.rb'
-
 # Offense count: 11
 # This cop supports safe autocorrection (--autocorrect).
 Lint/AmbiguousOperatorPrecedence:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -460,12 +460,6 @@ Layout/TrailingWhitespace:
     - 'test/test_hash.rb'
     - 'test/test_writer.rb'
 
-# Offense count: 3
-# This cop supports safe autocorrection (--autocorrect).
-Lint/AmbiguousRegexpLiteral:
-  Exclude:
-    - 'test/json_gem/json_common_interface_test.rb'
-
 # Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: AllowSafeAssignment.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -526,12 +526,6 @@ Lint/RaiseException:
   Exclude:
     - 'test/test_wab.rb'
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-Lint/RedundantStringCoercion:
-  Exclude:
-    - 'test/test_compat.rb'
-
 # Offense count: 57
 Lint/RescueException:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -577,14 +577,6 @@ Lint/SymbolConversion:
     - 'test/test_file.rb'
     - 'test/test_object.rb'
 
-# Offense count: 3
-# This cop supports safe autocorrection (--autocorrect).
-Lint/ToJSON:
-  Exclude:
-    - 'test/perf_simple.rb'
-    - 'test/test_file.rb'
-    - 'test/test_various.rb'
-
 # Offense count: 2
 # This cop supports safe autocorrection (--autocorrect).
 Lint/UnifiedInteger:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -577,12 +577,6 @@ Lint/SymbolConversion:
     - 'test/test_file.rb'
     - 'test/test_object.rb'
 
-# Offense count: 2
-# This cop supports safe autocorrection (--autocorrect).
-Lint/UnifiedInteger:
-  Exclude:
-    - 'test/test_fast.rb'
-
 # Offense count: 3
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: IgnoreEmptyBlocks, AllowUnusedKeywordArguments.

--- a/Rakefile
+++ b/Rakefile
@@ -29,19 +29,14 @@ task :test_all => [:clean, :compile] do
   end
   exitcode = 1 unless status
 
-  # Verifying that json gem tests work for native implementation for Ruby 2.4.0
-  # and above only. We know the older versions do not pass the 2.4.0 unit
-  # tests.
-  if RUBY_VERSION >= '2.4'
-    Dir.glob('test/json_gem/*_test.rb').each do |file|
-      cmd = "bundle exec ruby -Itest #{file}"
-      STDOUT.syswrite "\n#{'#'*90}\n#{cmd}\n"
-      Bundler.with_original_env do
-        ENV['REAL_JSON_GEM'] = '1'
-        status = system(cmd)
-      end
-      exitcode = 1 unless status
+  Dir.glob('test/json_gem/*_test.rb').each do |file|
+    cmd = "bundle exec ruby -Itest #{file}"
+    STDOUT.syswrite "\n#{'#'*90}\n#{cmd}\n"
+    Bundler.with_original_env do
+      ENV['REAL_JSON_GEM'] = '1'
+      status = system(cmd)
     end
+    exitcode = 1 unless status
   end
 
   Rake::Task['test'].invoke

--- a/test/files.rb
+++ b/test/files.rb
@@ -7,7 +7,6 @@ if $0 == __FILE__
   $: << '../ext'
 end
 
-require 'pp'
 require 'sample/file'
 require 'sample/dir'
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -15,7 +15,6 @@ require 'minitest/autorun'
 require 'stringio'
 require 'date'
 require 'bigdecimal'
-require 'pp'
 require 'oj'
 
 def verify_gc_compaction

--- a/test/json_gem/json_common_interface_test.rb
+++ b/test/json_gem/json_common_interface_test.rb
@@ -43,15 +43,15 @@ class JSONCommonInterfaceTest < Test::Unit::TestCase
   # functionality and perform better.
 
   def test_parser
-    assert_match /::Parser\z/, JSON.parser.name
+    assert_match(/::Parser\z/, JSON.parser.name)
   end
 
   def test_generator
-    assert_match /::Generator\z/, JSON.generator.name
+    assert_match(/::Generator\z/, JSON.generator.name)
   end
 
   def test_state
-    assert_match /::Generator::State\z/, JSON.state.name
+    assert_match(/::Generator::State\z/, JSON.state.name)
   end
 
   # This doesn't have anything to do with JSON parsing or generation. It seems

--- a/test/json_gem/json_parser_test.rb
+++ b/test/json_gem/json_parser_test.rb
@@ -95,21 +95,21 @@ class JSONParserTest < Test::Unit::TestCase
     assert_raise(JSON::ParserError) { JSON.parse('.23') }
     assert_raise(JSON::ParserError) { JSON.parse('023') }
     assert_equal 23, JSON.parse('23')
-    assert_equal -23, JSON.parse('-23')
+    assert_equal(-23, JSON.parse('-23'))
     assert_equal_float 3.141, JSON.parse('3.141')
-    assert_equal_float -3.141, JSON.parse('-3.141')
+    assert_equal_float(-3.141, JSON.parse('-3.141'))
     assert_equal_float 3.141, JSON.parse('3141e-3')
     assert_equal_float 3.141, JSON.parse('3141.1e-3')
     assert_equal_float 3.141, JSON.parse('3141E-3')
     assert_equal_float 3.141, JSON.parse('3141.0E-3')
-    assert_equal_float -3.141, JSON.parse('-3141.0e-3')
-    assert_equal_float -3.141, JSON.parse('-3141e-3')
+    assert_equal_float(-3.141, JSON.parse('-3141.0e-3'))
+    assert_equal_float(-3.141, JSON.parse('-3141e-3'))
     assert_raise(JSON::ParserError) { JSON.parse('NaN') }
     assert JSON.parse('NaN', :allow_nan => true).nan?
     assert_raise(JSON::ParserError) { JSON.parse('Infinity') }
     assert_equal 1.0/0, JSON.parse('Infinity', :allow_nan => true)
     assert_raise(JSON::ParserError) { JSON.parse('-Infinity') }
-    assert_equal -1.0/0, JSON.parse('-Infinity', :allow_nan => true)
+    assert_equal(-1.0/0, JSON.parse('-Infinity', :allow_nan => true))
   end
 
   if Array.method_defined?(:permutation)

--- a/test/perf.rb
+++ b/test/perf.rb
@@ -60,7 +60,7 @@ class Perf
     iva.each do |i|
       line = ["%*s" % [width, i.title]]
       iva.each do |o|
-        line << "%*.2f" % [width, o.duration / i.duration]
+        line << ("%*.2f" % [width, o.duration / i.duration])
       end
       puts line.join('  ')
     end

--- a/test/perf_file.rb
+++ b/test/perf_file.rb
@@ -42,7 +42,7 @@ $obj = {
 }
 
 json = Oj.dump($obj, :indent => $indent)
-cnt = ($size * 1024 * 1024 + json.size) / json.size
+cnt = (($size * 1024 * 1024) + json.size) / json.size
 cnt = 1 if 0 == $size
 
 filename = 'tmp.json'

--- a/test/perf_simple.rb
+++ b/test/perf_simple.rb
@@ -21,7 +21,7 @@ class Jazz
     @array = [true, false, nil]
     @hash = { 'one' => 1, 'two' => 2 }
   end
-  def to_json()
+  def to_json(*_args)
     %{
     { "boolean":#{@boolean},
       "number":#{@number},

--- a/test/sample.rb
+++ b/test/sample.rb
@@ -7,7 +7,6 @@ if $0 == __FILE__
   $: << '../ext'
 end
 
-require 'pp'
 require 'sample/doc'
 
 def sample_doc(size=3)

--- a/test/sample.rb
+++ b/test/sample.rb
@@ -27,7 +27,7 @@ def sample_doc(size=3)
       g = ::Sample::Group.new
       (1..size).each do |k|
         g2 = ::Sample::Group.new
-        r = ::Sample::Rect.new(j * 40 + 10.0, i * 10.0,
+        r = ::Sample::Rect.new((j * 40) + 10.0, i * 10.0,
                                10.123456 / k, 10.0 / k, colors[(i + j + k) % colors.size])
         r.add_prop(:part_of, layer.name)
         g2 << r
@@ -36,7 +36,7 @@ def sample_doc(size=3)
       end
       g2 = ::Sample::Group.new
       (1..size).each do |k|
-        o = ::Sample::Oval.new(j * 40 + 12.0, i * 10.0 + 2.0,
+        o = ::Sample::Oval.new((j * 40) + 12.0, (i * 10.0) + 2.0,
                                6.0 / k, 6.0 / k, colors[(i + j + k) % colors.size])
         o.add_prop(:inside, true)
         g << o

--- a/test/sample_json.rb
+++ b/test/sample_json.rb
@@ -7,7 +7,6 @@ if $0 == __FILE__
   $: << '../ext'
 end
 
-require 'pp'
 require 'oj'
 
 def sample_json(size=3)

--- a/test/test_compat.rb
+++ b/test/test_compat.rb
@@ -30,7 +30,7 @@ class CompatJuice < Minitest::Test
     alias == eql?
 
     def to_json(*a)
-      %|{"json_class":"#{self.class.to_s}","x":#{@x},"y":#{@y}}|
+      %|{"json_class":"#{self.class}","x":#{@x},"y":#{@y}}|
     end
 
     def self.json_create(h)

--- a/test/test_custom.rb
+++ b/test/test_custom.rb
@@ -449,12 +449,9 @@ class CustomJuice < Minitest::Test
   end
 
   def test_datetime_unix_zone
-    # older versions seems to have issues getting the utc offset.
-    if '2.4' <= RUBY_VERSION
-      obj = DateTime.new(2017, 1, 5, 10, 20, 30, '-0500')
-      json = Oj.dump(obj, :indent => 2, time_format: :unix_zone)
-      assert_equal('1483629630.000000000e-18000', json)
-    end
+    obj = DateTime.new(2017, 1, 5, 10, 20, 30, '-0500')
+    json = Oj.dump(obj, :indent => 2, time_format: :unix_zone)
+    assert_equal('1483629630.000000000e-18000', json)
   end
 
   def test_datetime_ruby

--- a/test/test_custom.rb
+++ b/test/test_custom.rb
@@ -204,7 +204,7 @@ class CustomJuice < Minitest::Test
 
     begin
       n = 10000
-      Oj.strict_load('[' * n + ']' * n)
+      Oj.strict_load(('[' * n) + (']' * n))
     rescue Exception => e
       assert(false, e.message)
     end

--- a/test/test_fast.rb
+++ b/test/test_fast.rb
@@ -91,11 +91,7 @@ class DocTest < Minitest::Test
   def test_fixnum
     json = %{12345}
     Oj::Doc.open(json) do |doc|
-      if '2.4.0' <= RUBY_VERSION
-        assert_equal(Integer, doc.type)
-      else
-        assert_equal(Fixnum, doc.type)
-      end
+      assert_equal(Integer, doc.type)
       assert_equal(12345, doc.fetch())
     end
   end
@@ -223,7 +219,7 @@ class DocTest < Minitest::Test
     if '2.4.0' <= RUBY_VERSION
       num_class = Integer
     else
-      num_class = Fixnum
+      num_class = Integer
     end
     Oj::Doc.open(@json1) do |doc|
       [['/', Hash],

--- a/test/test_fast.rb
+++ b/test/test_fast.rb
@@ -216,19 +216,14 @@ class DocTest < Minitest::Test
   end
 
   def test_type
-    if '2.4.0' <= RUBY_VERSION
-      num_class = Integer
-    else
-      num_class = Integer
-    end
     Oj::Doc.open(@json1) do |doc|
       [['/', Hash],
        ['/array', Array],
        ['/array/1', Hash],
-       ['/array/1/num', num_class],
+       ['/array/1/num', Integer],
        ['/array/1/string', String],
        ['/array/1/hash/h2/a', Array],
-       ['/array/1/hash/../num', num_class],
+       ['/array/1/hash/../num', Integer],
        ['/array/1/hash/../..', Array],
       ].each do |path, type|
         assert_equal(type, doc.type(path))

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -26,7 +26,7 @@ class FileJuice < Minitest::Test
       super
     end
 
-    def to_json()
+    def to_json(*_args)
       %{{"json_class":"#{self.class}","x":#{@x},"y":#{@y}}}
     end
 

--- a/test/test_scp.rb
+++ b/test/test_scp.rb
@@ -347,12 +347,10 @@ class ScpTest < Minitest::Test
   end
 
   def test_bad_bignum
-    if '2.4.0' < RUBY_VERSION
-      handler = AllHandler.new()
-      json = %|{"big":-e123456789}|
-      assert_raises Exception do # Can be either Oj::ParseError or ArgumentError depending on Ruby version
-        Oj.sc_parse(handler, json)
-      end
+    handler = AllHandler.new()
+    json = %|{"big":-e123456789}|
+    assert_raises Exception do # Can be either Oj::ParseError or ArgumentError depending on Ruby version
+      Oj.sc_parse(handler, json)
     end
   end
 

--- a/test/test_strict.rb
+++ b/test/test_strict.rb
@@ -160,7 +160,7 @@ class StrictJuice < Minitest::Test
 
     begin
       n = 10000
-      Oj.strict_load('[' * n + ']' * n)
+      Oj.strict_load(('[' * n) + (']' * n))
     rescue Exception => e
       assert(false, e.message)
     end

--- a/test/test_various.rb
+++ b/test/test_various.rb
@@ -706,10 +706,8 @@ class Juice < Minitest::Test
   end
 
   def test_bad_bignum
-    if '2.4.0' < RUBY_VERSION
-      assert_raises Oj::ParseError do
-        Oj.load(%|{ "big": -e123456789 }|, mode: :strict)
-      end
+    assert_raises Oj::ParseError do
+      Oj.load(%|{ "big": -e123456789 }|, mode: :strict)
     end
   end
 

--- a/test/test_various.rb
+++ b/test/test_various.rb
@@ -36,7 +36,7 @@ class Juice < Minitest::Test
       super
     end
 
-    def to_json()
+    def to_json(*_args)
       %{{"json_class":"#{self.class}","x":#{@x},"y":#{@y}}}
     end
 

--- a/test/test_wab.rb
+++ b/test/test_wab.rb
@@ -108,7 +108,7 @@ class WabJuice < Minitest::Test
 
     begin
       n = 10000
-      Oj.wab_load('[' * n + ']' * n)
+      Oj.wab_load(('[' * n) + (']' * n))
     rescue Exception => e
       assert(false, e.message)
     end


### PR DESCRIPTION
Autofix the Lint rules with no options. Fixing the last one I hit a conditional for testing on the old Ruby versions that have been removed, so added a commit to clean those up too