### PR TITLE
Use fast_memcpy16 to quickly copy up to 16 bytes for tail handling in ARM Neon code and small copies when generating JSON.

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -257,7 +257,30 @@ inline static size_t hibit_friendly_size(const uint8_t *str, size_t len) {
         size += tmp;
     }
 
+#ifdef HAVE_FAST_MEMCPY
+    size_t total = 0;
+    if (len - i > 4) {
+        size += (len - i);
+        unsigned char buf[sizeof(uint8x16_t)];
+        memset(buf, ' ', sizeof(buf));
+        fast_memcpy16(buf, str, len - i);
+
+        uint8x16_t chunk  = vld1q_u8((const unsigned char *)buf);
+        uint8x16_t tmp1   = vqtbl4q_u8(hibit_friendly_chars_neon[0], chunk);
+        uint8x16_t tmp2   = vqtbl4q_u8(hibit_friendly_chars_neon[1], veorq_u8(chunk, vdupq_n_u8(0x40)));
+        uint8x16_t result = vorrq_u8(tmp1, tmp2);
+        uint8_t    tmp    = vaddvq_u8(result);
+
+        size += tmp;
+
+        total = size;
+    } else {
+        total = size + calculate_string_size(str, len - i, hibit_friendly_chars);
+    }
+#else
     size_t total = size + calculate_string_size(str, len - i, hibit_friendly_chars);
+#endif
+
     return total;
 #elif defined(HAVE_SIMD_SSE4_2)
     if (SIMD_Impl == SIMD_SSE42) {
@@ -967,11 +990,12 @@ typedef struct _neon_match_result {
     uint8x16_t needs_escape;
     bool       has_some_hibit;
     bool       do_unicode_validation;
+    uint64_t   escape_mask;
 } neon_match_result;
 
 static inline FORCE_INLINE neon_match_result
 neon_update(const char *str, uint8x16x4_t *cmap_neon, int neon_table_size, bool do_unicode_validation, bool has_hi) {
-    neon_match_result result = {.has_some_hibit = false, .do_unicode_validation = false};
+    neon_match_result result = {.has_some_hibit = false, .do_unicode_validation = false, .escape_mask = 0};
 
     uint8x16_t chunk    = vld1q_u8((const unsigned char *)str);
     uint8x16_t tmp1     = vqtbl4q_u8(cmap_neon[0], chunk);
@@ -987,6 +1011,9 @@ neon_update(const char *str, uint8x16x4_t *cmap_neon, int neon_table_size, bool 
         result.has_some_hibit        = vmaxvq_u8(has_some_hibit) != 0;
         result.do_unicode_validation = has_hi && do_unicode_validation && result.has_some_hibit;
     }
+    const uint8x8_t res  = vshrn_n_u16(vreinterpretq_u16_u8(vmvnq_u8(vceqq_u8(result.needs_escape, vdupq_n_u8(0)))), 4);
+    const uint64_t  mask = vget_lane_u64(vreinterpret_u64_u8(res), 0);
+    result.escape_mask   = mask & 0x8888888888888888ull;
     return result;
 }
 
@@ -1189,7 +1216,16 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
         if (is_sym) {
             *out->cur++ = ':';
         }
+#ifdef HAVE_FAST_MEMCPY
+        if (cnt <= 16) {
+            fast_memcpy16(out->cur, str, cnt);
+            out->cur += size;
+        } else {
+            APPEND_CHARS(out->cur, str, cnt);
+        }
+#else
         APPEND_CHARS(out->cur, str, cnt);
+#endif
         *out->cur++ = '"';
     } else {
         const char *end         = str + cnt;
@@ -1223,6 +1259,17 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
 #endif
 
 #ifdef HAVE_SIMD_NEON
+
+#ifdef HAVE_FAST_MEMCPY
+#define APPEND_CHARS_SMALL(dst, src, length) \
+    fast_memcpy16((dst), (src), (length));   \
+    (dst) += (length);
+#define MEMCPY16 fast_memcpy16
+#else
+#define APPEND_CHARS_SMALL(dst, src, length) APPEND_CHARS(dst, str, length);
+#define MEMCPY16 memcpy
+#endif
+
         if (use_simd) {
             while (str < end) {
                 const char *chunk_ptr = NULL;
@@ -1231,8 +1278,8 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
                     chunk_start = str;
                     chunk_end   = str + sizeof(uint8x16_t);
                 } else if ((end - str) >= SIMD_MINIMUM_THRESHOLD) {
-                    memset(out->cur, 'A', sizeof(uint8x16_t));
-                    memcpy(out->cur, str, (end - str));
+                    memset(out->cur, ' ', sizeof(uint8x16_t));
+                    MEMCPY16(out->cur, str, (end - str));
                     chunk_ptr   = out->cur;
                     chunk_start = str;
                     chunk_end   = end;
@@ -1244,27 +1291,34 @@ void oj_dump_cstr(const char *str, size_t cnt, bool is_sym, bool escape1, Out ou
                                                        neon_table_size,
                                                        do_unicode_validation,
                                                        has_hi);
-                if ((result.do_unicode_validation) || vmaxvq_u8(result.needs_escape) != 0) {
+                if ((result.do_unicode_validation) || result.escape_mask != 0) {
                     SEARCH_FLUSH;
-                    uint8x16_t actions     = vaddq_u8(result.needs_escape, vdupq_n_u8('1'));
-                    uint8_t    num_matches = vaddvq_u8(vandq_u8(result.needs_escape, vdupq_n_u8(0x1)));
+                    bool       process_each = result.do_unicode_validation;
+                    uint8x16_t actions      = vaddq_u8(result.needs_escape, vdupq_n_u8('1'));
                     vst1q_u8((unsigned char *)matches, actions);
-                    bool process_each = result.do_unicode_validation || (num_matches > sizeof(uint8x16_t) / 2);
                     // If no byte in this chunk had the high bit set then we can skip
                     // all of the '1' bytes by directly copying them to the output.
                     if (!process_each) {
-                        while (str < chunk_end) {
-                            long i = str - chunk_start;
-                            char action;
-                            while (str < chunk_end && (action = matches[i++]) == '1') {
-                                *out->cur++ = *str++;
+                        while (result.escape_mask) {
+                            int  esc_pos = OJ_CTZ64(result.escape_mask) >> 2;
+                            long run_len = esc_pos - (str - chunk_start);
+                            if (run_len > 0) {
+                                APPEND_CHARS_SMALL(out->cur, str, run_len);
+                                str += run_len;
                             }
-                            cursor = str;
-                            if (str >= chunk_end) {
-                                break;
-                            }
-                            str = process_character(action, str, end, out, orig, do_unicode_validation, &check_start);
+                            str = process_character(matches[esc_pos],
+                                                    str,
+                                                    end,
+                                                    out,
+                                                    orig,
+                                                    do_unicode_validation,
+                                                    &check_start);
                             str++;
+                            result.escape_mask &= result.escape_mask - 1;
+                        }
+                        if (str < chunk_end) {
+                            APPEND_CHARS_SMALL(out->cur, str, chunk_end - str);
+                            str = chunk_end;
                         }
                     } else {
                         while (str < chunk_end) {

--- a/ext/oj/simd.h
+++ b/ext/oj/simd.h
@@ -191,4 +191,29 @@ static inline OJ_TARGET_SSE42 __m128i vector_lookup_sse42(__m128i input, __m128i
 
 #endif
 
+#ifndef __has_builtin
+#define __has_builtin(x) 0
+#endif
+
+#if __has_builtin(__builtin_memcpy)
+#define HAVE_FAST_MEMCPY 1
+
+inline static void fast_memcpy16(void *dest, const void *src, size_t n) {
+    char *d = (char *)dest;
+    char *s = (char *)src;
+    if (n >= 8) {
+        __builtin_memcpy(d, s, 8);
+        __builtin_memcpy(d + n - 8, s + n - 8, 8);
+    } else if (n >= 4) {
+        __builtin_memcpy(d, s, 4);
+        __builtin_memcpy(d + n - 4, s + n - 4, 4);
+    } else if (n >= 2) {
+        __builtin_memcpy(d, s, 2);
+        __builtin_memcpy(d + n - 2, s + n - 2, 2);
+    } else if (n >= 1) {
+        *d = *s;
+    }
+}
+#endif
+
 #endif /* OJ_SIMD_H */


### PR DESCRIPTION
## Overview

This PR defines a `fast_memcpy16` function if `__builtin_memcpy` is available. This function compiles down to some branches, two loads and two store instructions which may overlap depending on the number of bytes to copy. The overlap will copy bytes in the same position so the bytes end up in the correct location. This function will get inlined into the caller and avoid function call overhead to `memcpy`. 

A similar [pull request](https://github.com/ruby/json/pull/924) was accepted to `ruby/json` with a very similar optimization and implementation.

I can update the SSE4 implementation to use the same optimization to this PR or as a follow up depending on your preference, assuming this PR is accepted.

## Benchmarks

These were run on an M1 Macbook Air. Before is the `develop` branch as of commit `c7fd9159ef285ba940a2075f51c382defe16a914`.

```
== Encoding activitypub.json (52595 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after     2.525k i/100ms
Calculating -------------------------------------
               after     25.255k (± 2.2%) i/s   (39.60 μs/i) -    126.250k in   5.001562s

Comparison:
              before:    22862.2 i/s
               after:    25254.9 i/s - 1.10x  faster


== Encoding citm_catalog.json (500298 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after   114.000 i/100ms
Calculating -------------------------------------
               after      1.142k (± 1.4%) i/s  (875.98 μs/i) -      5.814k in   5.093910s

Comparison:
              before:     1042.6 i/s
               after:     1141.6 i/s - 1.09x  faster


== Encoding twitter.json (466906 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after   246.000 i/100ms
Calculating -------------------------------------
               after      2.487k (± 1.6%) i/s  (402.10 μs/i) -     12.546k in   5.046023s

Comparison:
              before:     2217.1 i/s
               after:     2487.0 i/s - 1.12x  faster


== Encoding ohai.json (20145 bytes)
ruby 3.4.8 (2025-12-17 revision 995b59f666) +YJIT +PRISM [arm64-darwin24]
Warming up --------------------------------------
               after     3.367k i/100ms
Calculating -------------------------------------
               after     33.844k (± 0.9%) i/s   (29.55 μs/i) -    171.717k in   5.074160s

Comparison:
              before:    30022.0 i/s
               after:    33844.5 i/s - 1.13x  faster
```