### PR TITLE
ARM Neon optimization of `oj_dump_cstr`

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -206,7 +206,7 @@ inline static size_t hibit_friendly_size(const uint8_t *str, size_t len) {
     size_t size = 0;
     size_t i    = 0;
 
-    for (; i + sizeof(uint8x16_t) < len; i += sizeof(uint8x16_t), str += sizeof(uint8x16_t)) {
+    for (; i + sizeof(uint8x16_t) <= len; i += sizeof(uint8x16_t), str += sizeof(uint8x16_t)) {
         size += sizeof(uint8x16_t);
 
         // See https://lemire.me/blog/2019/07/23/arbitrary-byte-to-byte-maps-using-arm-neon/
@@ -260,7 +260,7 @@ inline static long rails_xss_friendly_size(const uint8_t *str, size_t len) {
 
     uint8x16_t has_some_hibit = vdupq_n_u8(0);
     uint8x16_t hibit          = vdupq_n_u8(0x80);
-    for (; i + sizeof(uint8x16_t) < len; i += sizeof(uint8x16_t), str += sizeof(uint8x16_t)) {
+    for (; i + sizeof(uint8x16_t) <= len; i += sizeof(uint8x16_t), str += sizeof(uint8x16_t)) {
         size += sizeof(uint8x16_t);
 
         uint8x16_t chunk = vld1q_u8(str);
@@ -310,7 +310,7 @@ inline static size_t rails_friendly_size(const uint8_t *str, size_t len) {
     uint8x16_t has_some_hibit = vdupq_n_u8(0);
     uint8x16_t hibit          = vdupq_n_u8(0x80);
 
-    for (; i + sizeof(uint8x16_t) < len; i += sizeof(uint8x16_t), str += sizeof(uint8x16_t)) {
+    for (; i + sizeof(uint8x16_t) <= len; i += sizeof(uint8x16_t), str += sizeof(uint8x16_t)) {
         size += sizeof(uint8x16_t);
 
         // See https://lemire.me/blog/2019/07/23/arbitrary-byte-to-byte-maps-using-arm-neon/
@@ -896,9 +896,49 @@ void oj_dump_raw_json(VALUE obj, int depth, Out out) {
     }
 }
 
+#ifdef HAVE_SIMD_NEON
+typedef struct _neon_match_result {
+    uint8x16_t needs_escape;
+    bool       has_some_hibit;
+    bool       do_unicode_validation;
+} neon_match_result;
+
+#if defined(__clang__) || defined(__GNUC__)
+#define FORCE_INLINE __attribute__((always_inline))
+#else
+#define FORCE_INLINE
+#endif
+
+static inline FORCE_INLINE neon_match_result
+neon_update(const char *str, uint8x16x4_t *cmap_neon, int neon_table_size, bool do_unicode_validation, bool has_hi) {
+    neon_match_result result = {.has_some_hibit = false, .do_unicode_validation = false};
+
+    uint8x16_t chunk    = vld1q_u8((const unsigned char *)str);
+    uint8x16_t tmp1     = vqtbl4q_u8(cmap_neon[0], chunk);
+    uint8x16_t tmp2     = vqtbl4q_u8(cmap_neon[1], veorq_u8(chunk, vdupq_n_u8(0x40)));
+    result.needs_escape = vorrq_u8(tmp1, tmp2);
+    if (neon_table_size > 2) {
+        uint8x16_t tmp3     = vqtbl4q_u8(cmap_neon[2], veorq_u8(chunk, vdupq_n_u8(0x80)));
+        uint8x16_t tmp4     = vqtbl4q_u8(cmap_neon[3], veorq_u8(chunk, vdupq_n_u8(0xc0)));
+        result.needs_escape = vorrq_u8(result.needs_escape, vorrq_u8(tmp4, tmp3));
+    }
+    if (has_hi && do_unicode_validation) {
+        uint8x16_t has_some_hibit    = vandq_u8(chunk, vdupq_n_u8(0x80));
+        result.has_some_hibit        = vmaxvq_u8(has_some_hibit) != 0;
+        result.do_unicode_validation = has_hi && do_unicode_validation && result.has_some_hibit;
+    }
+    return result;
+}
+
+#endif /* HAVE_SIMD_NEON */
+
 void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out out) {
-    size_t      size;
-    char       *cmap;
+    size_t size;
+    char  *cmap;
+#ifdef HAVE_SIMD_NEON
+    uint8x16x4_t *cmap_neon = NULL;
+    int           neon_table_size;
+#endif /* HAVE_SIMD_NEON */
     const char *orig                  = str;
     bool        has_hi                = false;
     bool        do_unicode_validation = false;
@@ -930,7 +970,11 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
         long sz;
 
         cmap = rails_xss_friendly_chars;
-        sz   = rails_xss_friendly_size((uint8_t *)str, cnt);
+#ifdef HAVE_SIMD_NEON
+        cmap_neon       = rails_xss_friendly_chars_neon;
+        neon_table_size = 4;
+#endif /* HAVE_NEON_SIMD */
+        sz = rails_xss_friendly_size((uint8_t *)str, cnt);
         if (sz < 0) {
             has_hi = true;
             size   = (size_t)-sz;
@@ -943,7 +987,11 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
     case RailsEsc: {
         long sz;
         cmap = rails_friendly_chars;
-        sz   = rails_friendly_size((uint8_t *)str, cnt);
+#ifdef HAVE_SIMD_NEON
+        cmap_neon       = rails_friendly_chars_neon;
+        neon_table_size = 2;
+#endif /* HAVE_NEON_SIMD */
+        sz = rails_friendly_size((uint8_t *)str, cnt);
         if (sz < 0) {
             has_hi = true;
             size   = (size_t)-sz;
@@ -954,7 +1002,12 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
         break;
     }
     case JSONEsc:
-    default: cmap = hibit_friendly_chars; size = hibit_friendly_size((uint8_t *)str, cnt);
+    default: cmap = hibit_friendly_chars;
+#ifdef HAVE_SIMD_NEON
+        cmap_neon       = hibit_friendly_chars_neon;
+        neon_table_size = 2;
+#endif /* HAVE_NEON_SIMD */
+        size = hibit_friendly_size((uint8_t *)str, cnt);
     }
     assure_size(out, size + BUFFER_EXTRA);
     *out->cur++ = '"';
@@ -980,8 +1033,131 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
         if (is_sym) {
             *out->cur++ = ':';
         }
+#ifdef HAVE_SIMD_NEON
+        const char *chunk_start;
+        const char *chunk_end;
+        const char *cursor     = str;
+        int         neon_state = (cmap_neon != NULL) ? 1 : 4;
+        char        matches[16];
+        bool        do_hi_validation = false;
+        // uint64_t neon_match_mask = 0;
+#define SEARCH_FLUSH                                  \
+    if (str > cursor) {                               \
+        APPEND_CHARS(out->cur, cursor, str - cursor); \
+        cursor = str;                                 \
+    }
+
+    loop:
+#endif /* HAVE_SIMD_NEON */
         for (; str < end; str++) {
-            switch (cmap[(uint8_t)*str]) {
+            char action = 0;
+#ifdef HAVE_SIMD_NEON
+            /* neon_state:
+             * 1: Scanning for matches. There must be at least 
+                  sizeof(uint8x16_t) bytes of input data to use SIMD and
+                  cmap_neon must be non-null.
+             * 2: Matches have been found. Will set str to the position of the 
+             *    next match and set the state to 3.
+             *    If there are no more matches it will transition to state 1.
+             * 4: Fallback to the scalar algorithm. Not enough data to use 
+             *    SIMD.
+             */
+#define NEON_SET_STATE(state) \
+    neon_state = state;       \
+    goto loop;
+#define NEON_RETURN_TO_STATE(state) neon_state = state;
+            switch (neon_state) {
+            case 1: {
+                while (str + sizeof(uint8x16_t) <= end) {
+                    neon_match_result result = neon_update(str,
+                                                           cmap_neon,
+                                                           neon_table_size,
+                                                           do_unicode_validation,
+                                                           has_hi);
+                    if ((result.do_unicode_validation) || vmaxvq_u8(result.needs_escape) != 0) {
+                        SEARCH_FLUSH;
+                        chunk_start        = str;
+                        chunk_end          = str + sizeof(uint8x16_t);
+                        uint8x16_t actions = vaddq_u8(result.needs_escape, vdupq_n_u8('1'));
+                        do_hi_validation   = result.do_unicode_validation;
+                        vst1q_u8((unsigned char *)matches, actions);
+                        NEON_SET_STATE(2);
+                    }
+                    str += sizeof(uint8x16_t);
+                }
+                SEARCH_FLUSH;
+                // If we have at least SIMD_MINIMUM_THRESHOLD bytes of data and there is enough space
+                // in the output buffer (which we use as temporary storage) then we can use SIMD.
+                size_t remaining_bytes = end - str;
+                if (remaining_bytes >= SIMD_MINIMUM_THRESHOLD &&
+                    ((unsigned long)(out->end - out->cur)) >= sizeof(uint8x16_t)) {
+                    // We set sizeof(uint8x16_t) 'A' bytes to the end of the output buffer. We do this so anything past
+                    // the remaining_bytes of the str does not trigger the need to be escaped.
+                    memset(out->cur, 'A', sizeof(uint8x16_t));
+                    memcpy(out->cur, str, remaining_bytes);
+                    neon_match_result result = neon_update(out->cur,
+                                                           cmap_neon,
+                                                           neon_table_size,
+                                                           do_unicode_validation,
+                                                           has_hi);
+                    if ((result.do_unicode_validation) || vmaxvq_u8(result.needs_escape) != 0) {
+                        chunk_start        = str;
+                        chunk_end          = end;
+                        uint8x16_t actions = vaddq_u8(result.needs_escape, vdupq_n_u8('1'));
+                        do_hi_validation   = result.do_unicode_validation;
+                        vst1q_u8((unsigned char *)matches, actions);
+                        NEON_SET_STATE(2);
+                    } else {
+                        // No matches found. Conveniently the data has already been copied to the output buffer.
+                        str = end;
+                        out->cur += remaining_bytes;
+                        goto loop;
+                    }
+                }
+                // We must have run out of data to use SIMD. Go to state 4.
+                SEARCH_FLUSH;
+                NEON_SET_STATE(4);
+            } break;
+            case 3:
+                cursor = str;
+                // This fall through is intentional. We return to state 3 after we process
+                // a byte (or multiple). We return to this state to ensure the cursor is
+                // pointing to the correct location. We then resume looking for matches
+                // within the previously processed chunk.
+            case 2:
+                if (str >= chunk_end) {
+                    NEON_SET_STATE(1);
+                }
+                // if (!has_hi /*|| (do_unicode_validation && !chunk_has_hibit)*/) {
+                if (!do_hi_validation) {
+                    long i = str - chunk_start;
+                    for (; str < chunk_end; i++) {
+                        if ((action = matches[i]) != '1') {
+                            break;
+                        }
+                        *out->cur++ = *str++;
+                    }
+                    // The loop above may have advanced str and directly output them to out->cur.
+                    // Ensure cursor is set appropriately.
+                    cursor = str;
+                    if (str >= chunk_end) {
+                        // We must have advanced past the end... we are done.
+                        NEON_SET_STATE(1);
+                    }
+                } else {
+                    long match_index = str - chunk_start;
+                    action           = matches[match_index];
+                }
+                NEON_RETURN_TO_STATE(3);
+                break;
+            case 4: action = cmap[(uint8_t)*str];
+            }
+#undef NEON_SET_STATE
+#undef NEON_RETURN_TO_STATE
+#else
+            action = cmap[(uint8_t)*str];
+#endif /* HAVE_SIMD_NEON */
+            switch (action) {
             case '1':
                 if (do_unicode_validation && check_start <= str) {
                     if (0 != (0x80 & (uint8_t)*str)) {

--- a/ext/oj/simd.h
+++ b/ext/oj/simd.h
@@ -3,6 +3,7 @@
 
 #if defined(__ARM_NEON) || defined(__ARM_NEON__) || defined(__aarch64__) || defined(_M_ARM64)
 #define HAVE_SIMD_NEON 1
+#define SIMD_MINIMUM_THRESHOLD 6
 #include <arm_neon.h>
 #endif
 

--- a/test/test_long_strings.rb
+++ b/test/test_long_strings.rb
@@ -34,6 +34,41 @@ class LongStringsTest < Minitest::Test
   end
 
   def run_basic_tests(mode)
+    str = 'A'*4
+    expected = "\"#{'A'*4}\""
+    out = Oj.dump(str, mode: mode)
+    assert_equal(expected, out)
+
+    str = 'A'*6
+    expected = "\"#{'A'*6}\""
+    out = Oj.dump(str, mode: mode)
+    assert_equal(expected, out)
+
+    str = 'A'*7
+    expected = "\"#{'A'*7}\""
+    out = Oj.dump(str, mode: mode)
+    assert_equal(expected, out)
+
+    str = 'A'*15
+    expected = "\"#{'A'*15}\""
+    out = Oj.dump(str, mode: mode)
+    assert_equal(expected, out)
+
+    str = 'A'*16
+    expected = "\"#{'A'*16}\""
+    out = Oj.dump(str, mode: mode)
+    assert_equal(expected, out)
+
+    str = 'A'*17
+    expected = "\"#{'A'*17}\""
+    out = Oj.dump(str, mode: mode)
+    assert_equal(expected, out)
+
+    str = 'A'*31
+    expected = "\"#{'A'*31}\""
+    out = Oj.dump(str, mode: mode)
+    assert_equal(expected, out)
+
     str = '\n'*15
     expected = "\"#{'\\\\n'*15}\""
     out = Oj.dump(str, mode: mode)


### PR DESCRIPTION
# Overview

This pull request optimizes `oj_dump_cstr` using ARM Neon instructions to locate characters that need to be escaped. It does so by implementing a state machine within the current structure of the code.

Note: It may be nice in the future to refactor this code into two distinct functions. One function for searching for characters that need to be escaped and another to do the escaping. 

Additionally, I hope this doesn't break any of the Unicode validation. If `do_unicode_validation == true` and this code detects a high byte, it forces all of the characters within that chunk of text through the current code. 

# Benchmarks

Both benchmarks compare `master` (commit: `4332ae9f81db7caed9411be445a145276c69d4fb`) vs this `arm-neon-optimize-oj-dump-cstr` branch (commit `5e8a65304633d87d0f13ce192ce3404de74bbb5b`)

The benchmarks are a mix of macro benchmarks testing real-world data sets and synthetic "happy path" tests. Real world tests show a 0-25% speed up using `clang` and 6-42% speedup with `gcc-14`. 

The best-case synthetic test shows a 264% speedup on `clang` and 320% on `gcc`. This test is a 128 byte ascii string with a single `\n` at the end. 

**NOTE**: Please scroll down to see the notes about synthetic worst-case tests.

## compiler: Apple clang version 17.0.0 (clang-1700.0.13.3)
```
== Encoding activitypub.json (52595 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after     2.210k i/100ms
Calculating -------------------------------------
               after     22.296k (± 1.3%) i/s   (44.85 μs/i) -    112.710k in   5.055962s

Comparison:
              before:    17833.7 i/s
               after:    22296.3 i/s - 1.25x  faster


== Encoding citm_catalog.json (500298 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after    90.000 i/100ms
Calculating -------------------------------------
               after    902.113 (± 1.4%) i/s    (1.11 ms/i) -      4.590k in   5.089184s

Comparison:
              before:      909.1 i/s
               after:      902.1 i/s - same-ish: difference falls within error


== Encoding twitter.json (466906 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after   220.000 i/100ms
Calculating -------------------------------------
               after      2.193k (± 1.1%) i/s  (455.89 μs/i) -     11.000k in   5.015504s

Comparison:
              before:     2018.5 i/s
               after:     2193.5 i/s - 1.09x  faster


== Encoding bytes.16.singlematch-start (200001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after   396.000 i/100ms
Calculating -------------------------------------
               after      3.973k (± 1.5%) i/s  (251.67 μs/i) -     20.196k in   5.083963s

Comparison:
              before:     4082.4 i/s
               after:     3973.4 i/s - 1.03x  slower


== Encoding bytes.16.singlematch-middle (200001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after   400.000 i/100ms
Calculating -------------------------------------
               after      4.029k (± 1.3%) i/s  (248.22 μs/i) -     20.400k in   5.064644s

Comparison:
              before:     4138.4 i/s
               after:     4028.6 i/s - same-ish: difference falls within error


== Encoding bytes.16.singlematch-end (200001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after   421.000 i/100ms
Calculating -------------------------------------
               after      4.189k (± 0.9%) i/s  (238.72 μs/i) -     21.050k in   5.025500s

Comparison:
              before:     4241.0 i/s
               after:     4189.0 i/s - same-ish: difference falls within error


== Encoding bytes.128.single-escape-at-end (1330001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after   178.000 i/100ms
Calculating -------------------------------------
               after      1.761k (± 2.4%) i/s  (567.84 μs/i) -      8.900k in   5.056808s

Comparison:
              before:      668.1 i/s
               after:     1761.1 i/s - 2.64x  faster
```

### compiler: gcc version 14.2.0 (Homebrew GCC 14.2.0_1)

```
== Encoding activitypub.json (52595 bytes)
ruby 3.3.8 (2025-04-09 revision b200bad6cd) +YJIT [arm64-darwin24]
Warming up --------------------------------------
               after     2.388k i/100ms
Calculating -------------------------------------
               after     24.243k (± 1.1%) i/s   (41.25 μs/i) -    121.788k in   5.024204s

Comparison:
              before:    17104.2 i/s
               after:    24243.5 i/s - 1.42x  faster


== Encoding citm_catalog.json (500298 bytes)
ruby 3.3.8 (2025-04-09 revision b200bad6cd) +YJIT [arm64-darwin24]
Warming up --------------------------------------
               after   108.000 i/100ms
Calculating -------------------------------------
               after      1.097k (± 1.1%) i/s  (911.73 μs/i) -      5.508k in   5.022404s

Comparison:
              before:     1035.4 i/s
               after:     1096.8 i/s - 1.06x  faster


== Encoding twitter.json (466906 bytes)
ruby 3.3.8 (2025-04-09 revision b200bad6cd) +YJIT [arm64-darwin24]
Warming up --------------------------------------
               after   247.000 i/100ms
Calculating -------------------------------------
               after      2.482k (± 2.0%) i/s  (402.95 μs/i) -     12.597k in   5.078149s

Comparison:
              before:     2183.4 i/s
               after:     2481.7 i/s - 1.14x  faster


== Encoding bytes.16.singlematch-start (200001 bytes)
ruby 3.3.8 (2025-04-09 revision b200bad6cd) +YJIT [arm64-darwin24]
Warming up --------------------------------------
               after   424.000 i/100ms
Calculating -------------------------------------
               after      4.205k (± 2.5%) i/s  (237.80 μs/i) -     21.200k in   5.044784s

Comparison:
              before:     3423.3 i/s
               after:     4205.2 i/s - 1.23x  faster


== Encoding bytes.16.singlematch-middle (200001 bytes)
ruby 3.3.8 (2025-04-09 revision b200bad6cd) +YJIT [arm64-darwin24]
Warming up --------------------------------------
               after   422.000 i/100ms
Calculating -------------------------------------
               after      4.301k (± 1.5%) i/s  (232.48 μs/i) -     21.522k in   5.004466s

Comparison:
              before:     3439.2 i/s
               after:     4301.5 i/s - 1.25x  faster


== Encoding bytes.16.singlematch-end (200001 bytes)
ruby 3.3.8 (2025-04-09 revision b200bad6cd) +YJIT [arm64-darwin24]
Warming up --------------------------------------
               after   447.000 i/100ms
Calculating -------------------------------------
               after      4.419k (± 1.6%) i/s  (226.32 μs/i) -     22.350k in   5.059584s

Comparison:
              before:     3424.5 i/s
               after:     4418.5 i/s - 1.29x  faster


== Encoding bytes.128.single-escape-at-end (1330001 bytes)
ruby 3.3.8 (2025-04-09 revision b200bad6cd) +YJIT [arm64-darwin24]
Warming up --------------------------------------
               after   168.000 i/100ms
Calculating -------------------------------------
               after      1.763k (± 2.8%) i/s  (567.13 μs/i) -      8.904k in   5.053473s

Comparison:
              before:      551.6 i/s
               after:     1763.3 i/s - 3.20x  faster
```


# Synthetic worst case tests

Unfortunately, for escape heavy workloads this code may be significantly slower. I'm including these tests for transparency. Unfortunately it's not all roses.

I don't know how realistic these are... I would hope these sorts of use cases are quite uncommon. However, I'll like focus on a bit on trying to reduce the performance hit of these types of benchmarks/use cases. One quick idea I had was that if the output length is greater than `some multiple` of the input just fall back to the scalar loop.

I did include one "happy path" test for a control.

## The benchmarks

```
benchmark_encoding "bytes.15.bestcase", ([("a" * 15)] * 10000)
benchmark_encoding "bytes.15.worstcase", ([('"' * 15)] * 10000)
benchmark_encoding "bytes.15.worstcase-2", (["\u0001a\u0002b\u0001a\u0002b\u0001a\u0002b\u0001a\u0002"] * 10000)
benchmark_encoding "bytes.32.worstcase", ([("\"\t\\\n" * 8)] * 10000)
```

### compiler: Apple clang version 17.0.0 (clang-1700.0.13.3)
```
== Encoding bytes.15.bestcase (180001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after   556.000 i/100ms
Calculating -------------------------------------
               after      5.650k (± 1.8%) i/s  (176.99 μs/i) -     28.356k in   5.020415s

Comparison:
              before:     5748.1 i/s
               after:     5650.0 i/s - same-ish: difference falls within error


== Encoding bytes.15.worstcase (330001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after   172.000 i/100ms
Calculating -------------------------------------
               after      1.737k (± 4.4%) i/s  (575.76 μs/i) -      8.772k in   5.064093s

Comparison:
              before:     2766.3 i/s
               after:     1736.8 i/s - 1.59x  slower


== Encoding bytes.15.worstcase-2 (580001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after   202.000 i/100ms
Calculating -------------------------------------
               after      2.085k (± 5.1%) i/s  (479.64 μs/i) -     10.504k in   5.055611s

Comparison:
              before:     2589.5 i/s
               after:     2084.9 i/s - 1.24x  slower


== Encoding bytes.32.worstcase (670001 bytes)
ruby 3.4.1 (2024-12-25 revision 48d4efcb85) +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after    79.000 i/100ms
Calculating -------------------------------------
               after    824.656 (± 1.9%) i/s    (1.21 ms/i) -      4.187k in   5.079329s

Comparison:
              before:     1446.3 i/s
               after:      824.7 i/s - 1.75x  slower
```

### compiler: gcc version 14.2.0 (Homebrew GCC 14.2.0_1)
```
== Encoding bytes.15.bestcase (180001 bytes)
ruby 3.3.8 (2025-04-09 revision b200bad6cd) +YJIT [arm64-darwin24]
Warming up --------------------------------------
               after   605.000 i/100ms
Calculating -------------------------------------
               after      6.239k (± 2.1%) i/s  (160.28 μs/i) -     31.460k in   5.044701s

Comparison:
              before:     6504.8 i/s
               after:     6238.9 i/s - same-ish: difference falls within error


== Encoding bytes.15.worstcase (330001 bytes)
ruby 3.3.8 (2025-04-09 revision b200bad6cd) +YJIT [arm64-darwin24]
Warming up --------------------------------------
               after   158.000 i/100ms
Calculating -------------------------------------
               after      1.583k (± 1.6%) i/s  (631.72 μs/i) -      8.058k in   5.091748s

Comparison:
              before:     2182.4 i/s
               after:     1583.0 i/s - 1.38x  slower


== Encoding bytes.15.worstcase-2 (580001 bytes)
ruby 3.3.8 (2025-04-09 revision b200bad6cd) +YJIT [arm64-darwin24]
Warming up --------------------------------------
               after   227.000 i/100ms
Calculating -------------------------------------
               after      2.255k (± 2.2%) i/s  (443.38 μs/i) -     11.350k in   5.034758s

Comparison:
              before:     3010.0 i/s
               after:     2255.4 i/s - 1.33x  slower


== Encoding bytes.32.worstcase (670001 bytes)
ruby 3.3.8 (2025-04-09 revision b200bad6cd) +YJIT [arm64-darwin24]
Warming up --------------------------------------
               after    78.000 i/100ms
Calculating -------------------------------------
               after    799.802 (± 7.1%) i/s    (1.25 ms/i) -      3.978k in   5.020809s

Comparison:
              before:     1410.0 i/s
               after:      799.8 i/s - 1.76x  slower
```