### PR TITLE
Fix "Invalid float" parse error

### DIFF
--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -875,7 +875,11 @@ oj_num_as_value(NumInfo ni) {
             double d = strtod(ni->str, &end);
 
             if ((long)ni->len != (long)(end - ni->str)) {
+              if (Qnil == ni->pi->err_class) {
+                rb_raise(oj_parse_error_class, "Invalid float");
+              } else {
                 rb_raise(ni->pi->err_class, "Invalid float");
+              }
             }
             rnum = rb_float_new(d);
         }

--- a/test/test_strict.rb
+++ b/test/test_strict.rb
@@ -69,6 +69,16 @@ class StrictJuice < Minitest::Test
     dump_and_load(-2.48e100 * 1.0e10, false)
   end
 
+  def test_invalid_float
+    begin
+      Oj.load("64ecb72d29191067f91ff95b")
+    rescue Oj::ParseError => e
+      assert(e.message == "Invalid float")
+      return
+    end
+    assert(false, "*** expected an exception")
+  end
+
   def test_nan_dump
     assert_equal('null', Oj.dump(0/0.0, :nan => :null))
     assert_equal('3.3e14159265358979323846', Oj.dump(0/0.0, :nan => :huge))


### PR DESCRIPTION
Makes `Oj.load("64ecb72d29191067f91ff95b")` return `Oj::ParseError` again like versions before 3.15 did.

Closes #896 