### PR TITLE
CI: Use `bundle exe` to run each test files in order to solve CI error

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ task :test_all => [:clean, :compile] do
   exitcode = 0
   status = 0
 
-  cmds = 'ruby test/tests.rb -v && ruby test/tests_mimic.rb -v && ruby test/tests_mimic_addition.rb -v'
+  cmds = 'bundle exec ruby test/tests.rb -v && bundle exec ruby test/tests_mimic.rb -v && bundle exec ruby test/tests_mimic_addition.rb -v'
 
   $stdout.syswrite "\n#{'#'*90}\n#{cmds}\n"
   Bundler.with_original_env do


### PR DESCRIPTION
Since Ruby-HEAD fails to load some gems, this patch gives `bundle exe` so that gems are loaded via bundler.

The following errors will be resolved:
![image](https://github.com/ohler55/oj/assets/199156/e6c3da30-4380-492e-a090-15ed73d60245)
