### PR TITLE
Fix streaming to file descriptor

### DIFF
--- a/ext/oj/stream_writer.c
+++ b/ext/oj/stream_writer.c
@@ -42,7 +42,8 @@ static void stream_writer_write(StreamWriter sw) {
 
     switch (sw->type) {
     case STRING_IO:
-    case STREAM_IO: {
+    case STREAM_IO:
+    case FILE_IO: {
         volatile VALUE rs = rb_str_new(sw->sw.out.buf, size);
 
         // Oddly enough, when pushing ASCII characters with UTF-8 encoding or
@@ -53,11 +54,6 @@ static void stream_writer_write(StreamWriter sw) {
         rb_funcall(sw->stream, oj_write_id, 1, rs);
         break;
     }
-    case FILE_IO:
-        if (size != write(sw->fd, sw->sw.out.buf, size)) {
-            rb_raise(rb_eIOError, "Write failed. [_%d_:%s]\n", errno, strerror(errno));
-        }
-        break;
     default: rb_raise(rb_eArgError, "expected an IO Object.");
     }
     stream_writer_reset_buf(sw);

--- a/test/test_writer.rb
+++ b/test/test_writer.rb
@@ -4,6 +4,7 @@
 $LOAD_PATH << __dir__
 
 require 'helper'
+require 'open3'
 
 class OjWriter < Minitest::Test
 
@@ -376,5 +377,18 @@ class OjWriter < Minitest::Test
     w.push_value(nil, 'nothing')
     w.pop()
     assert_equal(%|{"nothing":null}\n|, output.string())
+  end
+
+  def test_stream_writer_subprocess
+    Open3.popen3("/bin/bash", "-c", "cat > /dev/null") do |stdin, _stdout, _stderr, _wait_thr|
+      w = Oj::StreamWriter.new(stdin, :indent => 0)
+      w.push_array()
+      chunk = "{\"foo\":\"#{"bar"*1000}\"}"
+      1000.times do |_|
+        w.push_json(chunk)
+      end
+      w.pop()
+      stdin.close
+    end
   end
 end # OjWriter

--- a/test/test_writer.rb
+++ b/test/test_writer.rb
@@ -380,6 +380,8 @@ class OjWriter < Minitest::Test
   end
 
   def test_stream_writer_subprocess
+    skip if RbConfig::CONFIG['host_os'] =~ /(mingw|mswin)/
+
     Open3.popen3("/bin/bash", "-c", "cat > /dev/null") do |stdin, _stdout, _stderr, _wait_thr|
       w = Oj::StreamWriter.new(stdin, :indent => 0)
       w.push_array()


### PR DESCRIPTION
Don't use write(2) for writing to file descriptors, use IO::write instead just as for writing to a non-file IO.

Using write(2) means having to handle all kinds of edge cases, such as EINTR and EAGAIN/EWOULDBLOCK, and doesn't release the GVL when blocking.

Fixes #943 