### PR TITLE
Remove checking whether rb_gc_mark_movable exists

### DIFF
--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -24,7 +24,6 @@ dflags = {
 }
 
 # Support for compaction.
-have_func('rb_gc_mark_movable')
 have_func('stpcpy')
 have_func('pthread_mutex_init')
 have_func('rb_enc_interned_str')

--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -22,13 +22,6 @@
 // #define BATCH_SIZE	(4096 / sizeof(struct _leaf) - 1)
 #define BATCH_SIZE 100
 
-// Support for compaction
-#ifdef HAVE_RB_GC_MARK_MOVABLE
-#define mark rb_gc_mark_movable
-#else
-#define mark rb_gc_mark
-#endif
-
 typedef struct _batch {
     struct _batch *next;
     int            next_avail;
@@ -691,7 +684,7 @@ static void mark_leaf(Leaf leaf) {
                 } while (e != first);
             }
             break;
-        case RUBY_VAL: mark(leaf->value); break;
+        case RUBY_VAL: rb_gc_mark_movable(leaf->value); break;
 
         default: break;
         }
@@ -702,11 +695,11 @@ static void mark_doc(void *ptr) {
     if (NULL != ptr) {
         Doc doc = (Doc)ptr;
 
-        mark(doc->self);
+        rb_gc_mark_movable(doc->self);
         mark_leaf(doc->data);
     }
 }
-#ifdef HAVE_RB_GC_MARK_MOVABLE
+
 static void compact_leaf(Leaf leaf) {
     switch (leaf->value_type) {
     case COL_VAL:
@@ -734,7 +727,6 @@ static void compact_doc(void *ptr) {
         compact_leaf(doc->data);
     }
 }
-#endif
 
 static const rb_data_type_t oj_doc_type = {
     "Oj/doc",
@@ -742,9 +734,7 @@ static const rb_data_type_t oj_doc_type = {
         mark_doc,
         free_doc_cb,
         NULL,
-#ifdef HAVE_RB_GC_MARK_MOVABLE
         compact_doc,
-#endif
     },
     0,
     0,


### PR DESCRIPTION
Currently the oj gem supports Ruby 2.7+.

rb_gc_mark_movable() has introduced at Ruby 2.7.
Ref. https://github.com/ruby/ruby/blob/v2_7_0/include/ruby/intern.h#L540

So, we can use rb_gc_mark_movable() freely in oj gem.