### PR TITLE
Stop using the deprecated `Data_*` API

### DIFF
--- a/ext/oj/cache.c
+++ b/ext/oj/cache.c
@@ -261,7 +261,7 @@ void cache_set_expunge_rate(Cache c, int rate) {
 }
 
 void cache_free(void *data) {
-    Cache c = (Cache)data;
+    Cache    c = (Cache)data;
     uint64_t i;
 
     for (i = 0; i < c->size; i++) {
@@ -278,7 +278,7 @@ void cache_free(void *data) {
 }
 
 void cache_mark(void *data) {
-    Cache c = (Cache)data;
+    Cache    c = (Cache)data;
     uint64_t i;
 
 #if !HAVE_PTHREAD_MUTEX_INIT

--- a/ext/oj/cache.c
+++ b/ext/oj/cache.c
@@ -260,7 +260,8 @@ void cache_set_expunge_rate(Cache c, int rate) {
     c->xrate = (uint8_t)rate;
 }
 
-void cache_free(Cache c) {
+void cache_free(void *data) {
+    Cache c = (Cache)data;
     uint64_t i;
 
     for (i = 0; i < c->size; i++) {
@@ -276,7 +277,8 @@ void cache_free(Cache c) {
     OJ_FREE(c);
 }
 
-void cache_mark(Cache c) {
+void cache_mark(void *data) {
+    Cache c = (Cache)data;
     uint64_t i;
 
 #if !HAVE_PTHREAD_MUTEX_INIT

--- a/ext/oj/cache.h
+++ b/ext/oj/cache.h
@@ -10,10 +10,11 @@
 #define CACHE_MAX_KEY 35
 
 struct _cache;
+typedef struct _cache *Cache;
 
 extern struct _cache *cache_create(size_t size, VALUE (*form)(const char *str, size_t len), bool mark, bool locking);
-extern void           cache_free(struct _cache *c);
-extern void           cache_mark(struct _cache *c);
+extern void           cache_free(void *data);
+extern void           cache_mark(void *data);
 extern void           cache_set_form(struct _cache *c, VALUE (*form)(const char *str, size_t len));
 extern VALUE          cache_intern(struct _cache *c, const char *key, size_t len);
 extern void           cache_set_expunge_rate(struct _cache *c, int rate);

--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -727,7 +727,7 @@ static void debug_raise(const char *orig, size_t cnt, int line) {
 
 void oj_dump_raw_json(VALUE obj, int depth, Out out) {
     if (oj_string_writer_class == rb_obj_class(obj)) {
-        StrWriter sw  = (StrWriter)DATA_PTR(obj);
+        StrWriter sw = oj_str_writer_unwrap(obj);
         size_t    len = sw->out.cur - sw->out.buf;
 
         if (0 < len) {

--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -727,8 +727,11 @@ static void debug_raise(const char *orig, size_t cnt, int line) {
 
 void oj_dump_raw_json(VALUE obj, int depth, Out out) {
     if (oj_string_writer_class == rb_obj_class(obj)) {
-        StrWriter sw = oj_str_writer_unwrap(obj);
-        size_t    len = sw->out.cur - sw->out.buf;
+        StrWriter sw;
+        size_t    len;
+
+        sw  = oj_str_writer_unwrap(obj);
+        len = sw->out.cur - sw->out.buf;
 
         if (0 < len) {
             len--;

--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -780,11 +780,10 @@ static VALUE parse_json(VALUE clas, char *json, bool given) {
         }
     }
 #endif
-    doc->json           = json;
-    self                = TypedData_Wrap_Struct(clas, &oj_doc_type, doc);
-    doc->self           = self;
-    DATA_PTR(doc->self) = doc;
-    result              = rb_protect(protect_open_proc, (VALUE)&pi, &ex);
+    doc->json = json;
+    self      = TypedData_Wrap_Struct(clas, &oj_doc_type, doc);
+    doc->self = self;
+    result    = rb_protect(protect_open_proc, (VALUE)&pi, &ex);
     if (given || 0 != ex) {
         DATA_PTR(doc->self) = NULL;
         // TBD is this needed?
@@ -1609,7 +1608,9 @@ static VALUE doc_dump(int argc, VALUE *argv, VALUE self) {
  *   Oj::Doc.open('[1,2,3]') { |doc| doc.size() }  #=> 4
  */
 static VALUE doc_size(VALUE self) {
-    return ULONG2NUM(((Doc)DATA_PTR(self))->size);
+    Doc d;
+    TypedData_Get_Struct(self, struct _doc, &oj_doc_type, d);
+    return ULONG2NUM(d->size);
 }
 
 /* @overload close() => nil

--- a/ext/oj/oj.h
+++ b/ext/oj/oj.h
@@ -262,6 +262,7 @@ extern void  oj_dump_leaf_to_json(Leaf leaf, Options copts, Out out);
 extern void  oj_write_leaf_to_file(Leaf leaf, const char *path, Options copts);
 extern char *oj_longlong_to_string(long long num, bool negative, char *buf);
 
+extern StrWriter oj_str_writer_unwrap(VALUE writer);
 extern void oj_str_writer_push_key(StrWriter sw, const char *key);
 extern void oj_str_writer_push_object(StrWriter sw, const char *key);
 extern void oj_str_writer_push_array(StrWriter sw, const char *key);

--- a/ext/oj/oj.h
+++ b/ext/oj/oj.h
@@ -263,6 +263,7 @@ extern void  oj_write_leaf_to_file(Leaf leaf, const char *path, Options copts);
 extern char *oj_longlong_to_string(long long num, bool negative, char *buf);
 
 extern StrWriter oj_str_writer_unwrap(VALUE writer);
+
 extern void oj_str_writer_push_key(StrWriter sw, const char *key);
 extern void oj_str_writer_push_object(StrWriter sw, const char *key);
 extern void oj_str_writer_push_array(StrWriter sw, const char *key);

--- a/ext/oj/parser.c
+++ b/ext/oj/parser.c
@@ -1334,10 +1334,11 @@ void oj_parser_set_option(ojParser p, VALUE ropts) {
  */
 static VALUE parser_missing(int argc, VALUE *argv, VALUE self) {
     ojParser       p;
-    TypedData_Get_Struct(self, struct _ojParser, &oj_parser_type, p);
     const char    *key  = NULL;
     volatile VALUE rkey = *argv;
     volatile VALUE rv   = Qnil;
+
+    TypedData_Get_Struct(self, struct _ojParser, &oj_parser_type, p);
 
 #if HAVE_RB_EXT_RACTOR_SAFE
     // This doesn't seem to do anything.
@@ -1365,8 +1366,9 @@ static VALUE parser_missing(int argc, VALUE *argv, VALUE self) {
  */
 static VALUE parser_parse(VALUE self, VALUE json) {
     ojParser    p;
-    TypedData_Get_Struct(self, struct _ojParser, &oj_parser_type, p);
     const byte *ptr = (const byte *)StringValuePtr(json);
+
+    TypedData_Get_Struct(self, struct _ojParser, &oj_parser_type, p);
 
     parser_reset(p);
     p->start(p);
@@ -1382,8 +1384,9 @@ static VALUE load_rescue(VALUE self, VALUE x) {
 
 static VALUE load(VALUE self) {
     ojParser       p;
-    TypedData_Get_Struct(self, struct _ojParser, &oj_parser_type, p);
     volatile VALUE rbuf = rb_str_new2("");
+
+    TypedData_Get_Struct(self, struct _ojParser, &oj_parser_type, p);
 
     p->start(p);
     while (true) {
@@ -1404,6 +1407,7 @@ static VALUE load(VALUE self) {
  */
 static VALUE parser_load(VALUE self, VALUE reader) {
     ojParser p;
+
     TypedData_Get_Struct(self, struct _ojParser, &oj_parser_type, p);
 
     parser_reset(p);
@@ -1422,9 +1426,10 @@ static VALUE parser_load(VALUE self, VALUE reader) {
  */
 static VALUE parser_file(VALUE self, VALUE filename) {
     ojParser    p;
-    TypedData_Get_Struct(self, struct _ojParser, &oj_parser_type, p);
     const char *path;
     int         fd;
+
+    TypedData_Get_Struct(self, struct _ojParser, &oj_parser_type, p);
 
     path = StringValuePtr(filename);
 
@@ -1470,6 +1475,7 @@ static VALUE parser_file(VALUE self, VALUE filename) {
  */
 static VALUE parser_just_one(VALUE self) {
     ojParser p;
+
     TypedData_Get_Struct(self, struct _ojParser, &oj_parser_type, p);
 
     return p->just_one ? Qtrue : Qfalse;
@@ -1485,6 +1491,7 @@ static VALUE parser_just_one(VALUE self) {
  */
 static VALUE parser_just_one_set(VALUE self, VALUE v) {
     ojParser p;
+
     TypedData_Get_Struct(self, struct _ojParser, &oj_parser_type, p);
 
     p->just_one = (Qtrue == v);

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -639,6 +639,17 @@ static void encoder_mark(void *ptr) {
     }
 }
 
+static const rb_data_type_t oj_encoder_type = {
+    "Oj/encoder",
+    {
+        encoder_mark,
+        encoder_free,
+        NULL,
+    },
+    0,
+    0,
+};
+
 /* Document-method: new
  *	call-seq: new(options=nil)
  *
@@ -656,7 +667,7 @@ static VALUE encoder_new(int argc, VALUE *argv, VALUE self) {
         oj_parse_options(*argv, &e->opts);
         e->arg = *argv;
     }
-    return Data_Wrap_Struct(encoder_class, encoder_mark, encoder_free, e);
+    return TypedData_Wrap_Struct(encoder_class, &oj_encoder_type, e);
 }
 
 static VALUE resolve_classpath(const char *name) {
@@ -748,7 +759,8 @@ static void optimize(int argc, VALUE *argv, ROptTable rot, bool on) {
  * - *classes* [_Class_] a list of classes to optimize
  */
 static VALUE encoder_optimize(int argc, VALUE *argv, VALUE self) {
-    Encoder e = (Encoder)DATA_PTR(self);
+    Encoder e;
+    TypedData_Get_Struct(self, struct _encoder, &oj_encoder_type, e);
 
     optimize(argc, argv, &e->ropts, true);
 
@@ -804,7 +816,8 @@ rails_mimic_json(VALUE self) {
  * - *classes* [_Class_] a list of classes to deoptimize
  */
 static VALUE encoder_deoptimize(int argc, VALUE *argv, VALUE self) {
-    Encoder e = (Encoder)DATA_PTR(self);
+    Encoder e;
+    TypedData_Get_Struct(self, struct _encoder, &oj_encoder_type, e);
 
     optimize(argc, argv, &e->ropts, false);
 
@@ -833,7 +846,8 @@ static VALUE rails_deoptimize(int argc, VALUE *argv, VALUE self) {
  * @return true if the class is being optimized for rails and false otherwise
  */
 static VALUE encoder_optimized(VALUE self, VALUE clas) {
-    Encoder e  = (Encoder)DATA_PTR(self);
+    Encoder e;
+    TypedData_Get_Struct(self, struct _encoder, &oj_encoder_type, e);
     ROpt    ro = oj_rails_get_opt(&e->ropts, clas);
 
     if (NULL == ro) {
@@ -940,7 +954,8 @@ static VALUE encode(VALUE obj, ROptTable ropts, Options opts, int argc, VALUE *a
  * Returns encoded object as a JSON string.
  */
 static VALUE encoder_encode(VALUE self, VALUE obj) {
-    Encoder e = (Encoder)DATA_PTR(self);
+    Encoder e;
+    TypedData_Get_Struct(self, struct _encoder, &oj_encoder_type, e);
 
     if (Qnil != e->arg) {
         VALUE argv[1] = {e->arg};

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -847,8 +847,10 @@ static VALUE rails_deoptimize(int argc, VALUE *argv, VALUE self) {
  */
 static VALUE encoder_optimized(VALUE self, VALUE clas) {
     Encoder e;
+    ROpt    ro;
+
     TypedData_Get_Struct(self, struct _encoder, &oj_encoder_type, e);
-    ROpt    ro = oj_rails_get_opt(&e->ropts, clas);
+    ro = oj_rails_get_opt(&e->ropts, clas);
 
     if (NULL == ro) {
         return Qfalse;

--- a/ext/oj/string_writer.c
+++ b/ext/oj/string_writer.c
@@ -469,7 +469,7 @@ static VALUE str_writer_reset(VALUE self) {
 static VALUE str_writer_to_s(VALUE self) {
     StrWriter sw;
     TypedData_Get_Struct(self, struct _strWriter, &oj_string_writer_type, sw);
-    VALUE     rstr = rb_str_new(sw->out.buf, sw->out.cur - sw->out.buf);
+    VALUE rstr = rb_str_new(sw->out.buf, sw->out.cur - sw->out.buf);
 
     return oj_encode(rstr);
 }

--- a/ext/oj/val_stack.c
+++ b/ext/oj/val_stack.c
@@ -8,7 +8,7 @@
 #include "odd.h"
 #include "oj.h"
 
-static void mark(void *ptr) {
+static void stack_mark(void *ptr) {
     ValStack stack = (ValStack)ptr;
     Val      v;
 
@@ -46,6 +46,17 @@ static void mark(void *ptr) {
 #endif
 }
 
+static const rb_data_type_t oj_stack_type = {
+    "Oj/stack",
+    {
+        stack_mark,
+        NULL,
+        NULL,
+    },
+    0,
+    0,
+};
+
 VALUE
 oj_stack_init(ValStack stack) {
 #ifdef HAVE_PTHREAD_MUTEX_INIT
@@ -70,7 +81,7 @@ oj_stack_init(ValStack stack) {
     stack->head->clen      = 0;
     stack->head->next      = NEXT_NONE;
 
-    return Data_Wrap_Struct(oj_cstack_class, mark, 0, stack);
+    return TypedData_Wrap_Struct(oj_cstack_class, &oj_stack_type, stack);
 }
 
 const char *oj_stack_next_string(ValNext n) {


### PR DESCRIPTION
The replacement API was introduced in Ruby 1.9.2 (2010),
and the old untyped data API was marked a deprecated in the documentation
as of Ruby 2.3.0 (2015)

Ref: https://bugs.ruby-lang.org/issues/19998

I made the minimal migration, which simply use `TypedData`, but it open the door to enable many GC features such as write barriers, immediate free, compaction support etc. But to avoid accidentally introducing any bugs I didn't do any of that, I kept changes the minimum.

On a side note I noticed this:

```c
    if (given || 0 != ex) {
        DATA_PTR(doc->self) = NULL;
        // TBD is this needed?
        /*
        doc_free(pi.doc);
        if (0 != ex) {  // will jump so caller will not free
            OJ_R_FREE(json);
        }
        */
```

To answer the comment, yes this is most definitely a memory leak, but it's unclear to me why the data pointer is even cleared in the first place, instead of letting the object free the memory. So since I don't understand why this is done I didn't attempt to fix it.