### PR TITLE
`size_t` everywhere.

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -29,4 +29,4 @@ jobs:
     - name: Run clang-format style check
       uses: jidicula/clang-format-action@v4.15.0
       with:
-        clang-format-version: 16
+        clang-format-version: 20

--- a/ext/oj/custom.c
+++ b/ext/oj/custom.c
@@ -40,7 +40,7 @@ static void dump_obj_as_str(VALUE obj, int depth, Out out) {
 static void bigdecimal_dump(VALUE obj, int depth, Out out) {
     volatile VALUE rstr = oj_safe_string_convert(obj);
     const char    *str  = RSTRING_PTR(rstr);
-    int            len  = (int)RSTRING_LEN(rstr);
+    size_t         len  = RSTRING_LEN(rstr);
 
     if (0 == strcasecmp("Infinity", str)) {
         str = oj_nan_str(obj, out->opts->dump_opts.nan_dump, out->opts->mode, true, &len);
@@ -123,7 +123,7 @@ static void date_dump(VALUE obj, int depth, Out out) {
         case RubyTime:
         case XmlTime:
             v = rb_funcall(obj, rb_intern("iso8601"), 0);
-            oj_dump_cstr(RSTRING_PTR(v), (int)RSTRING_LEN(v), 0, 0, out);
+            oj_dump_cstr(RSTRING_PTR(v), RSTRING_LEN(v), 0, 0, out);
             break;
         case UnixZTime:
             v = rb_funcall(obj, rb_intern("to_time"), 0);
@@ -405,7 +405,7 @@ static void dump_odd(VALUE obj, Odd odd, VALUE clas, int depth, Out out) {
             rb_raise(rb_eEncodingError, "Invalid type for raw JSON.\n");
         } else {
             const char *s    = RSTRING_PTR(v);
-            int         len  = (int)RSTRING_LEN(v);
+            size_t      len  = RSTRING_LEN(v);
             const char *name = rb_id2name(*odd->attrs);
             size_t      nlen = strlen(name);
 
@@ -478,7 +478,7 @@ static VALUE dump_common(VALUE obj, int depth, Out out) {
     } else if (Yes == out->opts->to_json && rb_respond_to(obj, oj_to_json_id)) {
         volatile VALUE rs;
         const char    *s;
-        int            len;
+        size_t         len;
 
         TRACE(out->opts->trace, "to_json", obj, depth + 1, TraceRubyIn);
         if (0 == rb_obj_method_arity(obj, oj_to_json_id)) {
@@ -488,7 +488,7 @@ static VALUE dump_common(VALUE obj, int depth, Out out) {
         }
         TRACE(out->opts->trace, "to_json", obj, depth + 1, TraceRubyOut);
         s   = RSTRING_PTR(rs);
-        len = (int)RSTRING_LEN(rs);
+        len = RSTRING_LEN(rs);
 
         assure_size(out, len + 1);
         APPEND_CHARS(out->cur, s, len);
@@ -509,7 +509,7 @@ static VALUE dump_common(VALUE obj, int depth, Out out) {
         if (aj == obj) {
             volatile VALUE rstr = oj_safe_string_convert(obj);
 
-            oj_dump_cstr(RSTRING_PTR(rstr), (int)RSTRING_LEN(rstr), false, false, out);
+            oj_dump_cstr(RSTRING_PTR(rstr), RSTRING_LEN(rstr), false, false, out);
         } else {
             oj_dump_custom_val(aj, depth, out, true);
         }
@@ -795,7 +795,7 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
                 volatile VALUE s = rb_sym2str(RARRAY_AREF(ma, i));
 
                 name = RSTRING_PTR(s);
-                len  = (int)RSTRING_LEN(s);
+                len  = RSTRING_LEN(s);
             } else {
                 len  = snprintf(num_id, sizeof(num_id), "%d", i);
                 name = num_id;

--- a/ext/oj/custom.c
+++ b/ext/oj/custom.c
@@ -676,7 +676,8 @@ static void dump_obj(VALUE obj, int depth, Out out, bool as_ok) {
 
 static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
     size_t size;
-    int    i, cnt;
+    size_t i;
+    size_t cnt;
     int    d2 = depth + 1;
     long   id = oj_check_circular(a, out);
 
@@ -684,7 +685,7 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
         oj_dump_nil(Qnil, depth, out, false);
         return;
     }
-    cnt         = (int)RARRAY_LEN(a);
+    cnt         = RARRAY_LEN(a);
     *out->cur++ = '[';
     assure_size(out, 2);
     if (0 == cnt) {

--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -1205,7 +1205,7 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
         *out->cur++ = '"';
     }
     if (do_unicode_validation && 0 < str - orig && 0 != (0x80 & *(str - 1))) {
-        uint8_t c = (uint8_t) * (str - 1);
+        uint8_t c = (uint8_t)*(str - 1);
         int     i;
         int     scnt = (int)(str - orig);
 

--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -350,7 +350,7 @@ inline static size_t rails_friendly_size(const uint8_t *str, size_t len) {
 #endif /* HAVE_SIMD_NEON */
 }
 
-const char *oj_nan_str(VALUE obj, int opt, int mode, bool plus, int *lenp) {
+const char *oj_nan_str(VALUE obj, int opt, int mode, bool plus, size_t *lenp) {
     const char *str = NULL;
 
     if (AutoNan == opt) {
@@ -615,7 +615,7 @@ void oj_dump_time(VALUE obj, Out out, int withZone) {
 void oj_dump_ruby_time(VALUE obj, Out out) {
     volatile VALUE rstr = oj_safe_string_convert(obj);
 
-    oj_dump_cstr(RSTRING_PTR(rstr), (int)RSTRING_LEN(rstr), 0, 0, out);
+    oj_dump_cstr(RSTRING_PTR(rstr), RSTRING_LEN(rstr), 0, 0, out);
 }
 
 void oj_dump_xml_time(VALUE obj, Out out) {
@@ -849,13 +849,13 @@ void oj_dump_str(VALUE obj, int depth, Out out, bool as_ok) {
         rb_encoding *enc = rb_enc_from_index(idx);
         obj              = rb_str_conv_enc(obj, enc, oj_utf8_encoding);
     }
-    oj_dump_cstr(RSTRING_PTR(obj), (int)RSTRING_LEN(obj), 0, 0, out);
+    oj_dump_cstr(RSTRING_PTR(obj), RSTRING_LEN(obj), 0, 0, out);
 }
 
 void oj_dump_sym(VALUE obj, int depth, Out out, bool as_ok) {
     volatile VALUE s = rb_sym2str(obj);
 
-    oj_dump_cstr(RSTRING_PTR(s), (int)RSTRING_LEN(s), 0, 0, out);
+    oj_dump_cstr(RSTRING_PTR(s), RSTRING_LEN(s), 0, 0, out);
 }
 
 static void debug_raise(const char *orig, size_t cnt, int line) {
@@ -1053,13 +1053,13 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
             char action = 0;
 #ifdef HAVE_SIMD_NEON
             /* neon_state:
-             * 1: Scanning for matches. There must be at least 
+             * 1: Scanning for matches. There must be at least
                   sizeof(uint8x16_t) bytes of input data to use SIMD and
                   cmap_neon must be non-null.
-             * 2: Matches have been found. Will set str to the position of the 
+             * 2: Matches have been found. Will set str to the position of the
              *    next match and set the state to 3.
              *    If there are no more matches it will transition to state 1.
-             * 4: Fallback to the scalar algorithm. Not enough data to use 
+             * 4: Fallback to the scalar algorithm. Not enough data to use
              *    SIMD.
              */
 #define NEON_SET_STATE(state) \
@@ -1256,7 +1256,7 @@ void oj_dump_class(VALUE obj, int depth, Out out, bool as_ok) {
 void oj_dump_obj_to_s(VALUE obj, Out out) {
     volatile VALUE rstr = oj_safe_string_convert(obj);
 
-    oj_dump_cstr(RSTRING_PTR(rstr), (int)RSTRING_LEN(rstr), 0, 0, out);
+    oj_dump_cstr(RSTRING_PTR(rstr), RSTRING_LEN(rstr), 0, 0, out);
 }
 
 void oj_dump_raw(const char *str, size_t cnt, Out out) {
@@ -1391,7 +1391,7 @@ void oj_dump_fixnum(VALUE obj, int depth, Out out, bool as_ok) {
 
 void oj_dump_bignum(VALUE obj, int depth, Out out, bool as_ok) {
     volatile VALUE rs             = rb_big2str(obj, 10);
-    int            cnt            = (int)RSTRING_LEN(rs);
+    size_t         cnt            = RSTRING_LEN(rs);
     bool           dump_as_string = false;
 
     if (out->opts->int_range_max != 0 || out->opts->int_range_min != 0) {  // Bignum cannot be inside of Fixnum range
@@ -1413,7 +1413,7 @@ void oj_dump_float(VALUE obj, int depth, Out out, bool as_ok) {
     char   buf[64];
     char  *b;
     double d   = rb_num2dbl(obj);
-    int    cnt = 0;
+    size_t cnt = 0;
 
     if (0.0 == d) {
         b    = buf;
@@ -1524,7 +1524,7 @@ void oj_dump_float(VALUE obj, int depth, Out out, bool as_ok) {
     } else if (0 == out->opts->float_prec) {
         volatile VALUE rstr = oj_safe_string_convert(obj);
 
-        cnt = (int)RSTRING_LEN(rstr);
+        cnt = RSTRING_LEN(rstr);
         if ((int)sizeof(buf) <= cnt) {
             cnt = sizeof(buf) - 1;
         }
@@ -1538,8 +1538,8 @@ void oj_dump_float(VALUE obj, int depth, Out out, bool as_ok) {
     *out->cur = '\0';
 }
 
-int oj_dump_float_printf(char *buf, size_t blen, VALUE obj, double d, const char *format) {
-    int cnt = snprintf(buf, blen, format, d);
+size_t oj_dump_float_printf(char *buf, size_t blen, VALUE obj, double d, const char *format) {
+    size_t cnt = snprintf(buf, blen, format, d);
 
     // Round off issues at 16 significant digits so check for obvious ones of
     // 0001 and 9999.
@@ -1547,7 +1547,7 @@ int oj_dump_float_printf(char *buf, size_t blen, VALUE obj, double d, const char
         volatile VALUE rstr = oj_safe_string_convert(obj);
 
         strcpy(buf, RSTRING_PTR(rstr));
-        cnt = (int)RSTRING_LEN(rstr);
+        cnt = RSTRING_LEN(rstr);
     }
     return cnt;
 }

--- a/ext/oj/dump.h
+++ b/ext/oj/dump.h
@@ -35,7 +35,7 @@ extern void oj_dump_xml_time(VALUE obj, Out out);
 extern void oj_dump_time(VALUE obj, Out out, int withZone);
 extern void oj_dump_obj_to_s(VALUE obj, Out out);
 
-extern const char *oj_nan_str(VALUE obj, int opt, int mode, bool plus, int *lenp);
+extern const char *oj_nan_str(VALUE obj, int opt, int mode, bool plus, size_t *lenp);
 
 // initialize an out buffer with the provided stack allocated memory
 extern void oj_out_init(Out out);
@@ -58,7 +58,7 @@ extern void oj_dump_raw_json(VALUE obj, int depth, Out out);
 extern VALUE oj_add_to_json(int argc, VALUE *argv, VALUE self);
 extern VALUE oj_remove_to_json(int argc, VALUE *argv, VALUE self);
 
-extern int oj_dump_float_printf(char *buf, size_t blen, VALUE obj, double d, const char *format);
+extern size_t oj_dump_float_printf(char *buf, size_t blen, VALUE obj, double d, const char *format);
 
 extern time_t oj_sec_from_time_hard_way(VALUE obj);
 

--- a/ext/oj/dump_compat.c
+++ b/ext/oj/dump_compat.c
@@ -124,7 +124,8 @@ static void dump_to_json(VALUE obj, Out out) {
 
 static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
     size_t size;
-    int    i, cnt;
+    size_t i;
+    size_t cnt;
     int    d2 = depth + 1;
     long   id = oj_check_circular(a, out);
 
@@ -136,7 +137,7 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
         dump_to_json(a, out);
         return;
     }
-    cnt         = (int)RARRAY_LEN(a);
+    cnt         = RARRAY_LEN(a);
     *out->cur++ = '[';
     assure_size(out, 2);
     if (0 == cnt) {

--- a/ext/oj/dump_compat.c
+++ b/ext/oj/dump_compat.c
@@ -103,7 +103,7 @@ static void dump_values_array(VALUE *values, int depth, Out out) {
 static void dump_to_json(VALUE obj, Out out) {
     volatile VALUE rs;
     const char    *s;
-    size_t        len;
+    size_t         len;
 
     TRACE(out->opts->trace, "to_json", obj, 0, TraceRubyIn);
     if (0 == rb_obj_method_arity(obj, oj_to_json_id)) {

--- a/ext/oj/dump_compat.c
+++ b/ext/oj/dump_compat.c
@@ -103,7 +103,7 @@ static void dump_values_array(VALUE *values, int depth, Out out) {
 static void dump_to_json(VALUE obj, Out out) {
     volatile VALUE rs;
     const char    *s;
-    int            len;
+    size_t        len;
 
     TRACE(out->opts->trace, "to_json", obj, 0, TraceRubyIn);
     if (0 == rb_obj_method_arity(obj, oj_to_json_id)) {
@@ -115,7 +115,7 @@ static void dump_to_json(VALUE obj, Out out) {
 
     StringValue(rs);
     s   = RSTRING_PTR(rs);
-    len = (int)RSTRING_LEN(rs);
+    len = RSTRING_LEN(rs);
 
     assure_size(out, len + 1);
     APPEND_CHARS(out->cur, s, len);
@@ -552,7 +552,7 @@ static void dump_float(VALUE obj, int depth, Out out, bool as_ok) {
     char   buf[64];
     char  *b;
     double d   = rb_num2dbl(obj);
-    int    cnt = 0;
+    size_t cnt = 0;
 
     if (0.0 == d) {
         b    = buf;
@@ -590,7 +590,7 @@ static void dump_float(VALUE obj, int depth, Out out, bool as_ok) {
         volatile VALUE rstr = oj_safe_string_convert(obj);
 
         strcpy(buf, RSTRING_PTR(rstr));
-        cnt = (int)RSTRING_LEN(rstr);
+        cnt = RSTRING_LEN(rstr);
     }
     assure_size(out, cnt);
     APPEND_CHARS(out->cur, buf, cnt);
@@ -800,7 +800,7 @@ static void dump_bignum(VALUE obj, int depth, Out out, bool as_ok) {
     // rb_big2str can not so unless overridden by using add_to_json(Integer)
     // this must use to_s to pass the json gem unit tests.
     volatile VALUE rs;
-    int            cnt;
+    size_t         cnt;
     bool           dump_as_string = false;
 
     if (use_bignum_alt) {
@@ -809,7 +809,7 @@ static void dump_bignum(VALUE obj, int depth, Out out, bool as_ok) {
         rs = oj_safe_string_convert(obj);
     }
     rb_check_type(rs, T_STRING);
-    cnt = (int)RSTRING_LEN(rs);
+    cnt = RSTRING_LEN(rs);
 
     if (out->opts->int_range_min != 0 || out->opts->int_range_max != 0) {
         dump_as_string = true;  // Bignum cannot be inside of Fixnum range

--- a/ext/oj/dump_leaf.c
+++ b/ext/oj/dump_leaf.c
@@ -17,7 +17,7 @@ inline static void dump_chars(const char *s, size_t size, Out out) {
 static void dump_leaf_str(Leaf leaf, Out out) {
     switch (leaf->value_type) {
     case STR_VAL: oj_dump_cstr(leaf->str, strlen(leaf->str), 0, 0, out); break;
-    case RUBY_VAL: oj_dump_cstr(StringValueCStr(leaf->value), (int)RSTRING_LEN(leaf->value), 0, 0, out); break;
+    case RUBY_VAL: oj_dump_cstr(StringValueCStr(leaf->value), RSTRING_LEN(leaf->value), 0, 0, out); break;
     case COL_VAL:
     default: rb_raise(rb_eTypeError, "Unexpected value type %02x.\n", leaf->value_type); break;
     }

--- a/ext/oj/dump_object.c
+++ b/ext/oj/dump_object.c
@@ -33,7 +33,7 @@ static void dump_data(VALUE obj, int depth, Out out, bool as_ok) {
         if (oj_bigdecimal_class == clas) {
             volatile VALUE rstr = oj_safe_string_convert(obj);
             const char    *str  = RSTRING_PTR(rstr);
-            int            len  = (int)RSTRING_LEN(rstr);
+            size_t         len  = RSTRING_LEN(rstr);
 
             if (No != out->opts->bigdec_as_num) {
                 oj_dump_raw(str, len, out);
@@ -62,7 +62,7 @@ static void dump_obj(VALUE obj, int depth, Out out, bool as_ok) {
     if (oj_bigdecimal_class == clas) {
         volatile VALUE rstr = oj_safe_string_convert(obj);
         const char    *str  = RSTRING_PTR(rstr);
-        int            len  = (int)RSTRING_LEN(rstr);
+        size_t         len  = RSTRING_LEN(rstr);
 
         if (0 == strcasecmp("Infinity", str)) {
             str = oj_nan_str(obj, out->opts->dump_opts.nan_dump, out->opts->mode, true, &len);
@@ -181,7 +181,7 @@ static void dump_str_class(VALUE obj, VALUE clas, int depth, Out out) {
         dump_obj_attrs(obj, clas, 0, depth, out);
     } else {
         const char *s   = RSTRING_PTR(obj);
-        size_t      len = (int)RSTRING_LEN(obj);
+        size_t      len = RSTRING_LEN(obj);
         char        s1  = s[1];
 
         oj_dump_cstr(s, len, 0, (':' == *s || ('^' == *s && ('r' == s1 || 'i' == s1))), out);
@@ -195,7 +195,7 @@ static void dump_str(VALUE obj, int depth, Out out, bool as_ok) {
 static void dump_sym(VALUE obj, int depth, Out out, bool as_ok) {
     volatile VALUE s = rb_sym2str(obj);
 
-    oj_dump_cstr(RSTRING_PTR(s), (int)RSTRING_LEN(s), 1, 0, out);
+    oj_dump_cstr(RSTRING_PTR(s), RSTRING_LEN(s), 1, 0, out);
 }
 
 static int hash_cb(VALUE key, VALUE value, VALUE ov) {
@@ -389,7 +389,7 @@ static void dump_odd(VALUE obj, Odd odd, VALUE clas, int depth, Out out) {
             rb_raise(rb_eEncodingError, "Invalid type for raw JSON.");
         } else {
             const char *s    = RSTRING_PTR(v);
-            int         len  = (int)RSTRING_LEN(v);
+            size_t      len  = RSTRING_LEN(v);
             const char *name = rb_id2name(*odd->attrs);
             size_t      nlen = strlen(name);
 
@@ -489,7 +489,7 @@ static void dump_obj_attrs(VALUE obj, VALUE clas, slot_t id, int depth, Out out)
         *out->cur++ = ',';
         fill_indent(out, d2);
         APPEND_CHARS(out->cur, "\"self\":", 7);
-        oj_dump_cstr(RSTRING_PTR(obj), (int)RSTRING_LEN(obj), 0, 0, out);
+        oj_dump_cstr(RSTRING_PTR(obj), RSTRING_LEN(obj), 0, 0, out);
         break;
     case T_ARRAY:
         assure_size(out, d2 * out->indent + 14);
@@ -585,7 +585,7 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
             volatile VALUE s = rb_sym2str(RARRAY_AREF(ma, i));
 
             name = RSTRING_PTR(s);
-            len  = (int)RSTRING_LEN(s);
+            len  = RSTRING_LEN(s);
             size = len + 3;
             assure_size(out, size);
             if (0 < i) {

--- a/ext/oj/dump_object.c
+++ b/ext/oj/dump_object.c
@@ -95,7 +95,8 @@ static void dump_class(VALUE obj, int depth, Out out, bool as_ok) {
 
 static void dump_array_class(VALUE a, VALUE clas, int depth, Out out) {
     size_t size;
-    int    i, cnt;
+    size_t i;
+    size_t cnt;
     int    d2 = depth + 1;
     long   id = oj_check_circular(a, out);
 
@@ -106,7 +107,7 @@ static void dump_array_class(VALUE a, VALUE clas, int depth, Out out) {
         dump_obj_attrs(a, clas, 0, depth, out);
         return;
     }
-    cnt         = (int)RARRAY_LEN(a);
+    cnt         = RARRAY_LEN(a);
     *out->cur++ = '[';
     if (0 < id) {
         assure_size(out, d2 * out->indent + 16);
@@ -564,7 +565,7 @@ static void dump_regexp(VALUE obj, int depth, Out out, bool as_ok) {
 static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
     VALUE       clas       = rb_obj_class(obj);
     const char *class_name = rb_class2name(clas);
-    int         i;
+    size_t      i;
     int         d2       = depth + 1;
     int         d3       = d2 + 1;
     size_t      len      = strlen(class_name);
@@ -578,7 +579,7 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
     if ('#' == *class_name) {
         VALUE       ma = rb_struct_s_members(clas);
         const char *name;
-        int         cnt = (int)RARRAY_LEN(ma);
+        size_t      cnt = RARRAY_LEN(ma);
 
         *out->cur++ = '[';
         for (i = 0; i < cnt; i++) {
@@ -618,8 +619,8 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
         if (0 == strcmp(class_name, "Range")) {
             out->opts->circular = 'n';
         }
-        for (i = 0; i < cnt; i++) {
-            v = RSTRUCT_GET(obj, i);
+        for (i = 0; i < (size_t)cnt; i++) {
+            v = RSTRUCT_GET(obj, (int)i);
             if (dump_ignore(out->opts, v)) {
                 v = Qnil;
             }

--- a/ext/oj/dump_strict.c
+++ b/ext/oj/dump_strict.c
@@ -109,7 +109,8 @@ static void dump_float(VALUE obj, int depth, Out out, bool as_ok) {
 
 static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
     size_t size;
-    int    i, cnt;
+    size_t i;
+    size_t cnt;
     int    d2 = depth + 1;
 
     if (Yes == out->opts->circular) {
@@ -118,7 +119,7 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
             return;
         }
     }
-    cnt         = (int)RARRAY_LEN(a);
+    cnt         = RARRAY_LEN(a);
     *out->cur++ = '[';
     size        = 2;
     assure_size(out, size);

--- a/ext/oj/dump_strict.c
+++ b/ext/oj/dump_strict.c
@@ -30,7 +30,7 @@ static void dump_float(VALUE obj, int depth, Out out, bool as_ok) {
     char   buf[64];
     char*  b;
     double d   = rb_num2dbl(obj);
-    int    cnt = 0;
+    size_t cnt = 0;
 
     if (0.0 == d) {
         b    = buf;
@@ -92,7 +92,7 @@ static void dump_float(VALUE obj, int depth, Out out, bool as_ok) {
         } else if (0 == out->opts->float_prec) {
             volatile VALUE rstr = oj_safe_string_convert(obj);
 
-            cnt = (int)RSTRING_LEN(rstr);
+            cnt = RSTRING_LEN(rstr);
             if ((int)sizeof(buf) <= cnt) {
                 cnt = sizeof(buf) - 1;
             }
@@ -290,7 +290,7 @@ static void dump_data_strict(VALUE obj, int depth, Out out, bool as_ok) {
     if (oj_bigdecimal_class == clas) {
         volatile VALUE rstr = oj_safe_string_convert(obj);
 
-        oj_dump_raw(RSTRING_PTR(rstr), (int)RSTRING_LEN(rstr), out);
+        oj_dump_raw(RSTRING_PTR(rstr), RSTRING_LEN(rstr), out);
     } else {
         raise_strict(obj);
     }
@@ -302,7 +302,7 @@ static void dump_data_null(VALUE obj, int depth, Out out, bool as_ok) {
     if (oj_bigdecimal_class == clas) {
         volatile VALUE rstr = oj_safe_string_convert(obj);
 
-        oj_dump_raw(RSTRING_PTR(rstr), (int)RSTRING_LEN(rstr), out);
+        oj_dump_raw(RSTRING_PTR(rstr), RSTRING_LEN(rstr), out);
     } else {
         oj_dump_nil(Qnil, depth, out, false);
     }

--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -1086,7 +1086,7 @@ static VALUE doc_open(VALUE clas, VALUE str) {
     int            given = rb_block_given_p();
 
     Check_Type(str, T_STRING);
-    len  = (int)RSTRING_LEN(str) + 1;
+    len  = RSTRING_LEN(str) + 1;
     json = OJ_R_ALLOC_N(char, len);
 
     memcpy(json, StringValuePtr(str), len);

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -924,12 +924,12 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
         OJ_R_FREE(copts->ignore);
         copts->ignore = NULL;
         if (Qnil != v) {
-            int cnt;
+            size_t cnt;
 
             rb_check_type(v, T_ARRAY);
-            cnt = (int)RARRAY_LEN(v);
+            cnt = RARRAY_LEN(v);
             if (0 < cnt) {
-                int i;
+                size_t i;
 
                 copts->ignore = OJ_R_ALLOC_N(VALUE, cnt + 1);
                 for (i = 0; i < cnt; i++) {

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -974,7 +974,7 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
         }
     } else if (float_format_sym == k) {
         rb_check_type(v, T_STRING);
-        if (6 < (int)RSTRING_LEN(v)) {
+        if (6 < RSTRING_LEN(v)) {
             rb_raise(rb_eArgError, ":float_format must be 6 bytes or less.");
         }
         strncpy(copts->float_fmt, RSTRING_PTR(v), (size_t)RSTRING_LEN(v));

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -1189,7 +1189,7 @@ static VALUE load_file(int argc, VALUE *argv, VALUE self) {
         OJ_FREE(wide_path);
     }
 #else
-    fd             = open(path, O_RDONLY);
+    fd = open(path, O_RDONLY);
 #endif
     if (0 == fd) {
         rb_raise(rb_eIOError, "%s", strerror(errno));

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -140,7 +140,7 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
     volatile VALUE v;
     int            cnt;
     int            i;
-    int            len;
+    size_t         len;
     const char    *name;
 
 #ifdef RSTRUCT_LEN
@@ -161,7 +161,7 @@ static void dump_struct(VALUE obj, int depth, Out out, bool as_ok) {
         volatile VALUE s = rb_sym2str(RARRAY_AREF(ma, i));
 
         name = RSTRING_PTR(s);
-        len  = (int)RSTRING_LEN(s);
+        len  = RSTRING_LEN(s);
         assure_size(out, size + sep_len + 6);
         if (0 < i) {
             *out->cur++ = ',';
@@ -205,11 +205,11 @@ static void dump_bigdecimal(VALUE obj, int depth, Out out, bool as_ok) {
     if ('I' == *str || 'N' == *str || ('-' == *str && 'I' == str[1])) {
         oj_dump_nil(Qnil, depth, out, false);
     } else if (out->opts->int_range_max != 0 || out->opts->int_range_min != 0) {
-        oj_dump_cstr(str, (int)RSTRING_LEN(rstr), 0, 0, out);
+        oj_dump_cstr(str, RSTRING_LEN(rstr), 0, 0, out);
     } else if (Yes == out->opts->bigdec_as_num) {
-        oj_dump_raw(str, (int)RSTRING_LEN(rstr), out);
+        oj_dump_raw(str, RSTRING_LEN(rstr), out);
     } else {
-        oj_dump_cstr(str, (int)RSTRING_LEN(rstr), 0, 0, out);
+        oj_dump_cstr(str, RSTRING_LEN(rstr), 0, 0, out);
     }
 }
 
@@ -330,14 +330,14 @@ static void dump_timewithzone(VALUE obj, int depth, Out out, bool as_ok) {
 static void dump_to_s(VALUE obj, int depth, Out out, bool as_ok) {
     volatile VALUE rstr = oj_safe_string_convert(obj);
 
-    oj_dump_cstr(RSTRING_PTR(rstr), (int)RSTRING_LEN(rstr), 0, 0, out);
+    oj_dump_cstr(RSTRING_PTR(rstr), RSTRING_LEN(rstr), 0, 0, out);
 }
 
 static ID parameters_id = 0;
 
 typedef struct _strLen {
     const char *str;
-    int         len;
+    size_t      len;
 } *StrLen;
 
 static void dump_actioncontroller_parameters(VALUE obj, int depth, Out out, bool as_ok) {
@@ -363,7 +363,7 @@ static StrLen columns_array(VALUE rcols, int *ccnt) {
             v = oj_safe_string_convert(v);
         }
         cp->str = StringValuePtr(v);
-        cp->len = (int)RSTRING_LEN(v);
+        cp->len = RSTRING_LEN(v);
     }
     return cols;
 }
@@ -1173,7 +1173,7 @@ static void dump_float(VALUE obj, int depth, Out out, bool as_ok) {
     char   buf[64];
     char  *b;
     double d   = rb_num2dbl(obj);
-    int    cnt = 0;
+    size_t cnt = 0;
 
     if (0.0 == d) {
         b    = buf;
@@ -1194,7 +1194,7 @@ static void dump_float(VALUE obj, int depth, Out out, bool as_ok) {
             volatile VALUE rstr = oj_safe_string_convert(obj);
 
             strcpy(buf, RSTRING_PTR(rstr));
-            cnt = (int)RSTRING_LEN(rstr);
+            cnt = RSTRING_LEN(rstr);
         }
     }
     assure_size(out, cnt);

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -352,10 +352,10 @@ static StrLen columns_array(VALUE rcols, int *ccnt) {
     volatile VALUE v;
     StrLen         cp;
     StrLen         cols;
-    int            i;
-    int            cnt = (int)RARRAY_LEN(rcols);
+    size_t         i;
+    size_t         cnt = RARRAY_LEN(rcols);
 
-    *ccnt = cnt;
+    *ccnt = (int)cnt;
     cols  = OJ_R_ALLOC_N(struct _strLen, cnt);
     for (i = 0, cp = cols; i < cnt; i++, cp++) {
         v = RARRAY_AREF(rcols, i);
@@ -424,7 +424,8 @@ static void dump_activerecord_result(VALUE obj, int depth, Out out, bool as_ok) 
     volatile VALUE rows;
     StrLen         cols;
     int            ccnt = 0;
-    int            i, rcnt;
+    size_t         i;
+    size_t         rcnt;
     size_t         size;
     int            d2 = depth + 1;
 
@@ -435,7 +436,7 @@ static void dump_activerecord_result(VALUE obj, int depth, Out out, bool as_ok) 
     out->argc = 0;
     cols      = columns_array(rb_ivar_get(obj, columns_id), &ccnt);
     rows      = rb_ivar_get(obj, rows_id);
-    rcnt      = (int)RARRAY_LEN(rows);
+    rcnt      = RARRAY_LEN(rows);
     assure_size(out, 2);
     *out->cur++ = '[';
     if (out->opts->dump_opts.use) {
@@ -1206,7 +1207,8 @@ static void dump_float(VALUE obj, int depth, Out out, bool as_ok) {
 
 static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
     size_t size;
-    int    i, cnt;
+    size_t i;
+    size_t cnt;
     int    d2 = depth + 1;
 
     if (Yes == out->opts->circular) {
@@ -1220,7 +1222,7 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
         dump_as_json(a, depth, out, false);
         return;
     }
-    cnt         = (int)RARRAY_LEN(a);
+    cnt         = RARRAY_LEN(a);
     *out->cur++ = '[';
     size        = 2;
     assure_size(out, size);

--- a/ext/oj/wab.c
+++ b/ext/oj/wab.c
@@ -111,10 +111,11 @@ static void dump_float(VALUE obj, int depth, Out out, bool as_ok) {
 
 static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
     size_t size;
-    int    i, cnt;
+    size_t i;
+    size_t cnt;
     int    d2 = depth + 1;
 
-    cnt         = (int)RARRAY_LEN(a);
+    cnt         = RARRAY_LEN(a);
     *out->cur++ = '[';
     size        = 2;
     assure_size(out, size);

--- a/ext/oj/wab.c
+++ b/ext/oj/wab.c
@@ -226,7 +226,7 @@ static void dump_obj(VALUE obj, int depth, Out out, bool as_ok) {
     } else if (oj_bigdecimal_class == clas) {
         volatile VALUE rstr = oj_safe_string_convert(obj);
 
-        oj_dump_raw(RSTRING_PTR(rstr), (int)RSTRING_LEN(rstr), out);
+        oj_dump_raw(RSTRING_PTR(rstr), RSTRING_LEN(rstr), out);
     } else if (resolve_wab_uuid_class() == clas) {
         oj_dump_str(oj_safe_string_convert(obj), depth, out, false);
     } else if (resolve_uri_http_class() == clas) {


### PR DESCRIPTION
`size_t size = (int)RSTRING_LEN(string)` leads to out of bounds reads.

See https://github.com/samuel-williams-shopify/oj-overflow for more details.