### PR TITLE
Revert "Remove checking whether rb_gc_mark_movable exists"

### DIFF
--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -24,6 +24,7 @@ dflags = {
 }
 
 # Support for compaction.
+have_func('rb_gc_mark_movable')
 have_func('stpcpy')
 have_func('pthread_mutex_init')
 have_func('rb_enc_interned_str')


### PR DESCRIPTION
Reverts ohler55/oj#876

Because truffleruby caseus following error about `rb_gc_mark_movable`.
Hmm, it has something changes in truffleruby head, maybe...

```
DocTest#test_open_close:
RuntimeError: Wrapped undumpable exception for: Polyglot::ForeignException: External LLVMFunction rb_gc_mark_movable cannot be found.
    /home/runner/work/oj/oj/ext/oj/fast.c:694:in `mark_doc'
    <internal:core> core/truffle/polyglot.rb:334:in `<unknown>'
    <internal:core> core/truffle/polyglot.rb:334:in `Truffle::Interop.execute'
    <internal:core> core/truffle/polyglot.rb:334:in `Polyglot::ExecutableTrait#call'
    /home/runner/.rubies/truffleruby-23.0.0-preview1/lib/truffle/truffle/cext.rb:1520:in `CExt#run_marker'
    /home/runner/.rubies/truffleruby-23.0.0-preview1/lib/truffle/truffle/cext_ruby.rb:41:in `Oj::Doc.open'
    /home/runner/work/oj/oj/test/test_fast.rb:421:in `DocTest#test_open_close'
```

https://github.com/ohler55/oj/actions/runs/4908511676/jobs/8764323186