### PR TITLE
CI: Fix failures with Ruby 3.5-dev

### DIFF
--- a/test/json_gem/json_ext_parser_test.rb
+++ b/test/json_gem/json_ext_parser_test.rb
@@ -9,13 +9,25 @@ class JSONExtParserTest < Test::Unit::TestCase
   include Test::Unit::TestCaseOmissionSupport
 
   if defined?(JSON::Ext::Parser)
-    def test_allocate
-      parser = JSON::Ext::Parser.new("{}")
-      assert_raise(TypeError, '[ruby-core:35079]') do
+    if REAL_JSON_GEM && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.5.0')
+      def test_allocate
+        parser = JSON::Ext::Parser.new("{}")
         parser.__send__(:initialize, "{}")
+        assert_equal "{}", parser.source
+
+        parser = JSON::Ext::Parser.allocate
+        assert_nil parser.source
       end
-      parser = JSON::Ext::Parser.allocate
-      assert_raise(TypeError, '[ruby-core:35079]') { parser.source }
+    else
+      # Ruby 3.4.x or before
+      def test_allocate
+        parser = JSON::Ext::Parser.new("{}")
+        assert_raise(TypeError, '[ruby-core:35079]') do
+          parser.__send__(:initialize, "{}")
+        end
+        parser = JSON::Ext::Parser.allocate
+        assert_raise(TypeError, '[ruby-core:35079]') { parser.source }
+      end
     end
   end
 end

--- a/test/json_gem/json_generator_test.rb
+++ b/test/json_gem/json_generator_test.rb
@@ -144,7 +144,8 @@ class JSONGeneratorTest < Test::Unit::TestCase
     actual.delete(:escape_slash)
     actual.delete(:strict)
     actual.delete(:script_safe)
-    assert_equal({
+
+    expected = {
       :allow_nan             => false,
       :array_nl              => "\n",
       :ascii_only            => false,
@@ -155,7 +156,12 @@ class JSONGeneratorTest < Test::Unit::TestCase
       :object_nl             => "\n",
       :space                 => " ",
       :space_before          => "",
-    }.sort_by { |n,| n.to_s }, actual.sort_by { |n,| n.to_s })
+    }
+    if REAL_JSON_GEM && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.5.0')
+      expected[:as_json] = false
+    end
+
+    assert_equal(expected.sort_by { |n,| n.to_s }, actual.sort_by { |n,| n.to_s })
   end
 
   def test_safe_state
@@ -166,7 +172,8 @@ class JSONGeneratorTest < Test::Unit::TestCase
     actual.delete(:escape_slash)
     actual.delete(:strict)
     actual.delete(:script_safe)
-    assert_equal({
+
+    expected = {
       :allow_nan             => false,
       :array_nl              => "",
       :ascii_only            => false,
@@ -177,7 +184,12 @@ class JSONGeneratorTest < Test::Unit::TestCase
       :object_nl             => "",
       :space                 => "",
       :space_before          => "",
-    }.sort_by { |n,| n.to_s }, actual.sort_by { |n,| n.to_s })
+    }
+    if REAL_JSON_GEM && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.5.0')
+      expected[:as_json] = false
+    end
+
+    assert_equal(expected.sort_by { |n,| n.to_s }, actual.sort_by { |n,| n.to_s })
   end
 
   def test_fast_state
@@ -188,7 +200,8 @@ class JSONGeneratorTest < Test::Unit::TestCase
     actual.delete(:escape_slash)
     actual.delete(:strict)
     actual.delete(:script_safe)
-    assert_equal({
+
+    expected = {
       :allow_nan             => false,
       :array_nl              => "",
       :ascii_only            => false,
@@ -199,7 +212,12 @@ class JSONGeneratorTest < Test::Unit::TestCase
       :object_nl             => "",
       :space                 => "",
       :space_before          => "",
-    }.sort_by { |n,| n.to_s }, actual.sort_by { |n,| n.to_s })
+    }
+    if REAL_JSON_GEM && Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.5.0')
+      expected[:as_json] = false
+    end
+
+    assert_equal(expected.sort_by { |n,| n.to_s }, actual.sort_by { |n,| n.to_s })
   end
 
   def test_allow_nan


### PR DESCRIPTION
Recently Ruby HEAD has some changes in JSON and it causes failures in tests.
Ref. https://github.com/ohler55/oj/actions/runs/13188779428

### 1. json_ext_parser_test.rb
Since https://github.com/ruby/ruby/commit/599fbeaffa, it causes failure in test_allocate
```
=========================================================================================================================================================================================================================================
Failure: test_allocate(JSONExtParserTest):
  [ruby-core:35079].
  <TypeError> exception was expected but none was thrown.
test/json_gem/json_ext_parser_test.rb:14:in 'JSONExtParserTest#test_allocate'
     11:   if defined?(JSON::Ext::Parser)
     12:     def test_allocate
     13:       parser = JSON::Ext::Parser.new("{}")
  => 14:       assert_raise(TypeError, '[ruby-core:35079]') do
     15:         parser.__send__(:initialize, "{}")
     16:       end
     17:       parser = JSON::Ext::Parser.allocate
```

### 2. json_generator_test.rb
Since https://github.com/ruby/ruby/commit/89e316ad06,  it causes failure in test_fast_state/test_pretty_state/test_safe_state
```
=========================================================================================================================================================================================================================================
Failure: test_fast_state(JSONGeneratorTest)
test/json_gem/json_generator_test.rb:191:in 'JSONGeneratorTest#test_fast_state'
     188:     actual.delete(:escape_slash)
     189:     actual.delete(:strict)
     190:     actual.delete(:script_safe)
  => 191:     assert_equal({
     192:       :allow_nan             => false,
     193:       :array_nl              => "",
     194:       :ascii_only            => false,
<[[:allow_nan, false],
 [:array_nl, ""],
 [:ascii_only, false],
 [:buffer_initial_length, 1024],
 [:depth, 0],
 [:indent, ""],
 [:max_nesting, 0],
 [:object_nl, ""],
 [:space, ""],
 [:space_before, ""]]> expected but was
<[[:allow_nan, false],
 [:array_nl, ""],
 [:as_json, false],
 [:ascii_only, false],
 [:buffer_initial_length, 1024],
 [:depth, 0],
 [:indent, ""],
 [:max_nesting, 0],
 [:object_nl, ""],
 [:space, ""],
 [:space_before, ""]]>

diff:
  [[:allow_nan, false],
   [:array_nl, ""],
+  [:as_json, false],
   [:ascii_only, false],
   [:buffer_initial_length, 1024],
   [:depth, 0],
   [:indent, ""],
   [:max_nesting, 0],
   [:object_nl, ""],
   [:space, ""],
   [:space_before, ""]]
=========================================================================================================================================================================================================================================
```
