### PR TITLE
Handle unterminated strings in usual parser

### DIFF
--- a/ext/oj/parser.c
+++ b/ext/oj/parser.c
@@ -635,6 +635,9 @@ static void parse(ojParser p, const byte *json) {
             if ('"' == *b) {
                 p->map = colon_map;
                 break;
+            } else if ('\0' == *b) {
+                parse_error(p, "quoted string not terminated");
+                break;
             }
             b--;
             p->map      = string_map;
@@ -658,6 +661,9 @@ static void parse(ojParser p, const byte *json) {
                 p->cur = b - json;
                 p->funcs[p->stack[p->depth]].add_str(p);
                 p->map = (0 == p->depth) ? value_map : after_map;
+                break;
+            } else if ('\0' == *b) {
+                parse_error(p, "quoted string not terminated");
                 break;
             }
             b--;

--- a/test/test_parser_usual.rb
+++ b/test/test_parser_usual.rb
@@ -13,6 +13,20 @@ class UsualTest < Minitest::Test
     assert_nil(doc)
   end
 
+  def test_unclosed_string
+    parser = Oj::Parser.new(:usual)
+
+    error = assert_raises(EncodingError) { parser.parse('"foo') }
+    assert_match(/quoted string not terminated/i, error.message)
+  end
+
+  def test_unclosed_object_key
+    parser = Oj::Parser.new(:usual)
+
+    error = assert_raises(EncodingError) { parser.parse('{"foo') }
+    assert_match(/quoted string not terminated/i, error.message)
+  end
+
   def test_not_closed_top_level_object
     parser = Oj::Parser.new(:usual)
 


### PR DESCRIPTION
Ensure the usual parser handles unterminated strings properly, and raises the legacy EncodingError to match the behavior aligned with the previous parser implementation.

## Before this change

```ruby
Oj::Parser.usual.parse('"foo') # => nil
```

## After this change

```ruby
Oj::Parser.usual.parse('"foo') # => quoted string not terminated at 1:-1 (EncodingError)
```