### PR TITLE
CI: Add to dependency what to migrate to bundle gem in Ruby 3.4

### DIFF
--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -4,5 +4,6 @@ source 'https://rubygems.org'
 
 gem 'rails', '6.1.3.1'
 gem 'sqlite3'
+gem 'mutex_m'
 
 gemspec :path => '../'

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -5,5 +5,6 @@ source 'https://rubygems.org'
 gem 'rails', '6.1.3.1'
 gem 'sqlite3'
 gem 'mutex_m'
+gem 'base64'
 
 gemspec :path => '../'

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -6,5 +6,6 @@ gem 'rails', '6.1.3.1'
 gem 'sqlite3'
 gem 'mutex_m'
 gem 'base64'
+gem 'drb'
 
 gemspec :path => '../'

--- a/gemfiles/rails_7.gemfile
+++ b/gemfiles/rails_7.gemfile
@@ -4,5 +4,6 @@ source 'https://rubygems.org'
 
 gem 'rails', '~> 7.0.3'
 gem 'sqlite3'
+gem 'mutex_m'
 
 gemspec :path => '../'

--- a/gemfiles/rails_7.gemfile
+++ b/gemfiles/rails_7.gemfile
@@ -5,5 +5,6 @@ source 'https://rubygems.org'
 gem 'rails', '~> 7.0.3'
 gem 'sqlite3'
 gem 'mutex_m'
+gem 'base64'
 
 gemspec :path => '../'

--- a/gemfiles/rails_7.gemfile
+++ b/gemfiles/rails_7.gemfile
@@ -6,5 +6,6 @@ gem 'rails', '~> 7.0.3'
 gem 'sqlite3'
 gem 'mutex_m'
 gem 'base64'
+gem 'drb'
 
 gemspec :path => '../'


### PR DESCRIPTION
This patch will fix https://github.com/ohler55/oj/actions/runs/7908156404/job/21586745798

Some gems using CI will be changed bundled gem since Ruby 3.4.0. To use bundled gem, it requires to specify the dependency in Gemfile.

Ref. https://github.com/ohler55/oj/pull/901