### PR TITLE
Add bigdecimal as dependency gem

### DIFF
--- a/oj.gemspec
+++ b/oj.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ['README.md', 'LICENSE', 'CHANGELOG.md', 'RELEASE_NOTES.md'] + Dir['pages/*.md']
   s.rdoc_options = ['--title', 'Oj', '--main', 'README.md']
 
+  s.add_runtime_dependency 'bigdecimal', '~> 3.1'
   s.add_development_dependency 'minitest', '~> 5'
   s.add_development_dependency 'rake-compiler', '>= 0.9', '< 2.0'
   s.add_development_dependency 'test-unit', '~> 3.0'


### PR DESCRIPTION
The bigdecimal gem will be changed bundled gem since Ruby 3.4.0.
https://www.ruby-lang.org/en/news/2023/09/14/ruby-3-3-0-preview2-released/

To use bundled gem, it requires to specify the dependency in Gemfile.

This patch will fix following warning with Ruby 3.3.0-preview2.
```
/Users/watson/.rbenv/versions/3.3.0-preview2/lib/ruby/gems/3.3.0+0/gems/oj-3.16.1/lib/oj/mimic.rb:3: warning: bigdecimal will be not part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile. Also contact author of  to add bigdecimal into its gemspec.
```