### PR TITLE
Cleanup RUBY_INTEGER_UNIFICATION

### DIFF
--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -1314,11 +1314,7 @@ static VALUE doc_type(int argc, VALUE *argv, VALUE self) {
         case T_TRUE: type = rb_cTrueClass; break;
         case T_FALSE: type = rb_cFalseClass; break;
         case T_STRING: type = rb_cString; break;
-#ifdef RUBY_INTEGER_UNIFICATION
         case T_FIXNUM: type = rb_cInteger; break;
-#else
-        case T_FIXNUM: type = rb_cFixnum; break;
-#endif
         case T_FLOAT: type = rb_cFloat; break;
         case T_ARRAY: type = rb_cArray; break;
         case T_HASH: type = rb_cHash; break;

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -640,15 +640,9 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
     } else if (float_prec_sym == k) {
         int n;
 
-#ifdef RUBY_INTEGER_UNIFICATION
         if (rb_cInteger != rb_obj_class(v)) {
             rb_raise(rb_eArgError, ":float_precision must be a Integer.");
         }
-#else
-        if (T_FIXNUM != rb_type(v)) {
-            rb_raise(rb_eArgError, ":float_precision must be a Fixnum.");
-        }
-#endif
         n = FIX2INT(v);
         if (0 >= n) {
             *copts->float_fmt = '\0';
@@ -663,15 +657,9 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
     } else if (cache_str_sym == k || cache_string_sym == k) {
         int n;
 
-#ifdef RUBY_INTEGER_UNIFICATION
         if (rb_cInteger != rb_obj_class(v)) {
             rb_raise(rb_eArgError, ":cache_str must be a Integer.");
         }
-#else
-        if (T_FIXNUM != rb_type(v)) {
-            rb_raise(rb_eArgError, ":cache_str must be a Fixnum.");
-        }
-#endif
         n = FIX2INT(v);
         if (0 >= n) {
             copts->cache_str = 0;
@@ -684,15 +672,9 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
     } else if (sec_prec_sym == k) {
         int n;
 
-#ifdef RUBY_INTEGER_UNIFICATION
         if (rb_cInteger != rb_obj_class(v)) {
             rb_raise(rb_eArgError, ":second_precision must be a Integer.");
         }
-#else
-        if (T_FIXNUM != rb_type(v)) {
-            rb_raise(rb_eArgError, ":second_precision must be a Fixnum.");
-        }
-#endif
         n = NUM2INT(v);
         if (0 > n) {
             n                   = 0;

--- a/ext/oj/stream_writer.c
+++ b/ext/oj/stream_writer.c
@@ -102,17 +102,10 @@ static VALUE stream_writer_new(int argc, VALUE *argv, VALUE self) {
             rb_gc_register_address(&buffer_size_sym);
         }
         if (Qnil != (v = rb_hash_lookup(argv[1], buffer_size_sym))) {
-#ifdef RUBY_INTEGER_UNIFICATION
             if (rb_cInteger != rb_obj_class(v)) {
                 OJ_R_FREE(sw);
                 rb_raise(rb_eArgError, ":buffer size must be a Integer.");
             }
-#else
-            if (T_FIXNUM != rb_type(v)) {
-                OJ_R_FREE(sw);
-                rb_raise(rb_eArgError, ":buffer size must be a Integer.");
-            }
-#endif
             buf_size = FIX2INT(v);
         }
         oj_str_writer_init(&sw->sw, buf_size);


### PR DESCRIPTION
RUBY_INTEGER_UNIFICATION was introduced at Ruby 2.4.0. https://github.com/ruby/ruby/blob/8c6b349805e2f17a57576b8dfad31e5681d6b0e9/doc/NEWS/NEWS-2.4.0#compatibility-issues-excluding-feature-bug-fixes-

Now, oj gem supports Ruby 2.7.0 or later.
https://github.com/ohler55/oj/blob/d289f4243b0bebd0ceb01c19cc8c338aff0c54d9/oj.gemspec#L21

So, this patch will remove unnecessary code for old Ruby.