### PR TITLE
Enable Windows Rails CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,10 +34,6 @@ jobs:
             ruby: head
           - os: windows
             ruby: head
-          - os: windows
-            gemfile: rails_6.1
-          - os: windows
-            gemfile: rails_7
         include:
           - ruby: '2.7'
             gemfile: rails_6 # End of life June 1, 2023

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -3,4 +3,6 @@ source "https://rubygems.org"
 gem "rails", "6.1.3.1"
 gem "sqlite3"
 
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
+
 gemspec :path => "../"

--- a/gemfiles/rails_7.gemfile
+++ b/gemfiles/rails_7.gemfile
@@ -3,4 +3,6 @@ source "https://rubygems.org"
 gem "rails", "~> 7.0.3"
 gem "sqlite3"
 
+gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw]
+
 gemspec :path => "../"


### PR DESCRIPTION
I'm expecting this to fail as I was testing on an earlier branch before.
I figured out one of the failure methods from going through the first error message that pointed to https://github.com/tzinfo/tzinfo/wiki/Resolving-TZInfo::DataSourceNotFound-Errors

Opening to see if the other failure gives anyone else an idea