### PR TITLE
Implement Oj::Parser.safe with configurable JSON safety limits

### DIFF
--- a/ext/oj/parser.c
+++ b/ext/oj/parser.c
@@ -1182,6 +1182,8 @@ extern void oj_set_parser_validator(ojParser p);
 extern void oj_set_parser_saj(ojParser p);
 extern void oj_set_parser_usual(ojParser p);
 extern void oj_set_parser_debug(ojParser p);
+extern void oj_set_parser_safe(ojParser p, VALUE options);
+extern void oj_safe_init(VALUE parser_class);
 
 static int opt_cb(VALUE rkey, VALUE value, VALUE ptr) {
     ojParser    p   = (ojParser)ptr;
@@ -1607,6 +1609,28 @@ static VALUE parser_validate(VALUE self) {
     return validate_parser;
 }
 
+static VALUE parser_safe(int argc, VALUE *argv, VALUE self) {
+    VALUE options;
+
+    if (1 == argc) {
+        options = argv[0];
+
+        Check_Type(options, T_HASH);
+    } else {
+        options = rb_hash_new();
+    }
+
+    ojParser p = OJ_R_ALLOC(struct _ojParser);
+
+    memset(p, 0, sizeof(struct _ojParser));
+    buf_init(&p->key);
+    buf_init(&p->buf);
+    p->map = value_map;
+    oj_set_parser_safe(p, options);
+
+    return TypedData_Wrap_Struct(parser_class, &oj_parser_type, p);
+}
+
 /* Document-class: Oj::Parser
  *
  * A reusable parser that makes use of named delegates to determine the
@@ -1634,4 +1658,7 @@ void oj_parser_init(void) {
     rb_define_module_function(parser_class, "usual", parser_usual, 0);
     rb_define_module_function(parser_class, "saj", parser_saj, 0);
     rb_define_module_function(parser_class, "validate", parser_validate, 0);
+    rb_define_module_function(parser_class, "safe", parser_safe, -1);
+
+    oj_safe_init(parser_class);
 }

--- a/ext/oj/safe.c
+++ b/ext/oj/safe.c
@@ -4,8 +4,9 @@ static VALUE max_hash_size_sym, max_array_size_sym, max_depth_sym, max_total_ele
     max_array_size_error_class, max_depth_error_class, max_total_elements_error_class;
 
 static void check_object_size(safe_T safe) {
-    if (NIL_P(safe->max_hash_size))
+    if (NIL_P(safe->max_hash_size)) {
         return;
+    }
 
     struct _usual usual                   = safe->usual;
     Col           current_object_location = usual.ctail - 1;
@@ -13,15 +14,17 @@ static void check_object_size(safe_T safe) {
     long int number_of_items_in_stack = usual.vtail - usual.vhead;
     long int number_of_items_in_hash  = (number_of_items_in_stack - current_object_location->vi - 1) / 2;
 
-    if (safe->max_hash_size > number_of_items_in_hash)
+    if (safe->max_hash_size > number_of_items_in_hash) {
         return;
+    }
 
     rb_raise(max_hash_size_error_class, "Too many object items!");
 }
 
 static void check_array_size(safe_T safe) {
-    if (NIL_P(safe->max_array_size))
+    if (NIL_P(safe->max_array_size)) {
         return;
+    }
 
     struct _usual usual                   = safe->usual;
     Col           current_object_location = usual.ctail - 1;
@@ -29,15 +32,17 @@ static void check_array_size(safe_T safe) {
     long int number_of_items_in_stack = usual.vtail - usual.vhead;
     long int number_of_items_in_array = number_of_items_in_stack - current_object_location->vi - 1;
 
-    if (safe->max_array_size > number_of_items_in_array)
+    if (safe->max_array_size > number_of_items_in_array) {
         return;
+    }
 
     rb_raise(max_array_size_error_class, "Too many array items!");
 }
 
 static void check_max_depth(safe_T safe, ojParser p) {
-    if (NIL_P(safe->max_depth) || safe->max_depth >= (p->depth + 1))
+    if (NIL_P(safe->max_depth) || safe->max_depth >= (p->depth + 1)) {
         return;
+    }
 
     rb_raise(max_depth_error_class, "JSON is too deep!");
 }
@@ -49,8 +54,9 @@ static void check_max_total_elements(safe_T safe) {
     * null, true) are not counted. As a result, `current_elements_count`
     * always holds one less than the actual total.
     */
-    if (NIL_P(safe->max_total_elements) || safe->max_total_elements > safe->current_elements_count)
+    if (NIL_P(safe->max_total_elements) || safe->max_total_elements > safe->current_elements_count) {
         return;
+    }
 
     rb_raise(max_total_elements_error_class, "Too many elements!");
 }

--- a/ext/oj/safe.c
+++ b/ext/oj/safe.c
@@ -1,0 +1,223 @@
+#include "safe.h"
+
+static VALUE max_hash_size_sym, max_array_size_sym, max_depth_sym, max_total_elements_sym, max_hash_size_error_class,
+    max_array_size_error_class, max_depth_error_class, max_total_elements_error_class;
+
+static void check_object_size(safe_T safe) {
+    if (NIL_P(safe->max_hash_size))
+        return;
+
+    struct _usual usual                   = safe->usual;
+    Col           current_object_location = usual.ctail - 1;
+
+    long int number_of_items_in_stack = usual.vtail - usual.vhead;
+    long int number_of_items_in_hash  = (number_of_items_in_stack - current_object_location->vi - 1) / 2;
+
+    if (safe->max_hash_size > number_of_items_in_hash)
+        return;
+
+    rb_raise(max_hash_size_error_class, "Too many object items!");
+}
+
+static void check_array_size(safe_T safe) {
+    if (NIL_P(safe->max_array_size))
+        return;
+
+    struct _usual usual                   = safe->usual;
+    Col           current_object_location = usual.ctail - 1;
+
+    long int number_of_items_in_stack = usual.vtail - usual.vhead;
+    long int number_of_items_in_array = number_of_items_in_stack - current_object_location->vi - 1;
+
+    if (safe->max_array_size > number_of_items_in_array)
+        return;
+
+    rb_raise(max_array_size_error_class, "Too many array items!");
+}
+
+static void check_max_depth(safe_T safe, ojParser p) {
+    if (NIL_P(safe->max_depth) || safe->max_depth >= (p->depth + 1))
+        return;
+
+    rb_raise(max_depth_error_class, "JSON is too deep!");
+}
+
+static void check_max_total_elements(safe_T safe) {
+    /*
+    * We check if `max_total_elements` is greater than `current_elements_count`
+    * (instead of greater than or equal) because top-level elements (e.g., [],
+    * null, true) are not counted. As a result, `current_elements_count`
+    * always holds one less than the actual total.
+    */
+    if (NIL_P(safe->max_total_elements) || safe->max_total_elements > safe->current_elements_count)
+        return;
+
+    rb_raise(max_total_elements_error_class, "Too many elements!");
+}
+
+static void safe_start(ojParser p) {
+    safe_T safe = (safe_T)p->ctx;
+
+    safe->current_hash_size      = 0;
+    safe->current_array_size     = 0;
+    safe->current_elements_count = 0;
+
+    safe->delegated_start_func(p);
+}
+
+static void safe_open_object(ojParser p) {
+    safe_T safe = (safe_T)p->ctx;
+
+    safe->current_hash_size++;
+    safe->current_elements_count++;
+
+    check_array_size(safe);
+    check_max_depth(safe, p);
+    check_max_total_elements(safe);
+
+    safe->delegated_open_object_func(p);
+}
+
+static void safe_open_array(ojParser p) {
+    safe_T safe = (safe_T)p->ctx;
+
+    safe->current_array_size++;
+    safe->current_elements_count++;
+
+    check_array_size(safe);
+    check_max_depth(safe, p);
+    check_max_total_elements(safe);
+
+    safe->delegated_open_array_func(p);
+}
+
+DEFINE_DELEGATED_FUNCTION(add_null);
+DEFINE_DELEGATED_FUNCTION(add_true);
+DEFINE_DELEGATED_FUNCTION(add_false);
+DEFINE_DELEGATED_FUNCTION(add_int);
+DEFINE_DELEGATED_FUNCTION(add_float);
+DEFINE_DELEGATED_FUNCTION(add_big);
+DEFINE_DELEGATED_FUNCTION(add_str);
+
+static void safe_open_object_key(ojParser p) {
+    safe_T safe = (safe_T)p->ctx;
+
+    safe->current_hash_size++;
+    safe->current_elements_count += 2;
+
+    check_object_size(safe);
+    check_max_depth(safe, p);
+    check_max_total_elements(safe);
+
+    safe->delegated_open_object_key_func(p);
+}
+
+static void safe_open_array_key(ojParser p) {
+    safe_T safe = (safe_T)p->ctx;
+
+    safe->current_array_size++;
+    safe->current_elements_count += 2;
+
+    check_object_size(safe);
+    check_max_depth(safe, p);
+    check_max_total_elements(safe);
+
+    safe->delegated_open_array_key_func(p);
+}
+
+DEFINE_DELEGATED_OBJECT_FUNCTION(add_null);
+DEFINE_DELEGATED_OBJECT_FUNCTION(add_true);
+DEFINE_DELEGATED_OBJECT_FUNCTION(add_false);
+DEFINE_DELEGATED_OBJECT_FUNCTION(add_int);
+DEFINE_DELEGATED_OBJECT_FUNCTION(add_float);
+DEFINE_DELEGATED_OBJECT_FUNCTION(add_big);
+DEFINE_DELEGATED_OBJECT_FUNCTION(add_str);
+
+void oj_init_safe_parser(ojParser p, safe_T safe, VALUE options) {
+    // Safe parser inherits all members of usual parser
+    oj_init_usual(p, &safe->usual);
+
+    safe->delegated_start_func = p->start;
+    p->start                   = safe_start;
+
+    Funcs f;
+
+    // Array parser functions
+    f                                = &p->funcs[ARRAY_FUN];
+    safe->delegated_open_object_func = f->open_object;
+    f->open_object                   = safe_open_object;
+    safe->delegated_open_array_func  = f->open_array;
+    f->open_array                    = safe_open_array;
+    // The following overrides are done for counting objects
+    safe->delegated_add_null_func  = f->add_null;
+    f->add_null                    = safe_add_null;
+    safe->delegated_add_true_func  = f->add_true;
+    f->add_true                    = safe_add_true;
+    safe->delegated_add_false_func = f->add_false;
+    f->add_false                   = safe_add_false;
+    safe->delegated_add_int_func   = f->add_int;
+    f->add_int                     = safe_add_int;
+    safe->delegated_add_float_func = f->add_float;
+    f->add_float                   = safe_add_float;
+    safe->delegated_add_big_func   = f->add_big;
+    f->add_big                     = safe_add_big;
+    safe->delegated_add_str_func   = f->add_str;
+    f->add_str                     = safe_add_str;
+
+    // Object parser functions
+    f                                    = &p->funcs[OBJECT_FUN];
+    safe->delegated_open_object_key_func = f->open_object;
+    f->open_object                       = safe_open_object_key;
+    safe->delegated_open_array_key_func  = f->open_array;
+    f->open_array                        = safe_open_array_key;
+    // The following overrides are done for counting objects
+    safe->delegated_add_null_key_func  = f->add_null;
+    f->add_null                        = safe_add_null_key;
+    safe->delegated_add_true_key_func  = f->add_true;
+    f->add_true                        = safe_add_true_key;
+    safe->delegated_add_false_key_func = f->add_false;
+    f->add_false                       = safe_add_false_key;
+    safe->delegated_add_int_key_func   = f->add_int;
+    f->add_int                         = safe_add_int_key;
+    safe->delegated_add_float_key_func = f->add_float;
+    f->add_float                       = safe_add_float_key;
+    safe->delegated_add_big_key_func   = f->add_big;
+    f->add_big                         = safe_add_big_key;
+    safe->delegated_add_str_key_func   = f->add_str;
+    f->add_str                         = safe_add_str_key;
+
+    SET_CONFIG(max_hash_size);
+    SET_CONFIG(max_array_size);
+    SET_CONFIG(max_depth);
+    SET_CONFIG(max_total_elements);
+}
+
+void oj_set_parser_safe(ojParser p, VALUE options) {
+    safe_T s = OJ_R_ALLOC(struct _safe_S);
+
+    oj_init_safe_parser(p, s, options);
+}
+
+void oj_safe_init(VALUE parser_class) {
+    VALUE validation_error_class = rb_define_class_under(parser_class, "ValidationError", rb_eRuntimeError);
+
+    max_hash_size_error_class      = rb_define_class_under(parser_class, "HashSizeError", validation_error_class);
+    max_array_size_error_class     = rb_define_class_under(parser_class, "ArraySizeError", validation_error_class);
+    max_depth_error_class          = rb_define_class_under(parser_class, "DepthError", validation_error_class);
+    max_total_elements_error_class = rb_define_class_under(parser_class, "TotalElementsError", validation_error_class);
+
+    rb_gc_register_address(&max_hash_size_error_class);
+    rb_gc_register_address(&max_array_size_error_class);
+    rb_gc_register_address(&max_depth_error_class);
+    rb_gc_register_address(&max_total_elements_error_class);
+
+    max_hash_size_sym      = ID2SYM(rb_intern("max_hash_size"));
+    max_array_size_sym     = ID2SYM(rb_intern("max_array_size"));
+    max_depth_sym          = ID2SYM(rb_intern("max_depth"));
+    max_total_elements_sym = ID2SYM(rb_intern("max_total_elements"));
+
+    rb_gc_register_address(&max_hash_size_sym);
+    rb_gc_register_address(&max_array_size_sym);
+    rb_gc_register_address(&max_depth_sym);
+    rb_gc_register_address(&max_total_elements_sym);
+}

--- a/ext/oj/safe.h
+++ b/ext/oj/safe.h
@@ -1,0 +1,79 @@
+#include <ruby.h>
+
+#include "parser.h"
+#include "usual.h"
+
+#define SET_CONFIG(config_name)                                                        \
+    do {                                                                               \
+        VALUE rb_##config_name = rb_hash_aref(options, config_name##_sym);             \
+                                                                                       \
+        if (RB_INTEGER_TYPE_P(rb_##config_name)) {                                     \
+            safe->config_name = NUM2LONG(rb_##config_name);                            \
+        } else if (!NIL_P(rb_##config_name)) {                                         \
+            rb_raise(rb_eArgError, "Incorrect value provided for `" #config_name "`"); \
+        } else {                                                                       \
+            safe->config_name = Qnil;                                                  \
+        }                                                                              \
+    } while (0);
+
+#define DEFINE_DELEGATED_FUNCTION(function_name)   \
+    static void safe_##function_name(ojParser p) { \
+        safe_T safe = (safe_T)p->ctx;              \
+                                                   \
+        safe->current_elements_count++;            \
+                                                   \
+        check_array_size(safe);                    \
+        check_max_total_elements(safe);            \
+                                                   \
+        safe->delegated_##function_name##_func(p); \
+    }
+
+#define DEFINE_DELEGATED_OBJECT_FUNCTION(function_name)  \
+    static void safe_##function_name##_key(ojParser p) { \
+        safe_T safe = (safe_T)p->ctx;                    \
+                                                         \
+        safe->current_elements_count += 2;               \
+                                                         \
+        check_object_size(safe);                         \
+        check_max_total_elements(safe);                  \
+                                                         \
+        safe->delegated_##function_name##_key_func(p);   \
+    }
+
+typedef struct _safe_S {
+    struct _usual usual;
+
+    long int max_hash_size;
+    long int max_array_size;
+    long int max_depth;
+    long int max_total_elements;
+    long int max_json_size_bytes;
+
+    long int current_hash_size;
+    long int current_array_size;
+    long int current_elements_count;
+
+    void (*delegated_start_func)(struct _ojParser *p);
+
+    // Array functions
+    void (*delegated_open_object_func)(struct _ojParser *p);
+    void (*delegated_open_array_func)(struct _ojParser *p);
+    void (*delegated_add_null_func)(struct _ojParser *p);
+    void (*delegated_add_true_func)(struct _ojParser *p);
+    void (*delegated_add_false_func)(struct _ojParser *p);
+    void (*delegated_add_int_func)(struct _ojParser *p);
+    void (*delegated_add_float_func)(struct _ojParser *p);
+    void (*delegated_add_big_func)(struct _ojParser *p);
+    void (*delegated_add_str_func)(struct _ojParser *p);
+
+    // Object functions
+    void (*delegated_open_object_key_func)(struct _ojParser *p);
+    void (*delegated_open_array_key_func)(struct _ojParser *p);
+    void (*delegated_add_null_key_func)(struct _ojParser *p);
+    void (*delegated_add_true_key_func)(struct _ojParser *p);
+    void (*delegated_add_false_key_func)(struct _ojParser *p);
+    void (*delegated_add_int_key_func)(struct _ojParser *p);
+    void (*delegated_add_float_key_func)(struct _ojParser *p);
+    void (*delegated_add_big_key_func)(struct _ojParser *p);
+    void (*delegated_add_str_key_func)(struct _ojParser *p);
+} *safe_T;

--- a/test/test_parser_safe.rb
+++ b/test/test_parser_safe.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+$LOAD_PATH << __dir__
+
+require 'helper'
+
+class ParserSafeTest < Minitest::Test
+  def test_invalid_max_array_size_option
+    error = assert_raises(ArgumentError) { Oj::Parser.safe(max_array_size: :foo) }
+
+    assert_equal('Incorrect value provided for `max_array_size`', error.message)
+  end
+
+  def test_json_array_with_fewer_items
+    parser = Oj::Parser.safe(max_array_size: 2)
+    result = parser.parse('[1, 2]')
+
+    assert_equal(result, [1, 2])
+  end
+
+  def test_json_array_with_too_many_items
+    parser = Oj::Parser.safe(max_array_size: 2)
+
+    error = assert_raises(Oj::Parser::ArraySizeError) { parser.parse('[1, 2, 3]') }
+
+    assert_equal('Too many array items!', error.message)
+  end
+
+  def test_invalid_max_hash_size_option
+    error = assert_raises(ArgumentError) { Oj::Parser.safe(max_hash_size: :foo) }
+
+    assert_equal('Incorrect value provided for `max_hash_size`', error.message)
+  end
+
+  def test_json_object_with_fewer_members
+    parser = Oj::Parser.safe(max_hash_size: 2)
+    result = parser.parse('{ "foo": 1, "bar": 2 }')
+
+    assert_equal(result, { 'foo' => 1, 'bar' => 2 })
+  end
+
+  def test_json_object_with_too_many_members
+    parser = Oj::Parser.safe(max_hash_size: 2)
+
+    error = assert_raises(Oj::Parser::HashSizeError) { parser.parse('{ "foo": 1, "bar": 2, "zoo": 3 }') }
+
+    assert_equal('Too many object items!', error.message)
+  end
+
+  def test_invalid_max_depth_option
+    error = assert_raises(ArgumentError) { Oj::Parser.safe(max_depth: :foo) }
+
+    assert_equal('Incorrect value provided for `max_depth`', error.message)
+  end
+
+  def test_shallow_json_document
+    parser = Oj::Parser.safe(max_depth: 2)
+    result = parser.parse('[[]]')
+
+    assert_equal(result, [[]])
+  end
+
+  def test_deep_json_document
+    parser = Oj::Parser.safe(max_depth: 2)
+
+    error = assert_raises(Oj::Parser::DepthError) { parser.parse('[[[]]]') }
+
+    assert_equal('JSON is too deep!', error.message)
+  end
+
+  def test_invalid_max_total_elements_option
+    error = assert_raises(ArgumentError) { Oj::Parser.safe(max_total_elements: :foo) }
+
+    assert_equal('Incorrect value provided for `max_total_elements`', error.message)
+  end
+
+  def test_json_with_fewer_elements
+    parser = Oj::Parser.safe(max_total_elements: 3)
+    result = parser.parse('{ "foo": "bar" }')
+
+    assert_equal(result, { 'foo' => 'bar' })
+  end
+
+  def test_json_with_too_many_elements
+    parser = Oj::Parser.safe(max_total_elements: 3)
+
+    error = assert_raises(Oj::Parser::TotalElementsError) { parser.parse('{ "foo": [1] }') }
+
+    assert_equal('Too many elements!', error.message)
+  end
+end


### PR DESCRIPTION
Introduce a safe parser mode that enforces limits for array size, hash size, nesting depth, and total elements to reduce risk from oversized or deeply nested payloads.