### PR TITLE
Fix memory leak in Oj::StreamWriter.new

### DIFF
--- a/ext/oj/stream_writer.c
+++ b/ext/oj/stream_writer.c
@@ -104,10 +104,12 @@ static VALUE stream_writer_new(int argc, VALUE *argv, VALUE self) {
         if (Qnil != (v = rb_hash_lookup(argv[1], buffer_size_sym))) {
 #ifdef RUBY_INTEGER_UNIFICATION
             if (rb_cInteger != rb_obj_class(v)) {
+                OJ_R_FREE(sw);
                 rb_raise(rb_eArgError, ":buffer size must be a Integer.");
             }
 #else
             if (T_FIXNUM != rb_type(v)) {
+                OJ_R_FREE(sw);
                 rb_raise(rb_eArgError, ":buffer size must be a Integer.");
             }
 #endif


### PR DESCRIPTION
When it invoked Data_Wrap_Struct(), Ruby's GC can release allocated memory properly. However, we have to manage the memory ourselves until invoking Data_Wrap_Struct(),

So, we have to release the memory manually before raising exception if it raises the exception before invoking Data_Wrap_Struct().

You will see an increase memory usage with attached test code.

### Before
```
0, 17.69140625 MB
1000, 22.37890625 MB
2000, 26.76171875 MB
3000, 31.14453125 MB
4000, 35.52734375 MB
5000, 40.16796875 MB
6000, 44.55078125 MB
7000, 48.93359375 MB
8000, 53.31640625 MB
9000, 57.69921875 MB
```

### After
```
0, 17.69140625 MB
1000, 17.9921875 MB
2000, 17.9921875 MB
3000, 17.9921875 MB
4000, 17.9921875 MB
5000, 17.9921875 MB
6000, 17.9921875 MB
7000, 17.9921875 MB
8000, 17.9921875 MB
9000, 17.9921875 MB
```

### Test code
```ruby
require 'oj'
require 'stringio'

sio = StringIO.new("hoge", 'r+')

10_000.times do |i|
  begin
    w = Oj::StreamWriter.new(sio, { buffer_size: 'aaaa' } )
  rescue
  end
  rss = Integer(`ps -o rss= -p #{Process.pid}`) / 1024.0
  puts "#{i}, #{rss} MB" if i % 1000 == 0
end
```