### PR TITLE
Fix read() not handling partial reads for large files

### DIFF
--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -1193,11 +1193,19 @@ oj_pi_parse(int argc, VALUE *argv, ParseInfo pi, char *json, size_t len, int yie
             buf      = OJ_R_ALLOC_N(char, len + 1);
             pi->json = buf;
             pi->end  = buf + len;
-            if (0 >= (cnt = read(fd, (char *)pi->json, len)) || cnt != (ssize_t)len) {
-                if (0 != buf) {
-                    OJ_R_FREE(buf);
+            {
+                size_t total = 0;
+
+                while (total < len) {
+                    cnt = read(fd, (char *)pi->json + total, len - total);
+                    if (cnt <= 0) {
+                        if (0 != buf) {
+                            OJ_R_FREE(buf);
+                        }
+                        rb_raise(rb_eIOError, "failed to read from IO Object.");
+                    }
+                    total += cnt;
                 }
-                rb_raise(rb_eIOError, "failed to read from IO Object.");
             }
             ((char *)pi->json)[len] = '\0';
             /* skip UTF-8 BOM if present */

--- a/ext/oj/saj.c
+++ b/ext/oj/saj.c
@@ -648,8 +648,16 @@ oj_saj_parse(int argc, VALUE *argv, VALUE self) {
             len = lseek(fd, 0, SEEK_END);
             lseek(fd, 0, SEEK_SET);
             json = OJ_R_ALLOC_N(char, len + 1);
-            if (0 >= (cnt = read(fd, json, len)) || cnt != (ssize_t)len) {
-                rb_raise(rb_eIOError, "failed to read from IO Object.");
+            {
+                size_t total = 0;
+
+                while (total < len) {
+                    cnt = read(fd, json + total, len - total);
+                    if (cnt <= 0) {
+                        rb_raise(rb_eIOError, "failed to read from IO Object.");
+                    }
+                    total += cnt;
+                }
             }
             json[len] = '\0';
 #endif

--- a/test/test_saj.rb
+++ b/test/test_saj.rb
@@ -175,6 +175,37 @@ class SajTest < Minitest::Test
                   [:hash_end, nil]], handler.calls)
   end
 
+  def test_file
+    handler = AllSaj.new()
+    filename = File.join(__dir__, 'saj_file_test.json')
+    File.write(filename, $json)
+
+    File.open(filename) do |f|
+      Oj.saj_parse(handler, f)
+    end
+
+    assert_equal([[:hash_start, nil],
+                  [:array_start, 'array'],
+                  [:hash_start, nil],
+                  [:add_value, 3, 'num'],
+                  [:add_value, 'message', 'string'],
+                  [:hash_start, 'hash'],
+                  [:hash_start, 'h2'],
+                  [:array_start, 'a'],
+                  [:add_value, 1, nil],
+                  [:add_value, 2, nil],
+                  [:add_value, 3, nil],
+                  [:array_end, 'a'],
+                  [:hash_end, 'h2'],
+                  [:hash_end, 'hash'],
+                  [:hash_end, nil],
+                  [:array_end, 'array'],
+                  [:add_value, true, 'boolean'],
+                  [:hash_end, nil]], handler.calls)
+  ensure
+    File.delete(filename) if filename && File.exist?(filename)
+  end
+
   def test_fixnum_bad
     handler = AllSaj.new()
     json = %{12345xyz}


### PR DESCRIPTION
## Summary

- `read()` system call may return fewer bytes than requested (POSIX allows short reads), especially for large files. Both `saj.c` and `parse.c` treated a short read as a failure, raising `IOError: failed to read from IO Object`. This change loops `read()` until all bytes are consumed.
- The same bug existed in two places: `oj_saj_parse` (saj.c) and `oj_pi_parse` (parse.c).

## Test plan

- Added `test_file` to `test/test_saj.rb` which passes a `File` object to `Oj.saj_parse`. This code path previously had no test coverage at all. The test verifies that parsing a File produces the same callbacks as parsing a String.
- Note: the test does not directly exercise the short-read fix, as triggering a partial `read()` on a regular file requires a file larger than ~2GB. The test serves as regression coverage for the File input path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)