### PR TITLE
Restore TruffleRuby in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -52,9 +52,9 @@ jobs:
           - os: windows
             gemfile: rails_7.2
         include:
-          # - ruby: 'truffleruby'
-          #   gemfile: no_rails
-          #   os: ubuntu
+          - ruby: 'truffleruby'
+            gemfile: no_rails
+            os: ubuntu
           - ruby: 'ucrt'
             gemfile: no_rails
             os: windows

--- a/test/test_custom.rb
+++ b/test/test_custom.rb
@@ -209,8 +209,6 @@ class CustomJuice < Minitest::Test
   end
 
   def test_deep_nest
-    skip 'TruffleRuby causes SEGV' if RUBY_ENGINE == 'truffleruby'
-
     begin
       n = 10_000
       Oj.strict_load(('[' * n) + (']' * n))
@@ -492,8 +490,6 @@ class CustomJuice < Minitest::Test
   end
 
   def test_time
-    skip 'TruffleRuby fails this spec' if RUBY_ENGINE == 'truffleruby'
-
     obj = Time.now()
     # These two forms should be able to recreate the time precisely,
     # so we check they can load a dumped version and recreate the

--- a/test/test_strict.rb
+++ b/test/test_strict.rb
@@ -162,8 +162,6 @@ class StrictJuice < Minitest::Test
   end
 
   def test_deep_nest
-    skip 'TruffleRuby causes SEGV' if RUBY_ENGINE == 'truffleruby'
-
     begin
       n = 10_000
       Oj.strict_load(('[' * n) + (']' * n))

--- a/test/test_wab.rb
+++ b/test/test_wab.rb
@@ -107,8 +107,6 @@ class WabJuice < Minitest::Test
   end
 
   def test_deep_nest
-    skip 'TruffleRuby causes SEGV' if RUBY_ENGINE == 'truffleruby'
-
     begin
       n = 10_000
       Oj.wab_load(('[' * n) + (']' * n))


### PR DESCRIPTION
Wondering if it's OK to run tests on TruffleRuby now (it was disabled in 1025d247c57602742bbf268b45c9bb2fcddbda3e).

Now all tests pass on TruffleRuby (except tests that rely on `#fork`). See https://github.com/andrykonchin/oj/pull/1.