### PR TITLE
Add ostruct as dependency gem for Ruby 3.5

### DIFF
--- a/lib/oj/mimic.rb
+++ b/lib/oj/mimic.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: false
 
 require 'bigdecimal'
-begin
-  require 'ostruct'
-rescue Exception
-  # ignore
-end
+require 'ostruct'
 
 module Oj
 

--- a/oj.gemspec
+++ b/oj.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ['--title', 'Oj', '--main', 'README.md']
 
   s.add_runtime_dependency 'bigdecimal', '>= 3.0'
+  s.add_runtime_dependency 'ostruct', '>= 0.2'
   s.add_development_dependency 'minitest', '~> 5'
   s.add_development_dependency 'rake-compiler', '>= 0.9', '< 2.0'
   s.add_development_dependency 'test-unit', '~> 3.0'


### PR DESCRIPTION
The ostruct gem will be changed bundled gem since Ruby 3.5.0. https://github.com/ruby/ruby/commit/4db7c8a24ad66e15ef6bce053c4d5d90b84cb855

The ostruct gem has been required at https://github.com/ohler55/oj/blob/2e57dc711172ee2aae4a1e381ad905c7d461e805/lib/oj/json.rb#L1

To use bundled gem, it requires to specify the dependency in Gemfile.

Similar with https://github.com/ohler55/oj/pull/901