### PR TITLE
ARM Neon `hibit_friendly_size` bugfix.

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -188,7 +188,7 @@ inline static size_t hibit_friendly_size(const uint8_t *str, size_t len) {
     size_t size = 0;
     size_t i    = 0;
 
-    for (; i + sizeof(uint8x16_t) < len; i += sizeof(uint8x16_t)) {
+    for (; i + sizeof(uint8x16_t) < len; i += sizeof(uint8x16_t), str += sizeof(uint8x16_t)) {
         size += sizeof(uint8x16_t);
 
         // See https://lemire.me/blog/2019/07/23/arbitrary-byte-to-byte-maps-using-arm-neon/
@@ -200,9 +200,7 @@ inline static size_t hibit_friendly_size(const uint8_t *str, size_t len) {
         size += tmp;
     }
 
-    const uint8_t *rem = (const uint8_t *)(str + i);
-
-    size_t total = size + calculate_string_size(rem, len - i, hibit_friendly_chars);
+    size_t total = size + calculate_string_size(str, len - i, hibit_friendly_chars);
     return total;
 #else
     return calculate_string_size(str, len, hibit_friendly_chars);


### PR DESCRIPTION
[This PR](https://github.com/ohler55/oj/pull/963) had a bug. Spending 0.1% of time in the `hibit_friendly_size` seemed too good to be true. I forgot to increment `str` in the loop...

After this fix we spend about 11% or so of time in the `hibit_friendly_size`. It's still a good improvement.

<img width="1156" alt="image" src="https://github.com/user-attachments/assets/97063e45-a69c-4a47-ad53-87a3b982101d" />

The performance mostly holds though.

```
== Encoding mixed utf8 (5003001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                  oj    54.000 i/100ms
Calculating -------------------------------------
                  oj    509.722 (± 5.3%) i/s    (1.96 ms/i) -      2.592k in   5.099497s
```