### PR TITLE
Refactor in where obtain hash keys by using common function

### DIFF
--- a/ext/oj/custom.c
+++ b/ext/oj/custom.c
@@ -889,12 +889,11 @@ void oj_dump_custom_val(VALUE obj, int depth, Out out, bool as_ok) {
 ///// load functions /////
 
 static void hash_set_cstr(ParseInfo pi, Val kval, const char *str, size_t len, const char *orig) {
-    const char    *key    = kval->key;
-    int            klen   = kval->klen;
-    Val            parent = stack_peek(&pi->stack);
-    volatile VALUE rkey   = kval->key_val;
+    const char *key    = kval->key;
+    int         klen   = kval->klen;
+    Val         parent = stack_peek(&pi->stack);
 
-    if (Qundef == rkey && Yes == pi->options.create_ok && NULL != pi->options.create_id &&
+    if (Qundef == kval->key_val && Yes == pi->options.create_ok && NULL != pi->options.create_id &&
         *pi->options.create_id == *key && (int)pi->options.create_id_len == klen &&
         0 == strncmp(pi->options.create_id, key, klen)) {
         parent->clas = oj_name2class(pi, str, len, false, rb_eArgError);
@@ -907,15 +906,8 @@ static void hash_set_cstr(ParseInfo pi, Val kval, const char *str, size_t len, c
         }
     } else {
         volatile VALUE rstr = oj_cstr_to_value(str, len, (size_t)pi->options.cache_str);
-        // volatile VALUE rstr = rb_utf8_str_new(str, len);
+        volatile VALUE rkey = oj_calc_hash_key(pi, kval);
 
-        if (Qundef == rkey) {
-            if (Yes == pi->options.sym_key) {
-                rkey = ID2SYM(rb_intern3(key, klen, oj_utf8_encoding));
-            } else {
-                rkey = rb_utf8_str_new(key, klen);
-            }
-        }
         if (Yes == pi->options.create_ok && NULL != pi->options.str_rx.head) {
             VALUE clas = oj_rxclass_match(&pi->options.str_rx, str, (int)len);
 

--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -709,10 +709,7 @@ void oj_parse2(ParseInfo pi) {
         case '[': array_start(pi); break;
         case ']': array_end(pi); break;
         case ',': comma(pi); break;
-        case '"':
-            read_str(pi);
-            break;
-            // case '+':
+        case '"': read_str(pi); break;
         case '+':
             if (CompatMode == pi->options.mode) {
                 oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "unexpected character");


### PR DESCRIPTION
Refactor in where obtain hash keys by using common function. However, it might have the margin of error for the overhead of calling oj_calc_hash_key().

−       | before   | after    | result
--       | --       | --       | --
Oj.dump  | 449.521k | 447.738k | 0.996x

### Environment
- Linux
  - Manjaro Linux x86_64
  - Kernel: 6.3.5-2-MANJARO
  - AMD Ryzen 7 5800H
  - gcc version 13.1.1
  - Ruby 3.2.2

### Before
```
Warming up --------------------------------------
             Oj.load    44.738k i/100ms
Calculating -------------------------------------
             Oj.load    449.521k (± 0.9%) i/s -      6.755M in  15.029388s
```

### After
```
Warming up --------------------------------------
             Oj.load    44.117k i/100ms
Calculating -------------------------------------
             Oj.load    447.738k (± 0.3%) i/s -      6.750M in  15.075672s
```

### Test code
```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
  gem 'oj'
end

json =<<-EOF
{
  "$id": "https://example.com/person.schema.json",
  "$schema": "https://json-schema.org/draft/2020-12/schema",
  "title": "Person",
  "type": "object",
  "properties": {
    "firstName": {
      "type": "string",
      "description": "The person's first name."
    },
    "lastName": {
      "type": "string",
      "description": "The person's last name."
    },
    "age": {
      "description": "Age in years which must be equal to or greater than zero.",
      "type": "integer",
      "minimum": 0
    }
  }
}
EOF

Benchmark.ips do |x|
  x.warmup = 5
  x.time = 15

  x.report('Oj.load') { Oj.load(json, mode: :compat) }
end
```