### PR TITLE
Clean up HAVE_RB_GC_MARK_MOVABLE

### DIFF
--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -26,7 +26,6 @@ dflags = {
 }
 
 # Support for compaction.
-have_func('rb_gc_mark_movable')
 have_func('stpcpy')
 have_func('pthread_mutex_init')
 have_func('rb_enc_interned_str')

--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -22,13 +22,6 @@
 // #define BATCH_SIZE	(4096 / sizeof(struct _leaf) - 1)
 #define BATCH_SIZE 100
 
-// Support for compaction
-#ifdef HAVE_RB_GC_MARK_MOVABLE
-#define mark rb_gc_mark_movable
-#else
-#define mark rb_gc_mark
-#endif
-
 typedef struct _batch {
     struct _batch *next;
     int            next_avail;
@@ -688,7 +681,7 @@ static void mark_leaf(Leaf leaf) {
                 } while (e != first);
             }
             break;
-        case RUBY_VAL: mark(leaf->value); break;
+        case RUBY_VAL: rb_gc_mark_movable(leaf->value); break;
 
         default: break;
         }
@@ -699,11 +692,11 @@ static void mark_doc(void *ptr) {
     if (NULL != ptr) {
         Doc doc = (Doc)ptr;
 
-        mark(doc->self);
+        rb_gc_mark_movable(doc->self);
         mark_leaf(doc->data);
     }
 }
-#ifdef HAVE_RB_GC_MARK_MOVABLE
+
 static void compact_leaf(Leaf leaf) {
     switch (leaf->value_type) {
     case COL_VAL:
@@ -731,7 +724,6 @@ static void compact_doc(void *ptr) {
         compact_leaf(doc->data);
     }
 }
-#endif
 
 static const rb_data_type_t oj_doc_type = {
     "Oj/doc",
@@ -739,9 +731,7 @@ static const rb_data_type_t oj_doc_type = {
         mark_doc,
         free_doc_cb,
         NULL,
-#ifdef HAVE_RB_GC_MARK_MOVABLE
         compact_doc,
-#endif
     },
     0,
     0,


### PR DESCRIPTION
rb_gc_mark_movable has introduced at Ruby 2.7.0
https://github.com/ruby/ruby/commit/aac4d9d6c7e6b6b0742f3941b574f6006ccb5672

Current Oj gem only supports Ruby 2.7.0 or later.
So there is no need to check whether function exists.