### PR TITLE
Raise error for incomplete primitive literals

### DIFF
--- a/ext/oj/parser.c
+++ b/ext/oj/parser.c
@@ -1360,6 +1360,35 @@ static VALUE parser_missing(int argc, VALUE *argv, VALUE self) {
     return p->option(p, key, rv);
 }
 
+static void validate_primitives_are_complete(ojParser p) {
+    if (0 >= p->ri) {
+        return;
+    }
+
+    switch (p->map[256]) {
+    case 'N': parse_error(p, "expected null"); break;
+    case 'F': parse_error(p, "expected false"); break;
+    case 'T': parse_error(p, "expected true"); break;
+    }
+}
+
+static void validate_non_primitives_are_complete(ojParser p) {
+    if (0 >= p->depth) {
+        return;
+    }
+
+    if (OBJECT_FUN == p->stack[p->depth]) {
+        parse_error(p, "Object is not closed");
+    } else {
+        parse_error(p, "Array is not closed");
+    }
+}
+
+static void validate_document_end(ojParser p) {
+    validate_primitives_are_complete(p);
+    validate_non_primitives_are_complete(p);
+}
+
 /* Document-method: parse(json)
  * call-seq: parse(json)
  *
@@ -1377,13 +1406,8 @@ static VALUE parser_parse(VALUE self, VALUE json) {
     p->start(p);
     parse(p, ptr);
 
-    if (0 < p->depth) {
-        if (OBJECT_FUN == p->stack[p->depth]) {
-            parse_error(p, "Object is not closed");
-        } else {
-            parse_error(p, "Array is not closed");
-        }
-    }
+    validate_document_end(p);
+
     return p->result(p);
 }
 

--- a/test/test_parser_usual.rb
+++ b/test/test_parser_usual.rb
@@ -8,9 +8,31 @@ require 'helper'
 class UsualTest < Minitest::Test
 
   def test_nil
-    p = Oj::Parser.new(:usual)
-    doc = p.parse('nil')
-    assert_nil(doc)
+    parser = Oj::Parser.new(:usual)
+
+    error = assert_raises(EncodingError) { parser.parse('nil') }
+    assert_match(/expected null/i, error.message)
+  end
+
+  def test_incomplete_null
+    parser = Oj::Parser.new(:usual)
+
+    error = assert_raises(EncodingError) { parser.parse('nul') }
+    assert_match(/expected null/i, error.message)
+  end
+
+  def test_incomplete_false
+    parser = Oj::Parser.new(:usual)
+
+    error = assert_raises(EncodingError) { parser.parse('fal') }
+    assert_match(/expected false/i, error.message)
+  end
+
+  def test_incomplete_true
+    parser = Oj::Parser.new(:usual)
+
+    error = assert_raises(EncodingError) { parser.parse('tru') }
+    assert_match(/expected true/i, error.message)
   end
 
   def test_unclosed_string


### PR DESCRIPTION
Validate partially consumed literal tokens (`nul`, `fal`, `tru`) after parsing finishes, so the usual parser raises explicit errors instead of accepting invalid JSON.

This aligns primitive end-of-document checks with existing unclosed array/object validation and prevents silent success on malformed input.