### PR TITLE
Mention drop of Ruby 2.6 in OJ 3.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@
 ## 3.14.3 - 2023-04-07
 
 - Fixed compat parse with optimized Hash when parsing a JSON::GenericObject.
-- Deprecated Ruby <= 2.6.
+- Deprecated Ruby <= 2.6.10
 
 ## 3.14.2 - 2023-02-10
 


### PR DESCRIPTION
- To save developers on older versions of Rails some time in finding the latest OJ version compatible with Rails 5.2 / Ruby 2.6, mention the drop of support in the CHANGELOG.