### PR TITLE
Optimize rails_xss_friendly_size and rails_friendly_size with ARM Neon instructions.

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -258,7 +258,7 @@ inline static long rails_xss_friendly_size(const uint8_t *str, size_t len) {
 
         uint8x16_t chunk = vld1q_u8(str);
 
-        // Check to see if any of these bits have the high bit set.
+        // Check to see if any of these bytes have the high bit set.
         has_some_hibit = vorrq_u8(has_some_hibit, vandq_u8(chunk, hibit));
 
         uint8x16_t tmp1   = vqtbl4q_u8(rails_xss_friendly_chars_neon[0], chunk);

--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -1044,7 +1044,7 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
         *out->cur++ = '"';
     }
     if (do_unicode_validation && 0 < str - orig && 0 != (0x80 & *(str - 1))) {
-        uint8_t c = (uint8_t)*(str - 1);
+        uint8_t c = (uint8_t) * (str - 1);
         int     i;
         int     scnt = (int)(str - orig);
 

--- a/test/test_long_strings.rb
+++ b/test/test_long_strings.rb
@@ -5,6 +5,15 @@ $LOAD_PATH << __dir__
 
 require 'helper'
 
+# This is to force testing 'rails_friendly_size'.
+begin
+  require 'active_support'
+  HAS_RAILS = true
+rescue LoadError
+  puts 'ActiveSupport not found. Skipping ActiveSupport tests.'
+  HAS_RAILS = false
+end
+
 # The tests in this file are to specifically handle testing the ARM Neon code
 # that is used to speed up the dumping of long strings. The tests are likely
 # redundant with respect to correctness. However, they are designed specifically
@@ -17,13 +26,10 @@ class LongStringsTest < Minitest::Test
     run_basic_tests(:compat)
     run_basic_tests(:rails)
 
-    # This is to force testing 'rails_friendly_size'.
-    begin
+    if HAS_RAILS
       Oj.optimize_rails()
       ActiveSupport::JSON::Encoding.escape_html_entities_in_json = false
       run_basic_tests(:rails)
-    rescue LoadError
-      puts 'ActiveSupport not found. Skipping ActiveSupport tests.'
     end
   end
 

--- a/test/test_long_strings.rb
+++ b/test/test_long_strings.rb
@@ -5,14 +5,14 @@ $LOAD_PATH << __dir__
 
 require 'helper'
 
-# This is to force testing 'rails_friendly_size'.
-begin
-  require 'active_support'
-  HAS_RAILS = true
-rescue LoadError
-  puts 'ActiveSupport not found. Skipping ActiveSupport tests.'
-  HAS_RAILS = false
-end
+# # This is to force testing 'rails_friendly_size'.
+# begin
+#   require 'active_support'
+#   HAS_RAILS = true
+# rescue LoadError
+#   puts 'ActiveSupport not found. Skipping ActiveSupport tests.'
+#   HAS_RAILS = false
+# end
 
 # The tests in this file are to specifically handle testing the ARM Neon code
 # that is used to speed up the dumping of long strings. The tests are likely
@@ -26,11 +26,11 @@ class LongStringsTest < Minitest::Test
     run_basic_tests(:compat)
     run_basic_tests(:rails)
 
-    if HAS_RAILS
-      Oj.optimize_rails()
-      ActiveSupport::JSON::Encoding.escape_html_entities_in_json = false
-      run_basic_tests(:rails)
-    end
+    # if HAS_RAILS
+    #   Oj.optimize_rails()
+    #   ActiveSupport::JSON::Encoding.escape_html_entities_in_json = false
+    #   run_basic_tests(:rails)
+    # end
   end
 
   def run_basic_tests(mode)

--- a/test/test_long_strings.rb
+++ b/test/test_long_strings.rb
@@ -1,0 +1,201 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH << __dir__
+
+require 'helper'
+
+# The tests in this file are to specifically handle testing the ARM Neon code
+# that is used to speed up the dumping of long strings. The tests are likely
+# redundant with respect to correctness. However, they are designed specifically
+# to exercise the code paths that operate on vectors of 16 bytes. Additionally,
+# we need to ensure that not all tests are exactly multiples of 16 bytes in length
+# so that we can test the code that handles the remainder of the string.
+class LongStringsTest < Minitest::Test
+
+  def test_escapes    
+    run_basic_tests(:compat)
+    run_basic_tests(:rails)
+
+    # This is to force testing 'rails_friendly_size'.
+    begin
+      require 'active_support'
+      Oj.optimize_rails()
+      ActiveSupport::JSON::Encoding.escape_html_entities_in_json = false
+      run_basic_tests(:rails)
+    rescue LoadError
+      puts 'ActiveSupport not found. Skipping ActiveSupport tests.'
+    end
+  end
+
+  def run_basic_tests(mode)
+    str = '\n'*15
+    expected = "\"#{'\\\\n'*15}\""
+    out = Oj.dump(str, mode: mode)
+    assert_equal(expected, out)
+
+    str = '\n'*16
+    expected = "\"#{'\\\\n'*16}\""
+    out = Oj.dump(str, mode: mode)
+    assert_equal(expected, out)
+
+    str = '\n'*17
+    expected = "\"#{'\\\\n'*17}\""
+    out = Oj.dump(str, mode: mode)
+    assert_equal(expected, out)
+
+    str = '\n'*32
+    expected = "\"#{'\\\\n'*32}\""
+    out = Oj.dump(str, mode: mode)
+    assert_equal(expected, out)
+
+    str = '\f'*63
+    expected = "\"#{'\\\\f'*63}\""
+    out = Oj.dump(str, mode: mode)
+    assert_equal(expected, out)
+
+    str = '\t'*127
+    expected = "\"#{'\\\\t'*127}\""
+    out = Oj.dump(str, mode: mode)
+    assert_equal(expected, out)
+
+    str = "\u0001" * 16
+    out = Oj.dump(str, mode: mode)
+    expected = "\"#{"\\u0001" * 16}\""
+    assert_equal(expected, out)
+
+    str = "\u0001\u0002" * 8
+    out = Oj.dump(str, mode: mode)
+    expected = "\"#{"\\u0001\\u0002" * 8}\""
+    assert_equal(expected, out)
+
+    str = "\u0001a" * 8
+    out = Oj.dump(str, mode: mode)
+    expected = "\"#{"\\u0001a" * 8}\""
+    assert_equal(expected, out)
+
+    str = "abc\u0010" * 4
+    out = Oj.dump(str, mode: mode)
+    expected = "\"#{"abc\\u0010" * 4}\""
+    assert_equal(expected, out)
+
+    str = "abc\u0010" * 5
+    out = Oj.dump(str, mode: mode)
+    expected = "\"#{"abc\\u0010" * 5}\""
+    assert_equal(expected, out)
+
+    str = "\u0001\u0002" * 9
+    out = Oj.dump(str, mode: mode)
+    expected = "\"#{"\\u0001\\u0002" * 9}\""
+    assert_equal(expected, out)
+
+    str = '\"'
+    out = Oj.dump(str, mode: mode)
+    expected =  "\"\\\\\\\"\""
+    assert_equal(expected, out)
+
+    str = '"'*16
+    out = Oj.dump(str, mode: mode)
+    expected =  '"\\"\\"\\"\\"\\"\\"\\"\\"\\"\\"\\"\\"\\"\\"\\"\\""'
+    assert_equal(expected, out)
+
+    str = '"'*20
+    out = Oj.dump(str, mode: mode)
+    expected =  '"\\"\\"\\"\\"\\"\\"\\"\\"\\"\\"\\"\\"\\"\\"\\"\\"\\"\\"\\"\\""'
+    assert_equal(expected, out)
+  end
+
+  def test_dump_long_str_no_escapes
+    str = 'This is a test of the emergency broadcast system. This is only a test.'
+    out = Oj.dump(str)
+    assert_equal(%|"#{str}"|, out)
+  end
+
+  def test_dump_long_str_with_escapes
+    str = 'This is a\ntest of the emergency broadcast system. This is only a test.'
+    out = Oj.dump(str)
+    expected = %|"This is a\\\\ntest of the emergency broadcast system. This is only a test."|
+    assert_equal(expected, out)
+  end
+
+  def test_dump_long_str_with_quotes
+    str = 'This is a "test" of the emergency broadcast system. This is only a "test".'
+    out = Oj.dump(str)
+    expected = %|"This is a \\\"test\\\" of the emergency broadcast system. This is only a \\\"test\\\"."|
+    assert_equal(expected, out)
+  end
+
+  def test_dump_long_str_no_escapes_rails
+    str = 'This is a test of the emergency broadcast system. This is only a test.'
+    out = Oj.dump(str, mode: :rails)
+    assert_equal(%|"#{str}"|, out)
+  end
+
+  def test_dump_long_str_with_escapes_rails
+    str = 'This is a\ntest of the emergency broadcast system. This is only a test.'
+    out = Oj.dump(str, mode: :rails)
+    expected = %|"This is a\\\\ntest of the emergency broadcast system. This is only a test."|
+    assert_equal(expected, out)
+  end
+
+  def test_dump_long_str_with_quotes_rails
+    str = 'This is a "test" of the emergency broadcast system. This is only a "test".'
+    out = Oj.dump(str, mode: :rails)
+    expected = %|"This is a \\\"test\\\" of the emergency broadcast system. This is only a \\\"test\\\"."|
+    assert_equal(expected, out)
+  end
+
+  def test_long_string_with_high_byte_set
+    str = 'This item will cost €1000.00. I hope you have a great day!'
+    out = Oj.dump(str)
+    expected = %["This item will cost €1000.00. I hope you have a great day!"]
+    assert_equal(expected, out)
+
+    out = Oj.dump(str, mode: :rails)
+    assert_equal(expected, out)
+  end
+
+  def test_high_byte_set
+    str = "€"*15
+    out = Oj.dump(str)
+    expected = %["#{"€"*15}"]
+    assert_equal(expected, out)
+    out = Oj.dump(str, mode: :rails)
+    assert_equal(expected, out)
+
+    str = "€"*16
+    out = Oj.dump(str)
+    expected = %["#{"€"*16}"]
+    assert_equal(expected, out)
+    out = Oj.dump(str, mode: :rails)
+    assert_equal(expected, out)
+
+    str = "€"*17
+    out = Oj.dump(str)
+    expected = %["#{"€"*17}"]
+    assert_equal(expected, out)
+    out = Oj.dump(str, mode: :rails)
+    assert_equal(expected, out)
+
+    str = "€abcdefghijklmnop"
+    out = Oj.dump(str)
+    expected = %["#{"€abcdefghijklmnop"}"]
+    assert_equal(expected, out)
+    out = Oj.dump(str, mode: :rails)
+    assert_equal(expected, out)
+
+    str = "€abcdefghijklmnop€"
+    out = Oj.dump(str)
+    expected = %["#{"€abcdefghijklmnop€"}"]
+    assert_equal(expected, out)
+    out = Oj.dump(str, mode: :rails)
+    assert_equal(expected, out)
+
+    str = "abcdefghijklmnop€"
+    out = Oj.dump(str)
+    expected = %["#{"abcdefghijklmnop€"}"]
+    assert_equal(expected, out)
+    out = Oj.dump(str, mode: :rails)
+    assert_equal(expected, out)
+  end
+end

--- a/test/test_long_strings.rb
+++ b/test/test_long_strings.rb
@@ -18,14 +18,13 @@ class LongStringsTest < Minitest::Test
     run_basic_tests(:rails)
 
     # This is to force testing 'rails_friendly_size'.
-    # begin
-    #   require 'active_support'
-    #   Oj.optimize_rails()
-    #   ActiveSupport::JSON::Encoding.escape_html_entities_in_json = false
-    #   run_basic_tests(:rails)
-    # rescue LoadError
-    #   puts 'ActiveSupport not found. Skipping ActiveSupport tests.'
-    # end
+    begin
+      Oj.optimize_rails()
+      ActiveSupport::JSON::Encoding.escape_html_entities_in_json = false
+      run_basic_tests(:rails)
+    rescue LoadError
+      puts 'ActiveSupport not found. Skipping ActiveSupport tests.'
+    end
   end
 
   def run_basic_tests(mode)
@@ -44,6 +43,11 @@ class LongStringsTest < Minitest::Test
     out = Oj.dump(str, mode: mode)
     assert_equal(expected, out)
 
+    str = '\n'*1700
+    expected = "\"#{'\\\\n'*1700}\""
+    out = Oj.dump(str, mode: mode)
+    assert_equal(expected, out)
+
     str = '\n'*32
     expected = "\"#{'\\\\n'*32}\""
     out = Oj.dump(str, mode: mode)
@@ -59,14 +63,29 @@ class LongStringsTest < Minitest::Test
     out = Oj.dump(str, mode: mode)
     assert_equal(expected, out)
 
+    str = '\t'*500
+    expected = "\"#{'\\\\t'*500}\""
+    out = Oj.dump(str, mode: mode)
+    assert_equal(expected, out)
+
     str = "\u0001" * 16
     out = Oj.dump(str, mode: mode)
     expected = "\"#{"\\u0001" * 16}\""
     assert_equal(expected, out)
 
+    str = "\u0001" * 1024
+    out = Oj.dump(str, mode: mode)
+    expected = "\"#{"\\u0001" * 1024}\""
+    assert_equal(expected, out)
+
     str = "\u0001\u0002" * 8
     out = Oj.dump(str, mode: mode)
     expected = "\"#{"\\u0001\\u0002" * 8}\""
+    assert_equal(expected, out)
+
+    str = "\u0001\u0002" * 2000
+    out = Oj.dump(str, mode: mode)
+    expected = "\"#{"\\u0001\\u0002" * 2000}\""
     assert_equal(expected, out)
 
     str = "\u0001a" * 8
@@ -87,6 +106,11 @@ class LongStringsTest < Minitest::Test
     str = "\u0001\u0002" * 9
     out = Oj.dump(str, mode: mode)
     expected = "\"#{"\\u0001\\u0002" * 9}\""
+    assert_equal(expected, out)
+
+    str = "\u0001\u0002" * 2048
+    out = Oj.dump(str, mode: mode)
+    expected = "\"#{"\\u0001\\u0002" * 2048}\""
     assert_equal(expected, out)
 
     str = '\"'
@@ -177,6 +201,13 @@ class LongStringsTest < Minitest::Test
     out = Oj.dump(str, mode: :rails)
     assert_equal(expected, out)
 
+    str = "€"*1700
+    out = Oj.dump(str)
+    expected = %["#{"€"*1700}"]
+    assert_equal(expected, out)
+    out = Oj.dump(str, mode: :rails)
+    assert_equal(expected, out)
+
     str = "€abcdefghijklmnop"
     out = Oj.dump(str)
     expected = %["#{"€abcdefghijklmnop"}"]
@@ -184,16 +215,23 @@ class LongStringsTest < Minitest::Test
     out = Oj.dump(str, mode: :rails)
     assert_equal(expected, out)
 
-    str = "€abcdefghijklmnop€"
+    str = "€" + "abcdefghijklmnop"*1000
     out = Oj.dump(str)
-    expected = %["#{"€abcdefghijklmnop€"}"]
+    expected = %["#{"€" + "abcdefghijklmnop"*1000}"]
     assert_equal(expected, out)
     out = Oj.dump(str, mode: :rails)
     assert_equal(expected, out)
 
-    str = "abcdefghijklmnop€"
+    str = "€" + "abcdefghijklmnop" * 2000 + "€"
     out = Oj.dump(str)
-    expected = %["#{"abcdefghijklmnop€"}"]
+    expected = %["#{"€" + "abcdefghijklmnop" * 2000 + "€"}"]
+    assert_equal(expected, out)
+    out = Oj.dump(str, mode: :rails)
+    assert_equal(expected, out)
+
+    str = "abcdefghijklmnop"*3000 + "€"
+    out = Oj.dump(str)
+    expected = %["#{"abcdefghijklmnop"*3000 + "€"}"]
     assert_equal(expected, out)
     out = Oj.dump(str, mode: :rails)
     assert_equal(expected, out)

--- a/test/test_long_strings.rb
+++ b/test/test_long_strings.rb
@@ -18,14 +18,14 @@ class LongStringsTest < Minitest::Test
     run_basic_tests(:rails)
 
     # This is to force testing 'rails_friendly_size'.
-    begin
-      require 'active_support'
-      Oj.optimize_rails()
-      ActiveSupport::JSON::Encoding.escape_html_entities_in_json = false
-      run_basic_tests(:rails)
-    rescue LoadError
-      puts 'ActiveSupport not found. Skipping ActiveSupport tests.'
-    end
+    # begin
+    #   require 'active_support'
+    #   Oj.optimize_rails()
+    #   ActiveSupport::JSON::Encoding.escape_html_entities_in_json = false
+    #   run_basic_tests(:rails)
+    # rescue LoadError
+    #   puts 'ActiveSupport not found. Skipping ActiveSupport tests.'
+    # end
   end
 
   def run_basic_tests(mode)

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -22,6 +22,7 @@ require 'test_rails'
 require 'test_wab'
 require 'test_writer'
 require 'test_integer_range'
+require 'test_long_strings'
 
 at_exit do
   require 'helper'


### PR DESCRIPTION
Note: This contains the bugfix from [this PR](https://github.com/ohler55/oj/pull/965).

Optimizing `Oj.dump(str, mode: :rails)`

The two benchmarks:
```
benchmark_encoding "mixed utf8", ([("a" * 5000) + "€" + ("a" * 5000)] * 500)
benchmark_encoding "ascii", ([("a" * 5000) + ("a" * 5000)] * 500)
```

The `€` triggers the `has_hi` so the speedup is quite different between the two benchmarks. The `mixed utf8` benchmark is a small speedup as the code spends most of its time in the main loop in `oj_dump_cstr`. 

## Scalar
```
== Encoding mixed utf8 (5003001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                  oj    12.000 i/100ms
Calculating -------------------------------------
                  oj    134.687 (± 2.2%) i/s    (7.42 ms/i) -    684.000 in   5.081051s

== Encoding ascii (5001501 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                  oj    34.000 i/100ms
Calculating -------------------------------------
                  oj    330.226 (± 4.5%) i/s    (3.03 ms/i) -      1.666k in   5.055125s
```

## ARM Neon
```
== Encoding mixed utf8 (5003001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                  oj    15.000 i/100ms
Calculating -------------------------------------
                  oj    147.281 (± 5.4%) i/s    (6.79 ms/i) -    735.000 in   5.006387s

== Encoding ascii (5001501 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
                  oj    48.000 i/100ms
Calculating -------------------------------------
                  oj    469.450 (± 3.4%) i/s    (2.13 ms/i) -      2.352k in   5.016355s
```
