### PR TITLE
Move development dependency gems into Gemfile to fix lint error

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,7 @@ group :development do
   gem "rubocop", "~> 1.47", require: false
   gem "rubocop-minitest", "~> 0.28.0", require: false
 end
+
+gem 'minitest', '~> 5', require: false
+gem 'rake-compiler', '>= 0.9', '< 2.0', require: false
+gem 'test-unit', '~> 3.0', require: false

--- a/oj.gemspec
+++ b/oj.gemspec
@@ -25,8 +25,4 @@ Gem::Specification.new do |s|
 
   s.extra_rdoc_files = ['README.md', 'LICENSE', 'CHANGELOG.md', 'RELEASE_NOTES.md'] + Dir["pages/*.md"]
   s.rdoc_options = ['--title', 'Oj', '--main', 'README.md']
-
-  s.add_development_dependency 'minitest', '~> 5'
-  s.add_development_dependency 'rake-compiler', '>= 0.9', '< 2.0'
-  s.add_development_dependency 'test-unit', '~> 3.0'
 end


### PR DESCRIPTION
This patch will fix lint error in https://github.com/ohler55/oj/actions/runs/5104692030/jobs/9175781272