### PR TITLE
Expose `oj_parser_type` for extensions

### DIFF
--- a/ext/oj/parser.c
+++ b/ext/oj/parser.c
@@ -1161,7 +1161,7 @@ static void parser_mark(void *ptr) {
     }
 }
 
-static const rb_data_type_t oj_parser_type = {
+const rb_data_type_t oj_parser_type = {
     "Oj/parser",
     {
         parser_mark,

--- a/ext/oj/parser.h
+++ b/ext/oj/parser.h
@@ -42,6 +42,8 @@ typedef struct _num {
 
 struct _ojParser;
 
+extern const rb_data_type_t oj_parser_type;
+
 typedef struct _funcs {
     void (*add_null)(struct _ojParser *p);
     void (*add_true)(struct _ojParser *p);


### PR DESCRIPTION
This is required for the Oj::Introspect parser.