### PR TITLE
Use ARM Neon instructions to accelerate hibit_friendly_size.

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -959,7 +959,7 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
         *out->cur++ = '"';
     }
     if (do_unicode_validation && 0 < str - orig && 0 != (0x80 & *(str - 1))) {
-        uint8_t c = (uint8_t)*(str - 1);
+        uint8_t c = (uint8_t) * (str - 1);
         int     i;
         int     scnt = (int)(str - orig);
 

--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -156,17 +156,17 @@ inline static size_t newline_friendly_size(const uint8_t *str, size_t len) {
 inline static uint8x16x4_t load_uint8x16_4(const unsigned char *table) {
     uint8x16x4_t tab;
     tab.val[0] = vld1q_u8(table);
-    tab.val[1] = vld1q_u8(table+16);
-    tab.val[2] = vld1q_u8(table+32);
-    tab.val[3] = vld1q_u8(table+48);
+    tab.val[1] = vld1q_u8(table + 16);
+    tab.val[2] = vld1q_u8(table + 32);
+    tab.val[3] = vld1q_u8(table + 48);
     return tab;
 }
 
 static uint8x16x4_t hibit_friendly_chars_neon[2];
 
 void initialize_neon(void) {
-    hibit_friendly_chars_neon[0] = load_uint8x16_4((const unsigned char *) hibit_friendly_chars);
-    hibit_friendly_chars_neon[1] = load_uint8x16_4((const unsigned char *) hibit_friendly_chars + 64);
+    hibit_friendly_chars_neon[0] = load_uint8x16_4((const unsigned char *)hibit_friendly_chars);
+    hibit_friendly_chars_neon[1] = load_uint8x16_4((const unsigned char *)hibit_friendly_chars + 64);
 
     // All bytes should be 0 except for those that need more than 1 byte of output. This will allow the
     // code to limit the lookups to the first 128 bytes (values 0 - 127). Bytes above 127 will result
@@ -181,14 +181,14 @@ void initialize_neon(void) {
     hibit_friendly_chars_neon[1].val[2] = vsubq_u8(hibit_friendly_chars_neon[1].val[2], vdupq_n_u8('1'));
     hibit_friendly_chars_neon[1].val[3] = vsubq_u8(hibit_friendly_chars_neon[1].val[3], vdupq_n_u8('1'));
 }
-#endif 
+#endif
 
 inline static size_t hibit_friendly_size(const uint8_t *str, size_t len) {
 #ifdef HAVE_SIMD_NEON
     size_t size = 0;
-    size_t i = 0;
+    size_t i    = 0;
 
-    for(; i+sizeof(uint8x16_t) < len; i += sizeof(uint8x16_t)) {
+    for (; i + sizeof(uint8x16_t) < len; i += sizeof(uint8x16_t)) {
         size += sizeof(uint8x16_t);
 
         // See https://lemire.me/blog/2019/07/23/arbitrary-byte-to-byte-maps-using-arm-neon/
@@ -196,13 +196,13 @@ inline static size_t hibit_friendly_size(const uint8_t *str, size_t len) {
         uint8x16_t tmp1   = vqtbl4q_u8(hibit_friendly_chars_neon[0], chunk);
         uint8x16_t tmp2   = vqtbl4q_u8(hibit_friendly_chars_neon[1], veorq_u8(chunk, vdupq_n_u8(0x40)));
         uint8x16_t result = vorrq_u8(tmp1, tmp2);
-        uint8_t tmp       = vaddvq_u8(result);
-        size              += tmp;
+        uint8_t    tmp    = vaddvq_u8(result);
+        size += tmp;
     }
 
     const uint8_t *rem = (const uint8_t *)(str + i);
 
-    size_t total =  size + calculate_string_size(rem, len-i, hibit_friendly_chars);
+    size_t total = size + calculate_string_size(rem, len - i, hibit_friendly_chars);
     return total;
 #else
     return calculate_string_size(str, len, hibit_friendly_chars);
@@ -959,7 +959,7 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
         *out->cur++ = '"';
     }
     if (do_unicode_validation && 0 < str - orig && 0 != (0x80 & *(str - 1))) {
-        uint8_t c = (uint8_t) * (str - 1);
+        uint8_t c = (uint8_t)*(str - 1);
         int     i;
         int     scnt = (int)(str - orig);
 

--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -21,8 +21,6 @@
 #include "trace.h"
 #include "util.h"
 
-#include <arm_neon.h>
-
 // Workaround in case INFINITY is not defined in math.h or if the OS is CentOS
 #define OJ_INFINITY (1.0 / 0.0)
 

--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -21,6 +21,8 @@
 #include "trace.h"
 #include "util.h"
 
+#include <arm_neon.h>
+
 // Workaround in case INFINITY is not defined in math.h or if the OS is CentOS
 #define OJ_INFINITY (1.0 / 0.0)
 
@@ -152,8 +154,61 @@ inline static size_t newline_friendly_size(const uint8_t *str, size_t len) {
     return calculate_string_size(str, len, newline_friendly_chars);
 }
 
+#ifdef HAVE_SIMD_NEON
+inline static uint8x16x4_t load_uint8x16_4(const unsigned char *table) {
+    uint8x16x4_t tab;
+    tab.val[0] = vld1q_u8(table);
+    tab.val[1] = vld1q_u8(table+16);
+    tab.val[2] = vld1q_u8(table+32);
+    tab.val[3] = vld1q_u8(table+48);
+    return tab;
+}
+
+static uint8x16x4_t hibit_friendly_chars_neon[2];
+
+void initialize_neon(void) {
+    hibit_friendly_chars_neon[0] = load_uint8x16_4((const unsigned char *) hibit_friendly_chars);
+    hibit_friendly_chars_neon[1] = load_uint8x16_4((const unsigned char *) hibit_friendly_chars + 64);
+
+    // All bytes should be 0 except for those that need more than 1 byte of output. This will allow the
+    // code to limit the lookups to the first 128 bytes (values 0 - 127). Bytes above 127 will result
+    // in 0 with the vqtbl4q_u8 instruction.
+    hibit_friendly_chars_neon[0].val[0] = vsubq_u8(hibit_friendly_chars_neon[0].val[0], vdupq_n_u8('1'));
+    hibit_friendly_chars_neon[0].val[1] = vsubq_u8(hibit_friendly_chars_neon[0].val[1], vdupq_n_u8('1'));
+    hibit_friendly_chars_neon[0].val[2] = vsubq_u8(hibit_friendly_chars_neon[0].val[2], vdupq_n_u8('1'));
+    hibit_friendly_chars_neon[0].val[3] = vsubq_u8(hibit_friendly_chars_neon[0].val[3], vdupq_n_u8('1'));
+
+    hibit_friendly_chars_neon[1].val[0] = vsubq_u8(hibit_friendly_chars_neon[1].val[0], vdupq_n_u8('1'));
+    hibit_friendly_chars_neon[1].val[1] = vsubq_u8(hibit_friendly_chars_neon[1].val[1], vdupq_n_u8('1'));
+    hibit_friendly_chars_neon[1].val[2] = vsubq_u8(hibit_friendly_chars_neon[1].val[2], vdupq_n_u8('1'));
+    hibit_friendly_chars_neon[1].val[3] = vsubq_u8(hibit_friendly_chars_neon[1].val[3], vdupq_n_u8('1'));
+}
+#endif 
+
 inline static size_t hibit_friendly_size(const uint8_t *str, size_t len) {
+#ifdef HAVE_SIMD_NEON
+    size_t size = 0;
+    size_t i = 0;
+
+    for(; i+sizeof(uint8x16_t) < len; i += sizeof(uint8x16_t)) {
+        size += sizeof(uint8x16_t);
+
+        // See https://lemire.me/blog/2019/07/23/arbitrary-byte-to-byte-maps-using-arm-neon/
+        uint8x16_t chunk  = vld1q_u8(str);
+        uint8x16_t tmp1   = vqtbl4q_u8(hibit_friendly_chars_neon[0], chunk);
+        uint8x16_t tmp2   = vqtbl4q_u8(hibit_friendly_chars_neon[1], veorq_u8(chunk, vdupq_n_u8(0x40)));
+        uint8x16_t result = vorrq_u8(tmp1, tmp2);
+        uint8_t tmp       = vaddvq_u8(result);
+        size              += tmp;
+    }
+
+    const uint8_t *rem = (const uint8_t *)(str + i);
+
+    size_t total =  size + calculate_string_size(rem, len-i, hibit_friendly_chars);
+    return total;
+#else
     return calculate_string_size(str, len, hibit_friendly_chars);
+#endif
 }
 
 inline static size_t slash_friendly_size(const uint8_t *str, size_t len) {

--- a/ext/oj/dump.h
+++ b/ext/oj/dump.h
@@ -7,11 +7,16 @@
 #include <ruby.h>
 
 #include "oj.h"
+#include "simd.h"
 
 #define MAX_DEPTH 1000
 
 // Extra padding at end of buffer.
 #define BUFFER_EXTRA 64
+
+#ifdef HAVE_SIMD_NEON
+extern void initialize_neon(void);
+#endif /* HAVE_SIMD_NEON */
 
 extern void oj_dump_nil(VALUE obj, int depth, Out out, bool as_ok);
 extern void oj_dump_true(VALUE obj, int depth, Out out, bool as_ok);

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -1189,7 +1189,7 @@ static VALUE load_file(int argc, VALUE *argv, VALUE self) {
         OJ_FREE(wide_path);
     }
 #else
-    fd = open(path, O_RDONLY);
+    fd             = open(path, O_RDONLY);
 #endif
     if (0 == fd) {
         rb_raise(rb_eIOError, "%s", strerror(errno));

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -11,7 +11,6 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include "simd.h"
 #include "dump.h"
 #include "encode.h"
 #include "intern.h"
@@ -19,6 +18,7 @@
 #include "odd.h"
 #include "parse.h"
 #include "rails.h"
+#include "simd.h"
 
 typedef struct _yesNoOpt {
     VALUE sym;
@@ -1189,7 +1189,7 @@ static VALUE load_file(int argc, VALUE *argv, VALUE self) {
         OJ_FREE(wide_path);
     }
 #else
-    fd             = open(path, O_RDONLY);
+    fd = open(path, O_RDONLY);
 #endif
     if (0 == fd) {
         rb_raise(rb_eIOError, "%s", strerror(errno));

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -11,6 +11,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "simd.h"
 #include "dump.h"
 #include "encode.h"
 #include "intern.h"
@@ -2081,4 +2082,8 @@ void Init_oj(void) {
 
     oj_parser_init();
     oj_scanner_init();
+
+#ifdef HAVE_SIMD_NEON
+    initialize_neon();
+#endif /* HAVE_SIMD_NEON */
 }

--- a/ext/oj/simd.h
+++ b/ext/oj/simd.h
@@ -1,0 +1,9 @@
+#ifndef OJ_SIMD_H
+#define OJ_SIMD_H
+
+#if defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(__aarch64__) || defined(_M_ARM64)
+#define HAVE_SIMD_NEON 1
+#include <arm_neon.h>
+#endif
+
+#endif /* OJ_SIMD_H */


### PR DESCRIPTION
This PR uses ARM Neon instruction to accelerate the `hibit_friendly_size` function. This same technique can be applied to the other `*_friendly_size` functions.

Would love your thoughts if this is something to pursue further.

## Benchmarks

These benchmarks use the [this benchmark](https://github.com/ruby/json/blob/master/benchmark/encoder.rb#L78) from the [ruby/json](https://github.com/ruby/json/) project.

### `develop` branch as of commit `d96bf95dd239ff45d0e5e8f76c53310c766fcc39`

```
== Encoding mixed utf8 (5003001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                  oj    35.000 i/100ms
Calculating -------------------------------------
                  oj    341.918 (± 4.1%) i/s    (2.92 ms/i) -      1.715k in   5.024382s
```

According to this call tree generated by [samply](https://github.com/mstange/samply) the `hibit_friendly_size` is 35% of the total samples collected.

<img width="1209" alt="oj long string call tree - current" src="https://github.com/user-attachments/assets/2432fca2-8153-4796-93d4-a33ce261d116" />


### This branch

```
== Encoding mixed utf8 (5003001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                  oj    59.000 i/100ms
Calculating -------------------------------------
                  oj    529.273 (± 6.2%) i/s    (1.89 ms/i) -      2.655k in   5.036889s
```

With the ARM Neon instructions the `hibit_friendly_size` is only 0.1% of collected samples.

<img width="1149" alt="oj long string call tree - neon" src="https://github.com/user-attachments/assets/8370bb99-ce9c-45f1-9b28-b57a17a759dc" />



