### PR TITLE
Fix JSON.create_id= to allow nil

### DIFF
--- a/ext/oj/mimic_json.c
+++ b/ext/oj/mimic_json.c
@@ -654,11 +654,9 @@ static VALUE mimic_recurse_proc(VALUE self, VALUE obj) {
  *
  * - *id* [_nil_|String] new create_id
  *
- * Returns [_String_] the id.
+ * Returns [_nil_|_String_] the id.
  */
 static VALUE mimic_set_create_id(VALUE self, VALUE id) {
-    Check_Type(id, T_STRING);
-
     if (NULL != oj_default_options.create_id) {
         if (oj_json_class != oj_default_options.create_id) {
             OJ_R_FREE((char *)oj_default_options.create_id);
@@ -667,10 +665,11 @@ static VALUE mimic_set_create_id(VALUE self, VALUE id) {
         oj_default_options.create_id_len = 0;
     }
     if (Qnil != id) {
-        size_t len = RSTRING_LEN(id) + 1;
+        const char *ptr = StringValueCStr(id);
+        size_t      len = RSTRING_LEN(id) + 1;
 
         oj_default_options.create_id = OJ_R_ALLOC_N(char, len);
-        strcpy((char *)oj_default_options.create_id, StringValuePtr(id));
+        strcpy((char *)oj_default_options.create_id, ptr);
         oj_default_options.create_id_len = len - 1;
     }
     return id;

--- a/lib/oj/easy_hash.rb
+++ b/lib/oj/easy_hash.rb
@@ -5,10 +5,6 @@ module Oj
   # that match the keys.
   class EasyHash < Hash
 
-    # Initializes the instance to an empty Hash.
-    def initialize()
-    end
-
     # Replaces the Object.respond_to?() method.
     # @param [Symbol] m method symbol
     # @param [Boolean] include_all whether to include private and protected methods in the search

--- a/lib/oj/mimic.rb
+++ b/lib/oj/mimic.rb
@@ -63,6 +63,8 @@ module Oj
       self.store(:allow_nan, true)
       self.store(:quirks_mode, oo[:quirks_mode])
       self.store(:ascii_only, (:ascii == oo[:escape_mode]))
+
+      super
     end
 
     def []=(key, value)

--- a/test/isolated/shared.rb
+++ b/test/isolated/shared.rb
@@ -260,6 +260,8 @@ class SharedMimicTest < Minitest::Test
     obj = JSON.parse(json, :create_additions => true)
     JSON.create_id = 'json_class'
     assert_equal(jam, obj)
+
+    assert_nothing_raised { JSON.create_id = nil }
   end
   def test_parse_bang
     json = %{{"a":1,"b":[true,false]}}

--- a/test/test_parser_saj.rb
+++ b/test/test_parser_saj.rb
@@ -25,6 +25,8 @@ class AllSaj < Oj::Saj
 
   def initialize()
     @calls = []
+
+    super
   end
 
   def hash_start(key)

--- a/test/test_saj.rb
+++ b/test/test_saj.rb
@@ -25,6 +25,8 @@ class AllSaj < Oj::Saj
 
   def initialize()
     @calls = []
+
+    super
   end
 
   def hash_start(key)


### PR DESCRIPTION
`JSON.create_id=` method accepts `nil` as an argument in document. https://github.com/ohler55/oj/blob/2c1a622660ed5ab94b9fdfbcc7bc16017307972a/ext/oj/mimic_json.c#L655

However, it raises TypeError when passed `nil`.

```
irb(main):001:0> require 'oj'
=> true
irb(main):002:0> Oj.mimic_JSON
=> JSON
irb(main):003:0> JSON.create_id = nil
(irb):3:in `create_id=': wrong argument type nil (expected String) (TypeError)
        from (irb):3:in `<main>'                             
        from /home/watson/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/irb-1.6.2/exe/irb:11:in `<top (required)>'
        from /home/watson/.rbenv/versions/3.2.1/bin/irb:25:in `load'
        from /home/watson/.rbenv/versions/3.2.1/bin/irb:25:in `<main>'
irb(main):004:0> 
```

This patch will accept `nil` as an argument.