### PR TITLE
Add an ARM Neon string scanning implementation.

### DIFF
--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -199,6 +199,31 @@ static inline const char *scan_string_noSIMD(const char *str, const char *end) {
     return str;
 }
 
+#ifdef HAVE_SIMD_NEON
+
+static inline const char *string_scan_neon(const char *str, const char *end) {
+    const uint8x16_t null_char = vdupq_n_u8(0);
+    const uint8x16_t backslash = vdupq_n_u8('\\');
+    const uint8x16_t quote     = vdupq_n_u8('"');
+
+    while (str + sizeof(uint8x16_t) <= end) {
+        uint8x16_t      chunk = vld1q_u8((const uint8_t *)str);
+        uint8x16_t      tmp   = vorrq_u8(vorrq_u8(vceqq_u8(chunk, null_char), vceqq_u8(chunk, backslash)),
+                                  vceqq_u8(chunk, quote));
+        const uint8x8_t res   = vshrn_n_u16(vreinterpretq_u16_u8(tmp), 4);
+        uint64_t        mask  = vget_lane_u64(vreinterpret_u64_u8(res), 0);
+        if (mask != 0) {
+            mask &= 0x8888888888888888ull;
+            return str + (OJ_CTZ64(mask) >> 2);
+        }
+        str += sizeof(uint8x16_t);
+    }
+
+    return scan_string_noSIMD(str, end);
+}
+
+#endif
+
 #ifdef HAVE_SIMD_SSE4_2
 // Optimized SIMD string scanner using SSE4.2 instructions
 // Uses prefetching and processes multiple chunks in parallel to reduce latency
@@ -358,9 +383,11 @@ void oj_scanner_init(void) {
 #ifdef HAVE_SIMD_SSE2
     case SIMD_SSE2: scan_func = scan_string_SSE2; break;
 #endif
+#ifdef HAVE_SIMD_NEON
+    case SIMD_NEON: scan_func = string_scan_neon; break;
+#endif
     default: scan_func = scan_string_noSIMD; break;
     }
-    // Note: ARM NEON string scanning would be added here if needed
 }
 
 // entered at /

--- a/ext/oj/simd.h
+++ b/ext/oj/simd.h
@@ -40,6 +40,7 @@ SIMD_Implementation oj_get_simd_implementation(void);
 // Count trailing zeros (for SSE2 mask scanning)
 #if defined(__GNUC__) || defined(__clang__)
 #define OJ_CTZ(x) __builtin_ctz(x)
+#define OJ_CTZ64(x) __builtin_ctzll(x)
 #elif defined(_MSC_VER)
 #include <intrin.h>
 static __inline int oj_ctz_msvc(unsigned int x) {
@@ -47,7 +48,15 @@ static __inline int oj_ctz_msvc(unsigned int x) {
     _BitScanForward(&index, x);
     return (int)index;
 }
+static __inline int oj_ctz64_msvc(uint64_t x) {
+    unsigned long index;
+    if (_BitScanForward64(&index, x)) {
+        return (int)index;
+    }
+    return 64;
+}
 #define OJ_CTZ(x) oj_ctz_msvc(x)
+#define OJ_CTZ64(x) oj_ctz64_msvc(x)
 #else
 // Fallback: naive implementation
 static inline int oj_ctz_fallback(unsigned int x) {
@@ -58,7 +67,17 @@ static inline int oj_ctz_fallback(unsigned int x) {
     }
     return count;
 }
+
+static inline int oj_ctz64_fallback(uint64_t x) {
+    int count = 0;
+    while ((x & 1) == 0 && count < 64) {
+        x >>= 1;
+        count++;
+    }
+    return count;
+}
 #define OJ_CTZ(x) oj_ctz_fallback(x)
+#define OJ_CTZ64(x) oj_ctz64_fallback(x)
 #endif
 
 // =============================================================================

--- a/ext/oj/simd.h
+++ b/ext/oj/simd.h
@@ -45,8 +45,12 @@ SIMD_Implementation oj_get_simd_implementation(void);
 #include <intrin.h>
 static __inline int oj_ctz_msvc(unsigned int x) {
     unsigned long index;
-    _BitScanForward(&index, x);
-    return (int)index;
+    if (0 == x) {
+        return 32;
+    } else {
+        _BitScanForward(&index, x);
+        return (int)index;
+    }
 }
 static __inline int oj_ctz64_msvc(uint64_t x) {
     unsigned long index;

--- a/ext/oj/simd.h
+++ b/ext/oj/simd.h
@@ -47,10 +47,9 @@ static __inline int oj_ctz_msvc(unsigned int x) {
     unsigned long index;
     if (0 == x) {
         return 32;
-    } else {
-        _BitScanForward(&index, x);
-        return (int)index;
     }
+    _BitScanForward(&index, x);
+    return (int)index;
 }
 static __inline int oj_ctz64_msvc(uint64_t x) {
     unsigned long index;


### PR DESCRIPTION
This pull request adds an ARM Neon `string_scan` implementation to the parser.

## Benchmarks

Using the benchmarks from the `ruby/json` repository on my M1 Macbook Air:

```
== Parsing activitypub.json (58160 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after   772.000 i/100ms
Calculating -------------------------------------
               after      7.690k (± 0.7%) i/s  (130.04 μs/i) -     38.600k in   5.019888s

Comparison:
              before:     7043.9 i/s
               after:     7689.8 i/s - 1.09x  faster


== Parsing twitter.json (567916 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after    54.000 i/100ms
Calculating -------------------------------------
               after    543.495 (± 1.1%) i/s    (1.84 ms/i) -      2.754k in   5.067752s

Comparison:
              before:      519.4 i/s
               after:      543.5 i/s - 1.05x  faster


== Parsing citm_catalog.json (1727030 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after    27.000 i/100ms
Calculating -------------------------------------
               after    277.792 (± 1.8%) i/s    (3.60 ms/i) -      1.404k in   5.055628s

Comparison:
              before:      272.7 i/s
               after:      277.8 i/s - same-ish: difference falls within error


== Parsing ohai.json (32444 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after   867.000 i/100ms
Calculating -------------------------------------
               after      8.747k (± 1.2%) i/s  (114.32 μs/i) -     44.217k in   5.055570s

Comparison:
              before:     8412.1 i/s
               after:     8747.5 i/s - 1.04x  faster
```