### PR TITLE
Add test for unecaped control characters in strings

### DIFF
--- a/test/test_parser_usual.rb
+++ b/test/test_parser_usual.rb
@@ -79,6 +79,16 @@ class UsualTest < Minitest::Test
     assert_equal({'ぴ' => '', 'ぴ ' => 'x', 'c' => 'ぴーたー', 'd' => ' ぴーたー '}, doc)
   end
 
+  def test_unescaped_ASCII_control_characters
+    p = Oj::Parser.new(:usual)
+
+    (0..31).each do |control_ord|
+      assert_raises(Oj::ParseError) do
+        p.parse(%{"invalid character: #{control_ord.chr}"})
+      end
+    end
+  end
+
   def test_capacity
     p = Oj::Parser.new(:usual, capacity: 1000)
     assert_equal(4096, p.capacity)

--- a/test/test_strict.rb
+++ b/test/test_strict.rb
@@ -133,6 +133,14 @@ class StrictJuice < Minitest::Test
     Oj.default_options = opts
   end
 
+  def test_unescaped_ASCII_control_characters
+    (0..31).each do |control_ord|
+      assert_raises(Oj::ParseError) do
+        Oj.load(%{"invalid character: #{control_ord.chr}"})
+      end
+    end
+  end
+
   def test_unicode
     # hits the 3 normal ranges and one extended surrogate pair
     json = %{"\\u019f\\u05e9\\u3074\\ud834\\udd1e"}


### PR DESCRIPTION
The JSON spec doesn't allow for unescaped control characters (`< 0x20`) in strings, but `Oj.load` does.

`Oj::Parser` correctly raises a parse error though.