### PR TITLE
Hide method redefined warnings

### DIFF
--- a/ext/oj/mimic_json.c
+++ b/ext/oj/mimic_json.c
@@ -791,28 +791,48 @@ void oj_mimic_json_methods(VALUE json) {
     VALUE json_error;
     VALUE generator;
     VALUE ext;
+    VALUE verbose;
 
+    // rb_undef_method doesn't work for modules or maybe sometimes
+    // doesn't. Anyway setting verbose should hide the warning.
+    verbose = rb_gv_get("$VERBOSE");
+    rb_gv_set("$VERBOSE", Qfalse);
+
+    rb_undef_method(json, "create_id=");
     rb_define_module_function(json, "create_id=", mimic_set_create_id, 1);
+    rb_undef_method(json, "create_id");
     rb_define_module_function(json, "create_id", mimic_create_id, 0);
 
+    rb_undef_method(json, "dump");
     rb_define_module_function(json, "dump", mimic_dump, -1);
+    rb_undef_method(json, "load");
     rb_define_module_function(json, "load", mimic_load, -1);
     rb_define_module_function(json, "restore", mimic_load, -1);
+    rb_undef_method(json, "recurse_proc");
     rb_define_module_function(json, "recurse_proc", mimic_recurse_proc, 1);
+    rb_undef_method(json, "[]");
     rb_define_module_function(json, "[]", mimic_dump_load, -1);
 
+    rb_undef_method(json, "generate");
     rb_define_module_function(json, "generate", oj_mimic_generate, -1);
+    rb_undef_method(json, "fast_generate");
     rb_define_module_function(json, "fast_generate", oj_mimic_generate, -1);
+    rb_undef_method(json, "pretty_generate");
     rb_define_module_function(json, "pretty_generate", oj_mimic_pretty_generate, -1);
     // For older versions of JSON, the deprecated unparse methods.
+    rb_undef_method(json, "unparse");
     rb_define_module_function(json, "unparse", oj_mimic_generate, -1);
     rb_define_module_function(json, "fast_unparse", oj_mimic_generate, -1);
     rb_define_module_function(json, "pretty_unparse", oj_mimic_pretty_generate, -1);
 
+    rb_undef_method(json, "parse");
     rb_define_module_function(json, "parse", oj_mimic_parse, -1);
+    rb_undef_method(json, "parse!");
     rb_define_module_function(json, "parse!", mimic_parse_bang, -1);
 
+    rb_undef_method(json, "state");
     rb_define_module_function(json, "state", mimic_state, 0);
+    rb_gv_set("$VERBOSE", verbose);
 
     if (rb_const_defined_at(json, rb_intern("JSONError"))) {
         json_error = rb_const_get(json, rb_intern("JSONError"));


### PR DESCRIPTION
A few warning messages appear while using `Oj.optimize_rails` with `$VERBOSE = true`
Here they are:
```
.../config/application.rb:23: warning: method redefined; discarding old create_id=
/Users/vasyldubinchyk/.rvm/gems/ruby-3.1.3/gems/json-2.6.2/lib/json/common.rb:120: warning: previous definition of create_id= was here
.../config/application.rb:23: warning: method redefined; discarding old create_id
/Users/vasyldubinchyk/.rvm/gems/ruby-3.1.3/gems/json-2.6.2/lib/json/common.rb:126: warning: previous definition of create_id was here
.../config/application.rb:23: warning: method redefined; discarding old dump
/Users/vasyldubinchyk/.rvm/gems/ruby-3.1.3/gems/json-2.6.2/lib/json/common.rb:631: warning: previous definition of dump was here
.../config/application.rb:23: warning: method redefined; discarding old dump
/Users/vasyldubinchyk/.rvm/gems/ruby-3.1.3/gems/json-2.6.2/lib/json/common.rb:631: warning: previous definition of dump was here
.../config/application.rb:23: warning: method redefined; discarding old load
/Users/vasyldubinchyk/.rvm/gems/ruby-3.1.3/gems/json-2.6.2/lib/json/common.rb:557: warning: previous definition of load was here
.../config/application.rb:23: warning: method redefined; discarding old recurse_proc
/Users/vasyldubinchyk/.rvm/gems/ruby-3.1.3/gems/json-2.6.2/lib/json/common.rb:575: warning: previous definition of recurse_proc was here
.../config/application.rb:23: warning: method redefined; discarding old recurse_proc
/Users/vasyldubinchyk/.rvm/gems/ruby-3.1.3/gems/json-2.6.2/lib/json/common.rb:575: warning: previous definition of recurse_proc was here
.../config/application.rb:23: warning: method redefined; discarding old []
/Users/vasyldubinchyk/.rvm/gems/ruby-3.1.3/gems/json-2.6.2/lib/json/common.rb:18: warning: previous definition of [] was here
.../config/application.rb:23: warning: method redefined; discarding old generate
/Users/vasyldubinchyk/.rvm/gems/ruby-3.1.3/gems/json-2.6.2/lib/json/common.rb:296: warning: previous definition of generate was here
.../config/application.rb:23: warning: method redefined; discarding old fast_generate
/Users/vasyldubinchyk/.rvm/gems/ruby-3.1.3/gems/json-2.6.2/lib/json/common.rb:335: warning: previous definition of fast_generate was here
.../config/application.rb:23: warning: method redefined; discarding old pretty_generate
/Users/vasyldubinchyk/.rvm/gems/ruby-3.1.3/gems/json-2.6.2/lib/json/common.rb:390: warning: previous definition of pretty_generate was here
.../config/application.rb:23: warning: method redefined; discarding old parse
.../config/application.rb:23: warning: method redefined; discarding old parse
.../config/application.rb:23: warning: method redefined; discarding old parse!
/Users/vasyldubinchyk/.rvm/gems/ruby-3.1.3/gems/json-2.6.2/lib/json/common.rb:230: warning: previous definition of parse! was here
.../config/application.rb:23: warning: method redefined; discarding old parse!
/Users/vasyldubinchyk/.rvm/gems/ruby-3.1.3/gems/json-2.6.2/lib/json/common.rb:230: warning: previous definition of parse! was here
.../config/application.rb:23: warning: method redefined; discarding old state
```

To fix this problem I suggest using the same method that used here:
https://github.com/ohler55/oj/blob/8095883382b33b4468e997be62622545403ec3be/ext/oj/rails.c#L1041-L1062
https://github.com/ohler55/oj/blob/8095883382b33b4468e997be62622545403ec3be/ext/oj/rails.c#L1093-L1099