### PR TITLE
Enable optional skipping of null bytes on dump

### DIFF
--- a/docs/mode_table.html
+++ b/docs/mode_table.html
@@ -36,6 +36,7 @@
   <tr><td>:quirks_mode</td><td>Boolean</td><td></td><td></td><td>6</td><td></td><td></td><td>x</td><td></td></tr>
   <tr><td>:safe</td><td>String</td><td></td><td></td><td>x</td><td></td><td></td><td></td><td></td></tr>
   <tr><td>:second_precision</td><td>Fixnum</td><td></td><td></td><td></td><td></td><td>x</td><td>x</td><td></td></tr>
+  <tr><td>:skip_null_byte</td><td>Boolean</td><td>x</td><td>x</td><td>x</td><td>x</td><td>x</td><td>x</td><td></td></tr>
   <tr><td>:space</td><td>String</td><td></td><td></td><td>x</td><td>x</td><td></td><td>x</td><td></td></tr>
   <tr><td>:space_before</td><td>String</td><td></td><td></td><td>x</td><td>x</td><td></td><td>x</td><td></td></tr>
   <tr><td>:symbol_keys</td><td>Boolean</td><td>x</td><td>x</td><td>x</td><td>x</td><td>x</td><td>x</td><td></td></tr>

--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -856,6 +856,8 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
                 str = dump_unicode(str, end, out, orig);
                 break;
             case '6':  // control characters
+                if ((uint8_t)*str == 0 && out->opts->skip_null_byte == Yes) break;
+
                 if (*(uint8_t *)str < 0x80) {
                     APPEND_CHARS(out->cur, "\\u00", 4);
                     dump_hex((uint8_t)*str, out);

--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -856,9 +856,10 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
                 str = dump_unicode(str, end, out, orig);
                 break;
             case '6':  // control characters
-                if ((uint8_t)*str == 0 && out->opts->skip_null_byte == Yes) break;
-
                 if (*(uint8_t *)str < 0x80) {
+                    if (0 == (uint8_t)*str && Yes == out->opts->skip_null_byte) {
+                        break;
+                    }
                     APPEND_CHARS(out->cur, "\\u00", 4);
                     dump_hex((uint8_t)*str, out);
                 } else {

--- a/ext/oj/mimic_json.c
+++ b/ext/oj/mimic_json.c
@@ -723,6 +723,7 @@ static struct _options mimic_object_to_json_options = {0,              // indent
                                                        "%0.16g",       // float_fmt
                                                        Qnil,           // hash_class
                                                        Qnil,           // array_class
+                                                       No,             // skip_null_byte
                                                        {
                                                            // dump_opts
                                                            false,     // use

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -387,10 +387,11 @@ static VALUE get_def_opts(VALUE self) {
         opts,
         cache_keys_sym,
         (Yes == oj_default_options.cache_keys) ? Qtrue : ((No == oj_default_options.cache_keys) ? Qfalse : Qnil));
-    rb_hash_aset(
-        opts,
-        oj_skip_null_byte_sym,
-        (Yes == oj_default_options.skip_null_byte) ? Qtrue : ((No == oj_default_options.skip_null_byte) ? Qfalse : Qnil));
+    rb_hash_aset(opts,
+                 oj_skip_null_byte_sym,
+                 (Yes == oj_default_options.skip_null_byte)
+                     ? Qtrue
+                     : ((No == oj_default_options.skip_null_byte) ? Qfalse : Qnil));
 
     switch (oj_default_options.mode) {
     case StrictMode: rb_hash_aset(opts, mode_sym, strict_sym); break;

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -97,6 +97,7 @@ VALUE oj_nanosecond_sym;
 VALUE oj_object_class_sym;
 VALUE oj_quirks_mode_sym;
 VALUE oj_safe_sym;
+VALUE oj_skip_null_byte_sym;
 VALUE oj_symbolize_names_sym;
 VALUE oj_trace_sym;
 
@@ -207,6 +208,7 @@ struct _options oj_default_options = {
     "%0.15g",       // float_fmt
     Qnil,           // hash_class
     Qnil,           // array_class
+    No,             // skip_null_byte
     {
         // dump_opts
         false,      // use
@@ -299,6 +301,7 @@ struct _options oj_default_options = {
  * - *:integer_range* [_Range_] Dump integers outside range as strings.
  * - *:trace* [_true,_|_false_] Trace all load and dump calls, default is false (trace is off)
  * - *:safe* [_true,_|_false_] Safe mimic breaks JSON mimic to be safer, default is false (safe is
+ * - *:skip_null_byte* [_true_|_false_] if true null bytes in strings will be omitted when dumping
  *off)
  *
  * Return [_Hash_] all current option settings.
@@ -384,6 +387,11 @@ static VALUE get_def_opts(VALUE self) {
         opts,
         cache_keys_sym,
         (Yes == oj_default_options.cache_keys) ? Qtrue : ((No == oj_default_options.cache_keys) ? Qfalse : Qnil));
+    rb_hash_aset(
+        opts,
+        oj_skip_null_byte_sym,
+        (Yes == oj_default_options.skip_null_byte) ? Qtrue : ((No == oj_default_options.skip_null_byte) ? Qfalse : Qnil));
+
     switch (oj_default_options.mode) {
     case StrictMode: rb_hash_aset(opts, mode_sym, strict_sym); break;
     case CompatMode: rb_hash_aset(opts, mode_sym, compat_sym); break;
@@ -585,6 +593,7 @@ bool set_yesno_options(VALUE key, VALUE value, Options copts) {
                                {ignore_under_sym, &copts->ignore_under},
                                {oj_create_additions_sym, &copts->create_ok},
                                {cache_keys_sym, &copts->cache_keys},
+                               {oj_skip_null_byte_sym, &copts->skip_null_byte},
                                {Qnil, 0}};
     YesNoOpt         o;
 
@@ -1967,6 +1976,8 @@ void Init_oj(void) {
     rb_gc_register_address(&oj_quirks_mode_sym);
     oj_safe_sym = ID2SYM(rb_intern("safe"));
     rb_gc_register_address(&oj_safe_sym);
+    oj_skip_null_byte_sym = ID2SYM(rb_intern("skip_null_byte"));
+    rb_gc_register_address(&oj_skip_null_byte_sym);
     oj_space_before_sym = ID2SYM(rb_intern("space_before"));
     rb_gc_register_address(&oj_space_before_sym);
     oj_space_sym = ID2SYM(rb_intern("space"));

--- a/ext/oj/oj.h
+++ b/ext/oj/oj.h
@@ -165,6 +165,7 @@ typedef struct _options {
     char             float_fmt[7];   // float format for dumping, if empty use Ruby
     VALUE            hash_class;     // class to use in place of Hash on load
     VALUE            array_class;    // class to use in place of Array on load
+    char             skip_null_byte; // YesNo
     struct _dumpOpts dump_opts;
     struct _rxClass  str_rx;
     VALUE           *ignore;  // Qnil terminated array of classes or NULL
@@ -323,6 +324,7 @@ extern VALUE oj_max_nesting_sym;
 extern VALUE oj_object_class_sym;
 extern VALUE oj_object_nl_sym;
 extern VALUE oj_quirks_mode_sym;
+extern VALUE oj_skip_null_byte_sym;
 extern VALUE oj_space_before_sym;
 extern VALUE oj_space_sym;
 extern VALUE oj_symbolize_names_sym;

--- a/ext/oj/oj.h
+++ b/ext/oj/oj.h
@@ -128,44 +128,44 @@ typedef struct _dumpOpts {
 } *DumpOpts;
 
 typedef struct _options {
-    int              indent;         // indention for dump, default 2
-    char             circular;       // YesNo
-    char             auto_define;    // YesNo
-    char             sym_key;        // YesNo
-    char             escape_mode;    // Escape_Mode
-    char             mode;           // Mode
-    char             class_cache;    // YesNo
-    char             time_format;    // TimeFormat
-    char             bigdec_as_num;  // YesNo
-    char             bigdec_load;    // BigLoad
-    char             compat_bigdec;  // boolean (0 or 1)
-    char             to_hash;        // YesNo
-    char             to_json;        // YesNo
-    char             as_json;        // YesNo
-    char             raw_json;       // YesNo
-    char             nilnil;         // YesNo
-    char             empty_string;   // YesNo
-    char             allow_gc;       // allow GC during parse
-    char             quirks_mode;    // allow single JSON values instead of documents
-    char             allow_invalid;  // YesNo - allow invalid unicode
-    char             create_ok;      // YesNo allow create_id
-    char             allow_nan;      // YEsyNo for parsing only
-    char             trace;          // YesNo
-    char             safe;           // YesNo
-    char             sec_prec_set;   // boolean (0 or 1)
-    char             ignore_under;   // YesNo - ignore attrs starting with _ if true in object and custom modes
-    char             cache_keys;     // YesNo
-    char             cache_str;      // string short than or equal to this are cache
-    int64_t          int_range_min;  // dump numbers below as string
-    int64_t          int_range_max;  // dump numbers above as string
-    const char      *create_id;      // 0 or string
-    size_t           create_id_len;  // length of create_id
-    int              sec_prec;       // second precision when dumping time
-    char             float_prec;     // float precision, linked to float_fmt
-    char             float_fmt[7];   // float format for dumping, if empty use Ruby
-    VALUE            hash_class;     // class to use in place of Hash on load
-    VALUE            array_class;    // class to use in place of Array on load
-    char             skip_null_byte; // YesNo
+    int              indent;          // indention for dump, default 2
+    char             circular;        // YesNo
+    char             auto_define;     // YesNo
+    char             sym_key;         // YesNo
+    char             escape_mode;     // Escape_Mode
+    char             mode;            // Mode
+    char             class_cache;     // YesNo
+    char             time_format;     // TimeFormat
+    char             bigdec_as_num;   // YesNo
+    char             bigdec_load;     // BigLoad
+    char             compat_bigdec;   // boolean (0 or 1)
+    char             to_hash;         // YesNo
+    char             to_json;         // YesNo
+    char             as_json;         // YesNo
+    char             raw_json;        // YesNo
+    char             nilnil;          // YesNo
+    char             empty_string;    // YesNo
+    char             allow_gc;        // allow GC during parse
+    char             quirks_mode;     // allow single JSON values instead of documents
+    char             allow_invalid;   // YesNo - allow invalid unicode
+    char             create_ok;       // YesNo allow create_id
+    char             allow_nan;       // YEsyNo for parsing only
+    char             trace;           // YesNo
+    char             safe;            // YesNo
+    char             sec_prec_set;    // boolean (0 or 1)
+    char             ignore_under;    // YesNo - ignore attrs starting with _ if true in object and custom modes
+    char             cache_keys;      // YesNo
+    char             cache_str;       // string short than or equal to this are cache
+    int64_t          int_range_min;   // dump numbers below as string
+    int64_t          int_range_max;   // dump numbers above as string
+    const char      *create_id;       // 0 or string
+    size_t           create_id_len;   // length of create_id
+    int              sec_prec;        // second precision when dumping time
+    char             float_prec;      // float precision, linked to float_fmt
+    char             float_fmt[7];    // float format for dumping, if empty use Ruby
+    VALUE            hash_class;      // class to use in place of Hash on load
+    VALUE            array_class;     // class to use in place of Array on load
+    char             skip_null_byte;  // YesNo
     struct _dumpOpts dump_opts;
     struct _rxClass  str_rx;
     VALUE           *ignore;  // Qnil terminated array of classes or NULL

--- a/pages/Options.md
+++ b/pages/Options.md
@@ -265,6 +265,10 @@ to true.
 
 The number of digits after the decimal when dumping the seconds of time.
 
+### :skip_null_byte [Boolean]
+
+If true, null bytes in strings will be omitted when dumping.
+
 ### :space
 
 String inserted after the ':' character when dumping a JSON object. The

--- a/test/test_custom.rb
+++ b/test/test_custom.rb
@@ -393,6 +393,11 @@ class CustomJuice < Minitest::Test
     assert_equal(%|{"x":{"a":1}}|, json)
   end
 
+  def test_skip_null_byte
+    json = Oj.dump({ "fo\x00o" => "b\x00ar" }, :skip_null_byte => true)
+    assert_equal(%|{"foo":"bar"}|, json)
+  end
+
   def test_complex
     obj = Complex(2, 9)
     dump_and_load(obj, false, :create_id => "^o", :create_additions => true)


### PR DESCRIPTION
Closes: #882 

## Why?

See https://github.com/ohler55/oj/issues/882

## What's changed?

- A `:skip_null_byte` boolean option is introduced. If set to `true`, null bytes will be omitted from strings when dumping.
- Documentation is updated (`docs/mode_table.html` and `Pages/Options.md`)

## Example

```rb
Oj.dump({ "key\x00" => "val\x00ue" }, :skip_null_byte => true)

# => "{\"key\":\"value\"}"
``` 