### PR TITLE
Use rb_utf8_str_new/rb_utf8_str_new_cstr to create UTF8 string

### DIFF
--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -193,8 +193,7 @@ static VALUE leaf_value(Doc doc, Leaf leaf) {
         case T_FIXNUM: leaf_fixnum_value(leaf); break;
         case T_FLOAT: leaf_float_value(leaf); break;
         case T_STRING:
-            leaf->value      = rb_str_new2(leaf->str);
-            leaf->value      = oj_encode(leaf->value);
+            leaf->value      = rb_utf8_str_new_cstr(leaf->str);
             leaf->value_type = RUBY_VAL;
             break;
         case T_ARRAY: return leaf_array_value(doc, leaf); break;
@@ -309,8 +308,7 @@ static VALUE leaf_hash_value(Doc doc, Leaf leaf) {
         volatile VALUE key;
 
         do {
-            key = rb_str_new2(e->key);
-            key = oj_encode(key);
+            key = rb_utf8_str_new_cstr(e->key);
             rb_hash_aset(h, key, leaf_value(doc, e));
             e = e->next;
         } while (e != first);
@@ -1257,8 +1255,7 @@ static VALUE doc_local_key(VALUE self) {
     volatile VALUE key  = Qnil;
 
     if (T_HASH == leaf->parent_type) {
-        key = rb_str_new2(leaf->key);
-        key = oj_encode(key);
+        key = rb_utf8_str_new_cstr(leaf->key);
     } else if (T_ARRAY == leaf->parent_type) {
         key = LONG2NUM(leaf->index);
     }

--- a/ext/oj/mimic_json.c
+++ b/ext/oj/mimic_json.c
@@ -246,8 +246,7 @@ static VALUE mimic_dump(int argc, VALUE *argv, VALUE self) {
     if (0 == out.buf) {
         rb_raise(rb_eNoMemError, "Not enough memory.");
     }
-    rstr = rb_str_new2(out.buf);
-    rstr = oj_encode(rstr);
+    rstr = rb_utf8_str_new_cstr(out.buf);
     if (2 <= argc && Qnil != argv[1] && rb_respond_to(argv[1], oj_write_id)) {
         VALUE io = argv[1];
         VALUE args[1];
@@ -396,8 +395,7 @@ static VALUE mimic_generate_core(int argc, VALUE *argv, Options copts) {
     if (0 == out.buf) {
         rb_raise(rb_eNoMemError, "Not enough memory.");
     }
-    rstr = rb_str_new2(out.buf);
-    rstr = oj_encode(rstr);
+    rstr = rb_utf8_str_new_cstr(out.buf);
 
     oj_out_free(&out);
 
@@ -768,8 +766,7 @@ static VALUE mimic_object_to_json(int argc, VALUE *argv, VALUE self) {
     if (NULL == out.buf) {
         rb_raise(rb_eNoMemError, "Not enough memory.");
     }
-    rstr = rb_str_new2(out.buf);
-    rstr = oj_encode(rstr);
+    rstr = rb_utf8_str_new_cstr(out.buf);
 
     oj_out_free(&out);
 

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -1277,8 +1277,7 @@ static VALUE dump_body(VALUE a) {
     if (0 == arg->out->buf) {
         rb_raise(rb_eNoMemError, "Not enough memory.");
     }
-    rstr = rb_str_new2(arg->out->buf);
-    rstr = oj_encode(rstr);
+    rstr = rb_utf8_str_new_cstr(arg->out->buf);
 
     return rstr;
 }
@@ -1378,8 +1377,7 @@ static VALUE to_json(int argc, VALUE *argv, VALUE self) {
     if (0 == out.buf) {
         rb_raise(rb_eNoMemError, "Not enough memory.");
     }
-    rstr = rb_str_new2(out.buf);
-    rstr = oj_encode(rstr);
+    rstr = rb_utf8_str_new_cstr(out.buf);
 
     oj_out_free(&out);
 

--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -1133,12 +1133,12 @@ CLEANUP:
             // The json gem requires the error message be UTF-8 encoded. In
             // additional the complete JSON source must be returned. There
             // does not seem to be a size limit.
-            VALUE msg = oj_encode(rb_str_new2(pi->err.msg));
+            VALUE msg = rb_utf8_str_new_cstr(pi->err.msg);
             VALUE args[1];
 
             if (NULL != pi->json) {
-                msg = rb_str_append(msg, oj_encode(rb_str_new2(" in '")));
-                msg = rb_str_append(msg, oj_encode(rb_str_new2(pi->json)));
+                msg = rb_str_append(msg, rb_utf8_str_new_cstr(" in '"));
+                msg = rb_str_append(msg, rb_utf8_str_new_cstr(pi->json));
             }
             args[0] = msg;
             if (pi->err.clas == oj_parse_error_class) {

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -933,8 +933,7 @@ static VALUE encode(VALUE obj, ROptTable ropts, Options opts, int argc, VALUE *a
         if (0 == out.buf) {
             rb_raise(rb_eNoMemError, "Not enough memory.");
         }
-        rstr = rb_str_new2(out.buf);
-        rstr = oj_encode(rstr);
+        rstr = rb_utf8_str_new_cstr(out.buf);
     }
     if (Yes == copts.circular) {
         oj_cache8_delete(out.circ_cache);

--- a/ext/oj/saj.c
+++ b/ext/oj/saj.c
@@ -94,8 +94,7 @@ inline static void call_add_value(VALUE handler, VALUE value, const char *key) {
     if (0 == key) {
         k = Qnil;
     } else {
-        k = rb_str_new2(key);
-        k = oj_encode(k);
+        k = rb_utf8_str_new_cstr(key);
     }
     rb_funcall(handler, oj_add_value_id, 2, value, k);
 }
@@ -106,8 +105,7 @@ inline static void call_no_value(VALUE handler, ID method, const char *key) {
     if (0 == key) {
         k = Qnil;
     } else {
-        k = rb_str_new2(key);
-        k = oj_encode(k);
+        k = rb_utf8_str_new_cstr(key);
     }
     rb_funcall(handler, method, 1, k);
 }
@@ -257,9 +255,8 @@ static void read_str(ParseInfo pi, const char *key) {
 
     text = read_quoted_value(pi);
     if (pi->has_add_value) {
-        VALUE s = rb_str_new2(text);
+        VALUE s = rb_utf8_str_new_cstr(text);
 
-        s = oj_encode(s);
         call_add_value(pi->handler, s, key);
     }
 }

--- a/ext/oj/scp.c
+++ b/ext/oj/scp.c
@@ -56,9 +56,8 @@ static void add_value(ParseInfo pi, VALUE val) {
 }
 
 static void add_cstr(ParseInfo pi, const char *str, size_t len, const char *orig) {
-    volatile VALUE rstr = rb_str_new(str, len);
+    volatile VALUE rstr = rb_utf8_str_new(str, len);
 
-    rstr = oj_encode(rstr);
     rb_funcall(pi->handler, oj_add_value_id, 1, rstr);
 }
 
@@ -87,9 +86,8 @@ static VALUE hash_key(ParseInfo pi, const char *key, size_t klen) {
 }
 
 static void hash_set_cstr(ParseInfo pi, Val kval, const char *str, size_t len, const char *orig) {
-    volatile VALUE rstr = rb_str_new(str, len);
+    volatile VALUE rstr = rb_utf8_str_new(str, len);
 
-    rstr = oj_encode(rstr);
     rb_funcall(pi->handler, oj_hash_set_id, 3, stack_peek(&pi->stack)->val, oj_calc_hash_key(pi, kval), rstr);
 }
 
@@ -107,9 +105,8 @@ static void hash_set_value(ParseInfo pi, Val kval, VALUE value) {
 }
 
 static void array_append_cstr(ParseInfo pi, const char *str, size_t len, const char *orig) {
-    volatile VALUE rstr = rb_str_new(str, len);
+    volatile VALUE rstr = rb_utf8_str_new(str, len);
 
-    rstr = oj_encode(rstr);
     rb_funcall(pi->handler, oj_array_append_id, 2, stack_peek(&pi->stack)->val, rstr);
 }
 

--- a/ext/oj/stream_writer.c
+++ b/ext/oj/stream_writer.c
@@ -44,13 +44,7 @@ static void stream_writer_write(StreamWriter sw) {
     case STRING_IO:
     case STREAM_IO:
     case FILE_IO: {
-        volatile VALUE rs = rb_str_new(sw->sw.out.buf, size);
-
-        // Oddly enough, when pushing ASCII characters with UTF-8 encoding or
-        // even ASCII-8BIT does not change the output encoding. Pushing any
-        // non-ASCII no matter what the encoding changes the output encoding
-        // to ASCII-8BIT if it the string is not forced to UTF-8 here.
-        rs = oj_encode(rs);
+        volatile VALUE rs = rb_utf8_str_new(sw->sw.out.buf, size);
         rb_funcall(sw->stream, oj_write_id, 1, rs);
         break;
     }

--- a/ext/oj/strict.c
+++ b/ext/oj/strict.c
@@ -19,8 +19,7 @@ VALUE oj_cstr_to_value(const char *str, size_t len, size_t cache_str) {
     if (len < cache_str) {
         rstr = oj_str_intern(str, len);
     } else {
-        rstr = rb_str_new(str, len);
-        rstr = oj_encode(rstr);
+        rstr = rb_utf8_str_new(str, len);
     }
     return rstr;
 }
@@ -35,8 +34,7 @@ VALUE oj_calc_hash_key(ParseInfo pi, Val parent) {
         if (Yes == pi->options.sym_key) {
             rkey = ID2SYM(rb_intern3(parent->key, parent->klen, oj_utf8_encoding));
         } else {
-            rkey = rb_str_new(parent->key, parent->klen);
-            rkey = oj_encode(rkey);
+            rkey = rb_utf8_str_new(parent->key, parent->klen);
             OBJ_FREEZE(rkey);  // frozen when used as a Hash key anyway
         }
         return rkey;

--- a/ext/oj/string_writer.c
+++ b/ext/oj/string_writer.c
@@ -469,9 +469,7 @@ static VALUE str_writer_reset(VALUE self) {
 static VALUE str_writer_to_s(VALUE self) {
     StrWriter sw;
     TypedData_Get_Struct(self, struct _strWriter, &oj_string_writer_type, sw);
-    VALUE rstr = rb_str_new(sw->out.buf, sw->out.cur - sw->out.buf);
-
-    return oj_encode(rstr);
+    return rb_utf8_str_new(sw->out.buf, sw->out.cur - sw->out.buf);
 }
 
 /* Document-method: as_json


### PR DESCRIPTION
This patch will use rb_utf8_str_new/rb_utf8_str_new_cstr API to create UTF8 string.
Seems it has slightly better performance.

−       | before  | after   | result
--      | --      | --      | --
Oj.load | 654.004 | 670.792 | 1.025x

### Environment
- Linux
  - Manjaro Linux x86_64
  - Kernel: 6.12.4-1-MANJARO
  - AMD Ryzen 9 8945HS
  - gcc version 14.2.1
  - Ruby 3.4.1

### Code
```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'benchmark-ips'
  gem 'oj'
end

# https://github.com/miloyip/nativejson-benchmark/blob/master/data/twitter.json
json = File.read('twitter.json')

Benchmark.ips do |x|
  x.time = 10
  x.report('Oj.load compat') { Oj.load(json, mode: :compat) }
end
```

### Before
```
$ ruby json_load.rb
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [x86_64-linux]
Warming up --------------------------------------
      Oj.load compat    64.000 i/100ms
Calculating -------------------------------------
      Oj.load compat    654.004 (± 1.7%) i/s    (1.53 ms/i) -      6.592k in  10.082170s
```

### After
```
$ ruby json_load.rb
Warming up --------------------------------------
      Oj.load compat    65.000 i/100ms
Calculating -------------------------------------
      Oj.load compat    670.792 (± 1.6%) i/s    (1.49 ms/i) -      6.760k in  10.080319s
```