### PR TITLE
Use TRACE_PARSE_CALL() macro for debug log

### DIFF
--- a/ext/oj/custom.c
+++ b/ext/oj/custom.c
@@ -937,9 +937,7 @@ static void hash_set_cstr(ParseInfo pi, Val kval, const char *str, size_t len, c
             break;
         default: break;
         }
-        if (RB_UNLIKELY(Yes == pi->options.trace)) {
-            oj_trace_parse_call("set_string", pi, __FILE__, __LINE__, rstr);
-        }
+        TRACE_PARSE_CALL(pi->options.trace, "set_string", pi, rstr);
     }
 }
 
@@ -998,9 +996,7 @@ static void hash_set_num(struct _parseInfo *pi, Val kval, NumInfo ni) {
         break;
     default: break;
     }
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("set_string", pi, __FILE__, __LINE__, rval);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "set_string", pi, rval);
 }
 
 static void hash_set_value(ParseInfo pi, Val kval, VALUE value) {
@@ -1011,9 +1007,7 @@ static void hash_set_value(ParseInfo pi, Val kval, VALUE value) {
     case T_HASH: rb_hash_aset(parent->val, oj_calc_hash_key(pi, kval), value); break;
     default: break;
     }
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("set_value", pi, __FILE__, __LINE__, value);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "set_value", pi, value);
 }
 
 static void array_append_num(ParseInfo pi, NumInfo ni) {
@@ -1021,9 +1015,7 @@ static void array_append_num(ParseInfo pi, NumInfo ni) {
     volatile VALUE rval   = oj_num_as_value(ni);
 
     rb_ary_push(parent->val, rval);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("append_number", pi, __FILE__, __LINE__, rval);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "append_number", pi, rval);
 }
 
 static void array_append_cstr(ParseInfo pi, const char *str, size_t len, const char *orig) {
@@ -1038,9 +1030,7 @@ static void array_append_cstr(ParseInfo pi, const char *str, size_t len, const c
         }
     }
     rb_ary_push(stack_peek(&pi->stack)->val, rstr);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("append_string", pi, __FILE__, __LINE__, rstr);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "append_string", pi, rstr);
 }
 
 void oj_set_custom_callbacks(ParseInfo pi) {

--- a/ext/oj/object.c
+++ b/ext/oj/object.c
@@ -446,9 +446,7 @@ WHICH_TYPE:
                         rb_class2name(rb_obj_class(parent->val)));
         return;
     }
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("set_string", pi, __FILE__, __LINE__, rval);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "set_string", pi, rval);
 }
 
 static void hash_set_num(ParseInfo pi, Val kval, NumInfo ni) {
@@ -517,9 +515,7 @@ WHICH_TYPE:
                         rb_class2name(rb_obj_class(parent->val)));
         return;
     }
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("add_number", pi, __FILE__, __LINE__, rval);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "add_number", pi, rval);
 }
 
 static void hash_set_value(ParseInfo pi, Val kval, VALUE value) {
@@ -603,9 +599,7 @@ WHICH_TYPE:
                         rb_class2name(rb_obj_class(parent->val)));
         return;
     }
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("add_value", pi, __FILE__, __LINE__, value);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "add_value", pi, value);
 }
 
 static VALUE start_hash(ParseInfo pi) {
@@ -651,32 +645,24 @@ static void array_append_cstr(ParseInfo pi, const char *str, size_t len, const c
     }
     rval = str_to_value(pi, str, len, orig);
     rb_ary_push(stack_peek(&pi->stack)->val, rval);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("append_string", pi, __FILE__, __LINE__, rval);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "append_string", pi, rval);
 }
 
 static void array_append_num(ParseInfo pi, NumInfo ni) {
     volatile VALUE rval = oj_num_as_value(ni);
 
     rb_ary_push(stack_peek(&pi->stack)->val, rval);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("append_number", pi, __FILE__, __LINE__, rval);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "append_number", pi, rval);
 }
 
 static void add_cstr(ParseInfo pi, const char *str, size_t len, const char *orig) {
     pi->stack.head->val = str_to_value(pi, str, len, orig);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("add_string", pi, __FILE__, __LINE__, pi->stack.head->val);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "add_string", pi, pi->stack.head->val);
 }
 
 static void add_num(ParseInfo pi, NumInfo ni) {
     pi->stack.head->val = oj_num_as_value(ni);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("add_num", pi, __FILE__, __LINE__, pi->stack.head->val);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "add_num", pi, pi->stack.head->val);
 }
 
 void oj_set_object_callbacks(ParseInfo pi) {

--- a/ext/oj/strict.c
+++ b/ext/oj/strict.c
@@ -62,9 +62,7 @@ static VALUE noop_hash_key(ParseInfo pi, const char *key, size_t klen) {
 }
 
 static void add_value(ParseInfo pi, VALUE val) {
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("add_value", pi, __FILE__, __LINE__, val);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "add_value", pi, val);
     pi->stack.head->val = val;
 }
 
@@ -72,9 +70,7 @@ static void add_cstr(ParseInfo pi, const char *str, size_t len, const char *orig
     volatile VALUE rstr = oj_cstr_to_value(str, len, (size_t)pi->options.cache_str);
 
     pi->stack.head->val = rstr;
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("add_string", pi, __FILE__, __LINE__, rstr);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "add_string", pi, rstr);
 }
 
 static void add_num(ParseInfo pi, NumInfo ni) {
@@ -82,9 +78,7 @@ static void add_num(ParseInfo pi, NumInfo ni) {
         oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "not a number or other value");
     }
     pi->stack.head->val = oj_num_as_value(ni);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("add_number", pi, __FILE__, __LINE__, pi->stack.head->val);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "add_number", pi, pi->stack.head->val);
 }
 
 static VALUE start_hash(ParseInfo pi) {
@@ -99,9 +93,7 @@ static void hash_set_cstr(ParseInfo pi, Val parent, const char *str, size_t len,
     volatile VALUE rstr = oj_cstr_to_value(str, len, (size_t)pi->options.cache_str);
 
     rb_hash_aset(stack_peek(&pi->stack)->val, oj_calc_hash_key(pi, parent), rstr);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("set_string", pi, __FILE__, __LINE__, rstr);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "set_string", pi, rstr);
 }
 
 static void hash_set_num(ParseInfo pi, Val parent, NumInfo ni) {
@@ -112,16 +104,12 @@ static void hash_set_num(ParseInfo pi, Val parent, NumInfo ni) {
     }
     v = oj_num_as_value(ni);
     rb_hash_aset(stack_peek(&pi->stack)->val, oj_calc_hash_key(pi, parent), v);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("set_number", pi, __FILE__, __LINE__, v);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "set_number", pi, v);
 }
 
 static void hash_set_value(ParseInfo pi, Val parent, VALUE value) {
     rb_hash_aset(stack_peek(&pi->stack)->val, oj_calc_hash_key(pi, parent), value);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("set_value", pi, __FILE__, __LINE__, value);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "set_value", pi, value);
 }
 
 static VALUE start_array(ParseInfo pi) {
@@ -133,9 +121,7 @@ static void array_append_cstr(ParseInfo pi, const char *str, size_t len, const c
     volatile VALUE rstr = oj_cstr_to_value(str, len, (size_t)pi->options.cache_str);
 
     rb_ary_push(stack_peek(&pi->stack)->val, rstr);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("append_string", pi, __FILE__, __LINE__, rstr);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "append_string", pi, rstr);
 }
 
 static void array_append_num(ParseInfo pi, NumInfo ni) {
@@ -146,16 +132,12 @@ static void array_append_num(ParseInfo pi, NumInfo ni) {
     }
     v = oj_num_as_value(ni);
     rb_ary_push(stack_peek(&pi->stack)->val, v);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("append_number", pi, __FILE__, __LINE__, v);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "append_number", pi, v);
 }
 
 static void array_append_value(ParseInfo pi, VALUE value) {
     rb_ary_push(stack_peek(&pi->stack)->val, value);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("append_value", pi, __FILE__, __LINE__, value);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "append_value", pi, value);
 }
 
 void oj_set_strict_callbacks(ParseInfo pi) {

--- a/ext/oj/wab.c
+++ b/ext/oj/wab.c
@@ -318,9 +318,7 @@ static VALUE noop_hash_key(ParseInfo pi, const char *key, size_t klen) {
 }
 
 static void add_value(ParseInfo pi, VALUE val) {
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("add_value", pi, __FILE__, __LINE__, val);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "add_value", pi, val);
     pi->stack.head->val = val;
 }
 
@@ -468,9 +466,7 @@ static VALUE cstr_to_rstr(ParseInfo pi, const char *str, size_t len) {
 
 static void add_cstr(ParseInfo pi, const char *str, size_t len, const char *orig) {
     pi->stack.head->val = cstr_to_rstr(pi, str, len);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("add_string", pi, __FILE__, __LINE__, pi->stack.head->val);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "add_string", pi, pi->stack.head->val);
 }
 
 static void add_num(ParseInfo pi, NumInfo ni) {
@@ -478,9 +474,7 @@ static void add_num(ParseInfo pi, NumInfo ni) {
         oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "not a number or other value");
     }
     pi->stack.head->val = oj_num_as_value(ni);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("add_number", pi, __FILE__, __LINE__, pi->stack.head->val);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "add_number", pi, pi->stack.head->val);
 }
 
 static VALUE start_hash(ParseInfo pi) {
@@ -495,9 +489,7 @@ static void hash_set_cstr(ParseInfo pi, Val parent, const char *str, size_t len,
     volatile VALUE rval = cstr_to_rstr(pi, str, len);
 
     rb_hash_aset(stack_peek(&pi->stack)->val, calc_hash_key(pi, parent), rval);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("set_string", pi, __FILE__, __LINE__, rval);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "set_string", pi, rval);
 }
 
 static void hash_set_num(ParseInfo pi, Val parent, NumInfo ni) {
@@ -508,16 +500,12 @@ static void hash_set_num(ParseInfo pi, Val parent, NumInfo ni) {
     }
     rval = oj_num_as_value(ni);
     rb_hash_aset(stack_peek(&pi->stack)->val, calc_hash_key(pi, parent), rval);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("set_number", pi, __FILE__, __LINE__, rval);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "set_number", pi, rval);
 }
 
 static void hash_set_value(ParseInfo pi, Val parent, VALUE value) {
     rb_hash_aset(stack_peek(&pi->stack)->val, calc_hash_key(pi, parent), value);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("set_value", pi, __FILE__, __LINE__, value);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "set_value", pi, value);
 }
 
 static VALUE start_array(ParseInfo pi) {
@@ -529,9 +517,7 @@ static void array_append_cstr(ParseInfo pi, const char *str, size_t len, const c
     volatile VALUE rval = cstr_to_rstr(pi, str, len);
 
     rb_ary_push(stack_peek(&pi->stack)->val, rval);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("set_value", pi, __FILE__, __LINE__, rval);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "set_value", pi, rval);
 }
 
 static void array_append_num(ParseInfo pi, NumInfo ni) {
@@ -542,16 +528,12 @@ static void array_append_num(ParseInfo pi, NumInfo ni) {
     }
     rval = oj_num_as_value(ni);
     rb_ary_push(stack_peek(&pi->stack)->val, rval);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("append_number", pi, __FILE__, __LINE__, rval);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "append_number", pi, rval);
 }
 
 static void array_append_value(ParseInfo pi, VALUE value) {
     rb_ary_push(stack_peek(&pi->stack)->val, value);
-    if (RB_UNLIKELY(Yes == pi->options.trace)) {
-        oj_trace_parse_call("append_value", pi, __FILE__, __LINE__, value);
-    }
+    TRACE_PARSE_CALL(pi->options.trace, "append_value", pi, value);
 }
 
 void oj_set_wab_callbacks(ParseInfo pi) {


### PR DESCRIPTION
I forgot to change these when I was add `-enable-trace-log` install option at https://github.com/ohler55/oj/pull/832.