### PR TITLE
Make invalid Unicode data raise when encoding through Oj::Rails::Encoder

### DIFF
--- a/test/activesupport7/encoding_test.rb
+++ b/test/activesupport7/encoding_test.rb
@@ -8,8 +8,17 @@ require "active_support/time"
 require_relative "time_zone_test_helpers"
 require_relative "encoding_test_cases"
 
+require 'oj'
+# Sets the ActiveSupport encoder to be Oj and also wraps the setting of globals.
+Oj::Rails.set_encoder()
+Oj::Rails.optimize()
+
 class TestJSONEncoding < ActiveSupport::TestCase
   include TimeZoneTestHelpers
+
+  def test_is_actually_oj
+    assert_equal Oj::Rails::Encoder, ActiveSupport.json_encoder
+  end
 
   def sorted_json(json)
     if json.start_with?("{") && json.end_with?("}")

--- a/test/activesupport7/encoding_test.rb
+++ b/test/activesupport7/encoding_test.rb
@@ -70,35 +70,76 @@ class TestJSONEncoding < ActiveSupport::TestCase
     ActiveSupport.escape_html_entities_in_json = false
   end
 
-  def test_utf8_string_encoded_properly
-    result = ActiveSupport::JSON.encode("€2.99")
-    assert_equal '"€2.99"', result
-    assert_equal(Encoding::UTF_8, result.encoding)
-
-    result = ActiveSupport::JSON.encode("✎☺")
-    assert_equal '"✎☺"', result
-    assert_equal(Encoding::UTF_8, result.encoding)
+  def test_hash_keys_encoding_without_escaping
+    assert_equal "{\"<>\":\"<>\"}", ActiveSupport::JSON.encode("<>" => "<>")
   end
 
-  def test_non_utf8_string_transcodes
-    s = "二".encode("Shift_JIS")
-    result = ActiveSupport::JSON.encode(s)
-    assert_equal '"二"', result
-    assert_equal Encoding::UTF_8, result.encoding
+  module UnicodeTests
+    def test_utf8_string_encoded_properly
+      result = ActiveSupport::JSON.encode("€2.99")
+      assert_equal '"€2.99"', result
+      assert_equal(Encoding::UTF_8, result.encoding)
+
+      result = ActiveSupport::JSON.encode("✎☺")
+      assert_equal '"✎☺"', result
+      assert_equal(Encoding::UTF_8, result.encoding)
+    end
+
+    def test_non_utf8_string_transcodes
+      s = "二".encode("Shift_JIS")
+      result = ActiveSupport::JSON.encode(s)
+      assert_equal '"二"', result
+      assert_equal Encoding::UTF_8, result.encoding
+    end
+
+    def test_wide_utf8_chars
+      w = "𠜎"
+      result = ActiveSupport::JSON.encode(w)
+      assert_equal '"𠜎"', result
+    end
+
+    def test_wide_utf8_roundtrip
+      hash = { string: "𐒑" }
+      json = ActiveSupport::JSON.encode(hash)
+      decoded_hash = ActiveSupport::JSON.decode(json)
+      assert_equal "𐒑", decoded_hash["string"]
+    end
+
+    def test_invalid_encoding_raises
+      s = "\xAE\xFF\x9F"
+      refute s.valid_encoding?
+
+      # n.b. this raises EncodingError, because we didn't call Oj.mimic_JSON in the test setup; but,
+      # if you do that (even indirectly through Oj.optimize_rails), then this raises a
+      # JSON::GeneratorError instead of an EncodingError.
+      assert_raises(EncodingError) do
+        ActiveSupport::JSON.encode([s])
+      end
+    end
   end
 
-  def test_wide_utf8_chars
-    w = "𠜎"
-    result = ActiveSupport::JSON.encode(w)
-    assert_equal '"𠜎"', result
+  module UnicodeTestsWithEscapingOn
+    def setup
+      ActiveSupport.escape_html_entities_in_json = true
+    end
+
+    def teardown
+      ActiveSupport.escape_html_entities_in_json = false
+    end
+
+    include UnicodeTests
   end
 
-  def test_wide_utf8_roundtrip
-    hash = { string: "𐒑" }
-    json = ActiveSupport::JSON.encode(hash)
-    decoded_hash = ActiveSupport::JSON.decode(json)
-    assert_equal "𐒑", decoded_hash["string"]
+  module UnicodeTestsWithEscapingOff
+    def setup
+      ActiveSupport.escape_html_entities_in_json = false
+    end
+
+    include UnicodeTests
   end
+
+  include UnicodeTestsWithEscapingOn
+  include UnicodeTestsWithEscapingOff
 
   def test_hash_key_identifiers_are_always_quoted
     values = { 0 => 0, 1 => 1, :_ => :_, "$" => "$", "a" => "a", :A => :A, :A0 => :A0, "A0B" => "A0B" }


### PR DESCRIPTION
This is a potential fix for https://github.com/ohler55/oj/issues/911. Currently, whether or not `Oj::Rails::Encoder` raises on invalid unicode data depends on the value of `ActiveSupport.escape_html_entities_in_json`. In order to accurately mimic the behaviour of stock Rails with the stock json gem, it should in fact raise an exception regardless.

I've so far deliberately copied rather than shared functionality that's shared between `RailsEsc` and `RailsXEsc` mode, because I wasn't quite sure how to factor the similarities out. We can leave it like this, or I'm happy to take pointers on a way to factor this down better.

I added a testcase for invalid Unicode to the Rails 6 & 7 encoding tests, and also parameterised the existing unicode-related tests to make sure they work correctly with both settings of `ActiveSupport.escape_html_entities_in_json`.