### PR TITLE
Fix new parser stack consistency error

### DIFF
--- a/ext/oj/parser.c
+++ b/ext/oj/parser.c
@@ -1354,6 +1354,17 @@ static VALUE parser_missing(int argc, VALUE *argv, VALUE self) {
     return p->option(p, key, rv);
 }
 
+static void validate_final_depth(ojParser parser) {
+    if (0 == parser->depth) {
+        return;
+    }
+
+    switch (parser->stack[parser->depth]) {
+    case OBJECT_FUN: parse_error(parser, "Object is not closed");
+    case ARRAY_FUN: parse_error(parser, "Array is not closed");
+    }
+}
+
 /* Document-method: parse(json)
  * call-seq: parse(json)
  *
@@ -1370,6 +1381,8 @@ static VALUE parser_parse(VALUE self, VALUE json) {
     parser_reset(p);
     p->start(p);
     parse(p, ptr);
+
+    validate_final_depth(p);
 
     return p->result(p);
 }

--- a/test/test_parser_usual.rb
+++ b/test/test_parser_usual.rb
@@ -13,6 +13,18 @@ class UsualTest < Minitest::Test
     assert_nil(doc)
   end
 
+  def test_not_closed_top_level_object
+    parser = Oj::Parser.new(:usual)
+
+    assert_raises(EncodingError) { parser.parse('{') }
+  end
+
+  def test_not_closed_top_level_array
+    parser = Oj::Parser.new(:usual)
+
+    assert_raises(EncodingError) { parser.parse('[') }
+  end
+
   def test_primitive
     p = Oj::Parser.new(:usual)
     [


### PR DESCRIPTION
The following JSON payloads cause "Stack inconsistency error", because the `result` function tries to return `Qundef` from the stack.

```ruby
parser = Oj::Parser.new(:usual)

parser.parse("{") # => !!!
parser.parse("[") # => !!!
```

With this change, we validate that the depth is always 0 after we finish parsing the JSON payload.