### PR TITLE
bench: Avoid allocating an extra hash when not necessary

### DIFF
--- a/test/perf_strict.rb
+++ b/test/perf_strict.rb
@@ -104,7 +104,11 @@ puts '-' * 80
 puts 'Strict Parse Performance'
 perf = Perf.new()
 unless @failed.key?('JSON::Ext')
-  perf.add('JSON::Ext', 'parse') { JSON.parse(@json, symbolize_names: @symbolize) }
+  if @symbolize
+    perf.add('JSON::Ext', 'parse') { JSON.parse(@json, symbolize_names: true) }
+  else
+    perf.add('JSON::Ext', 'parse') { JSON.parse(@json) }
+  end
   perf.before('JSON::Ext') { JSON.parser = JSON::Ext::Parser }
 end
 unless @failed.key?('Oj:strict')


### PR DESCRIPTION
`JSON.parse(@json, symbolize_names: @symbolize)` allocates an extra hash, which isn't necessary when `symbolize` is `false`.

In the grand scheme of things, it's not a big deal, but on this sort of micro-benchmarks that can easily accound for a huge part of the runtime just because of the increased GC pressure.