### PR TITLE
Clean up HAVE_RB_HASH_BULK_INSERT

### DIFF
--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -31,8 +31,6 @@ have_func('stpcpy')
 have_func('pthread_mutex_init')
 have_func('rb_enc_interned_str')
 have_func('rb_ext_ractor_safe', 'ruby.h')
-# rb_hash_bulk_insert is deep down in a header not included in normal build and that seems to fool have_func.
-have_func('rb_hash_bulk_insert', 'ruby.h') unless '2' == version[0] && '6' == version[1]
 
 dflags['OJ_DEBUG'] = true unless ENV['OJ_DEBUG'].nil?
 

--- a/ext/oj/usual.c
+++ b/ext/oj/usual.c
@@ -281,7 +281,6 @@ static void close_object(ojParser p) {
     VALUE         *head = d->vhead + c->vi + 1;
     volatile VALUE obj  = rb_hash_new();
 
-#if HAVE_RB_HASH_BULK_INSERT
     for (vp = head; kp < d->ktail; kp++, vp += 2) {
         *vp = d->get_key(p, kp);
         if (sizeof(kp->buf) <= (size_t)kp->len) {
@@ -289,14 +288,6 @@ static void close_object(ojParser p) {
         }
     }
     rb_hash_bulk_insert(d->vtail - head, head, obj);
-#else
-    for (vp = head; kp < d->ktail; kp++, vp += 2) {
-        rb_hash_aset(obj, d->get_key(p, kp), *(vp + 1));
-        if (sizeof(kp->buf) <= (size_t)kp->len) {
-            OJ_R_FREE(kp->key);
-        }
-    }
-#endif
     d->ktail = d->khead + c->ki;
     d->vtail = head;
     head--;
@@ -341,7 +332,6 @@ static void close_object_create(ojParser p) {
         head++;
         if (Qnil == d->hash_class) {
             obj = rb_hash_new();
-#if HAVE_RB_HASH_BULK_INSERT
             for (vp = head; kp < d->ktail; kp++, vp += 2) {
                 *vp = d->get_key(p, kp);
                 if (sizeof(kp->buf) <= (size_t)kp->len) {
@@ -349,14 +339,6 @@ static void close_object_create(ojParser p) {
                 }
             }
             rb_hash_bulk_insert(d->vtail - head, head, obj);
-#else
-            for (vp = head; kp < d->ktail; kp++, vp += 2) {
-                rb_hash_aset(obj, d->get_key(p, kp), *(vp + 1));
-                if (sizeof(kp->buf) <= (size_t)kp->len) {
-                    OJ_R_FREE(kp->key);
-                }
-            }
-#endif
         } else {
             obj = rb_class_new_instance(0, NULL, d->hash_class);
             for (vp = head; kp < d->ktail; kp++, vp += 2) {
@@ -373,7 +355,6 @@ static void close_object_create(ojParser p) {
         if (!d->ignore_json_create && rb_respond_to(clas, oj_json_create_id)) {
             volatile VALUE arg = rb_hash_new();
 
-#if HAVE_RB_HASH_BULK_INSERT
             for (vp = head; kp < d->ktail; kp++, vp += 2) {
                 *vp = d->get_key(p, kp);
                 if (sizeof(kp->buf) <= (size_t)kp->len) {
@@ -381,14 +362,6 @@ static void close_object_create(ojParser p) {
                 }
             }
             rb_hash_bulk_insert(d->vtail - head, head, arg);
-#else
-            for (vp = head; kp < d->ktail; kp++, vp += 2) {
-                rb_hash_aset(arg, d->get_key(p, kp), *(vp + 1));
-                if (sizeof(kp->buf) <= (size_t)kp->len) {
-                    OJ_R_FREE(kp->key);
-                }
-            }
-#endif
             obj = rb_funcall(clas, oj_json_create_id, 1, arg);
         } else {
             obj = rb_class_new_instance(0, NULL, clas);


### PR DESCRIPTION
`rb_hash_bulk_insert` function can be used as public API since Ruby 2.7.0. https://github.com/ruby/ruby/commit/d3df725f9efeb0e6c121f9a1316abaa90956f1b8

Current Oj gem only supports Ruby 2.7.0 or later.
So there is no need to check whether function exists.