### PR TITLE
Add `max_integer_digits` limit for legacy integer parsing

### DIFF
--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -246,6 +246,19 @@ static void skip_comment(ParseInfo pi) {
 #define NUM_MAX (FIXNUM_MAX >> 8)
 #endif
 
+static void validate_integer_size(size_t limit, char *head, char *tail) {
+    size_t total       = (size_t)(tail - head);
+    bool   has_sign    = (head[0] == '-' || head[0] == '+');
+    size_t digit_count = total - (has_sign ? 1 : 0);
+
+    if (digit_count > limit) {
+        rb_raise(oj_parse_error_class,
+                 "integer exceeds :max_integer_digits (%lu > %lu)",
+                 (unsigned long)digit_count,
+                 (unsigned long)limit);
+    }
+}
+
 static void leaf_fixnum_value(Leaf leaf) {
     char   *s   = leaf->str;
     int64_t n   = 0;
@@ -265,7 +278,12 @@ static void leaf_fixnum_value(Leaf leaf) {
         }
     }
     if (big) {
-        char c = *s;
+        size_t limit = oj_default_options.max_integer_digits;
+        char   c     = *s;
+
+        if (0 < limit) {
+            validate_integer_size(limit, leaf->str, s);
+        }
 
         *s          = '\0';
         leaf->value = rb_cstr_to_inum(leaf->str, 10, 0);

--- a/ext/oj/mimic_json.c
+++ b/ext/oj/mimic_json.c
@@ -711,6 +711,7 @@ static struct _options mimic_object_to_json_options = {0,              // indent
                                                        0,              // cache_str
                                                        0,              // int_range_min
                                                        0,              // int_range_max
+                                                       0,              // max_integer_digits
                                                        oj_json_class,  // create_id
                                                        10,             // create_id_len
                                                        3,              // sec_prec

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -122,6 +122,7 @@ static VALUE empty_string_sym;
 static VALUE escape_mode_sym;
 static VALUE except_sym;
 static VALUE integer_range_sym;
+static VALUE max_integer_digits_sym;
 static VALUE fast_sym;
 static VALUE float_prec_sym;
 static VALUE float_format_sym;
@@ -206,6 +207,7 @@ struct _options oj_default_options = {
     0,              // cache_str
     0,              // int_range_min
     0,              // int_range_max
+    0,              // max_integer_digits
     oj_json_class,  // create_id
     10,             // create_id_len
     9,              // sec_prec
@@ -334,6 +336,11 @@ static VALUE only_array_from_string(const char *str) {
  * - *:cache_str* [_Fixnum_] maximum string value length to cache (strings less
  *   than this are cached)
  * - *:integer_range* [_Range_] Dump integers outside range as strings.
+ * - *:max_integer_digits* [_Fixnum_] Maximum number of decimal digits allowed in a
+ *   parsed integer. When the limit is exceeded a parse error is raised. 0 (the
+ *   default) disables the limit. Setting a reasonable limit is recommended when
+ *   parsing untrusted input to mitigate CPU-DoS attacks. Only applies to the
+ *   legacy parsers (Oj.load, Oj::Doc, JSON.parse mimic); Oj::Parser is unaffected.
  * - *:trace* [_true,_|_false_] Trace all load and dump calls, default is false
  *   (trace is off)
  * - *:safe* [_true,_|_false_] Safe mimic breaks JSON mimic to be safer, default
@@ -448,6 +455,7 @@ static VALUE get_def_opts(VALUE self) {
     } else {
         rb_hash_aset(opts, integer_range_sym, Qnil);
     }
+    rb_hash_aset(opts, max_integer_digits_sym, LONG2NUM((long)oj_default_options.max_integer_digits));
     switch (oj_default_options.escape_mode) {
     case NLEsc: rb_hash_aset(opts, escape_mode_sym, newline_sym); break;
     case JSONEsc: rb_hash_aset(opts, escape_mode_sym, json_sym); break;
@@ -591,6 +599,8 @@ static VALUE get_def_opts(VALUE self) {
  *   - *:cache_keys* [_Boolean_] if true then hash keys are cached
  *   - *:cache_str* [_Fixnum_] maximum string value length to cache (strings less than this are cached)
  *   - *:integer_range* [_Range_] Dump integers outside range as strings.
+ *   - *:max_integer_digits* [_Fixnum_] Maximum decimal digits in a parsed integer
+ *     (0 = unlimited). Use to mitigate CPU-DoS via huge integer values in JSON.
  *   - *:trace* [_Boolean_] turn trace on or off.
  *   - *:safe* [_Boolean_] turn safe mimic on or off.
  */
@@ -1070,6 +1080,20 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
             copts->int_range_max = FIX2LONG(max);
         } else if (Qfalse != v) {
             rb_raise(rb_eArgError, ":integer_range must be a range of Fixnum.");
+        }
+    } else if (max_integer_digits_sym == k) {
+        if (Qnil == v || Qfalse == v) {
+            copts->max_integer_digits = 0;
+        } else if (T_FIXNUM == rb_type(v)) {
+            long n = FIX2LONG(v);
+
+            if (n < 0) {
+                rb_raise(rb_eArgError, ":max_integer_digits must be >= 0.");
+            }
+
+            copts->max_integer_digits = (size_t)n;
+        } else {
+            rb_raise(rb_eArgError, ":max_integer_digits must be a non-negative Integer.");
         }
     } else if (symbol_keys_sym == k || oj_symbolize_names_sym == k) {
         if (Qnil == v) {
@@ -2153,6 +2177,8 @@ void Init_oj(void) {
     rb_gc_register_address(&escape_mode_sym);
     integer_range_sym = ID2SYM(rb_intern("integer_range"));
     rb_gc_register_address(&integer_range_sym);
+    max_integer_digits_sym = ID2SYM(rb_intern("max_integer_digits"));
+    rb_gc_register_address(&max_integer_digits_sym);
     fast_sym = ID2SYM(rb_intern("fast"));
     rb_gc_register_address(&fast_sym);
     float_format_sym = ID2SYM(rb_intern("float_format"));

--- a/ext/oj/oj.h
+++ b/ext/oj/oj.h
@@ -124,43 +124,44 @@ typedef struct _dumpOpts {
 } *DumpOpts;
 
 typedef struct _options {
-    int              indent;         // indention for dump, default 2
-    char             circular;       // YesNo
-    char             auto_define;    // YesNo
-    char             sym_key;        // YesNo
-    char             escape_mode;    // Escape_Mode
-    char             mode;           // Mode
-    char             class_cache;    // YesNo
-    char             time_format;    // TimeFormat
-    char             bigdec_as_num;  // YesNo
-    char             bigdec_load;    // BigLoad
-    char             compat_bigdec;  // boolean (0 or 1)
-    char             to_hash;        // YesNo
-    char             to_json;        // YesNo
-    char             as_json;        // YesNo
-    char             raw_json;       // YesNo
-    char             nilnil;         // YesNo
-    char             empty_string;   // YesNo
-    char             allow_gc;       // allow GC during parse
-    char             quirks_mode;    // allow single JSON values instead of documents
-    char             allow_invalid;  // YesNo - allow invalid unicode
-    char             create_ok;      // YesNo allow create_id
-    char             allow_nan;      // YesNo for parsing only
-    char             trace;          // YesNo
-    char             safe;           // YesNo
-    char             sec_prec_set;   // boolean (0 or 1)
-    char             ignore_under;   // YesNo - ignore attrs starting with _ if true in object and custom modes
-    char             cache_keys;     // YesNo
-    char             cache_str;      // string short than or equal to this are cache
-    int64_t          int_range_min;  // dump numbers below as string
-    int64_t          int_range_max;  // dump numbers above as string
-    const char      *create_id;      // 0 or string
-    size_t           create_id_len;  // length of create_id
-    int              sec_prec;       // second precision when dumping time
-    char             float_prec;     // float precision, linked to float_fmt
-    char             float_fmt[7];   // float format for dumping, if empty use Ruby
-    VALUE            hash_class;     // class to use in place of Hash on load
-    VALUE            array_class;    // class to use in place of Array on load
+    int              indent;              // indention for dump, default 2
+    char             circular;            // YesNo
+    char             auto_define;         // YesNo
+    char             sym_key;             // YesNo
+    char             escape_mode;         // Escape_Mode
+    char             mode;                // Mode
+    char             class_cache;         // YesNo
+    char             time_format;         // TimeFormat
+    char             bigdec_as_num;       // YesNo
+    char             bigdec_load;         // BigLoad
+    char             compat_bigdec;       // boolean (0 or 1)
+    char             to_hash;             // YesNo
+    char             to_json;             // YesNo
+    char             as_json;             // YesNo
+    char             raw_json;            // YesNo
+    char             nilnil;              // YesNo
+    char             empty_string;        // YesNo
+    char             allow_gc;            // allow GC during parse
+    char             quirks_mode;         // allow single JSON values instead of documents
+    char             allow_invalid;       // YesNo - allow invalid unicode
+    char             create_ok;           // YesNo allow create_id
+    char             allow_nan;           // YesNo for parsing only
+    char             trace;               // YesNo
+    char             safe;                // YesNo
+    char             sec_prec_set;        // boolean (0 or 1)
+    char             ignore_under;        // YesNo - ignore attrs starting with _ if true in object and custom modes
+    char             cache_keys;          // YesNo
+    char             cache_str;           // string short than or equal to this are cache
+    int64_t          int_range_min;       // dump numbers below as string
+    int64_t          int_range_max;       // dump numbers above as string
+    size_t           max_integer_digits;  // 0 = unlimited; max decimal digits for parsed integers
+    const char      *create_id;           // 0 or string
+    size_t           create_id_len;       // length of create_id
+    int              sec_prec;            // second precision when dumping time
+    char             float_prec;          // float precision, linked to float_fmt
+    char             float_fmt[7];        // float format for dumping, if empty use Ruby
+    VALUE            hash_class;          // class to use in place of Hash on load
+    VALUE            array_class;         // class to use in place of Array on load
     struct _dumpOpts dump_opts;
     struct _rxClass  str_rx;
     VALUE           *ignore;  // Qnil terminated array of classes or NULL

--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -971,6 +971,20 @@ static long double exp_plus[] = {
     1.0e39, 1.0e40, 1.0e41, 1.0e42, 1.0e43, 1.0e44, 1.0e45, 1.0e46, 1.0e47, 1.0e48, 1.0e49,
 };
 
+static void validate_integer_size(size_t limit, NumInfo ni) {
+    size_t digit_count = ni->len - (ni->neg ? 1 : 0);
+
+    if (digit_count > limit) {
+        oj_set_error_at(ni->pi,
+                        (Qnil != ni->pi->err_class) ? ni->pi->err_class : oj_parse_error_class,
+                        __FILE__,
+                        __LINE__,
+                        "integer exceeds :max_integer_digits (%lu > %lu)",
+                        (unsigned long)digit_count,
+                        (unsigned long)limit);
+    }
+}
+
 VALUE
 oj_num_as_value(NumInfo ni) {
     VALUE rnum = Qnil;
@@ -984,6 +998,12 @@ oj_num_as_value(NumInfo ni) {
     } else if (ni->nan) {
         rnum = rb_float_new(0.0 / 0.0);
     } else if (1 == ni->div && 0 == ni->exp && !ni->has_exp) {  // fixnum
+        size_t limit = (NULL != ni->pi) ? ni->pi->options.max_integer_digits : 0;
+
+        if (0 < limit) {
+            validate_integer_size(limit, ni);
+        }
+
         if (ni->big) {
             if (256 > ni->len) {
                 char buf[256];

--- a/ext/oj/sparse.c
+++ b/ext/oj/sparse.c
@@ -399,6 +399,7 @@ static void read_num(ParseInfo pi) {
     char            c;
 
     reader_protect(&pi->rd);
+    ni.pi       = pi;
     ni.i        = 0;
     ni.num      = 0;
     ni.div      = 1;
@@ -549,6 +550,7 @@ static void read_nan(ParseInfo pi) {
     struct _numInfo ni;
     char            c;
 
+    ni.pi       = pi;
     ni.str      = pi->rd.str;
     ni.i        = 0;
     ni.num      = 0;
@@ -745,6 +747,7 @@ void oj_sparse2(ParseInfo pi) {
                     oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "expected NaN");
                     return;
                 }
+                ni.pi       = pi;
                 ni.str      = pi->rd.str;
                 ni.i        = 0;
                 ni.num      = 0;

--- a/test/test_max_integer_digits.rb
+++ b/test/test_max_integer_digits.rb
@@ -1,0 +1,189 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+$LOAD_PATH << __dir__
+@oj_dir = File.dirname(File.expand_path(__dir__))
+%w(lib ext).each do |dir|
+  $LOAD_PATH << File.join(@oj_dir, dir)
+end
+
+require 'minitest'
+require 'minitest/autorun'
+require 'oj'
+
+class MaxIntegerDigitsTest < Minitest::Test
+  def setup
+    @default_options = Oj.default_options
+  end
+
+  def teardown
+    Oj.default_options = @default_options
+  end
+
+  def test_default_is_zero
+    assert_equal(0, Oj.default_options[:max_integer_digits])
+  end
+
+  def test_default_unlimited_allows_huge_integer
+    huge = '1' * 10_000
+    result = Oj.load(huge)
+
+    assert_equal(huge.to_i, result)
+  end
+
+  def test_limit_allows_value_within_limit
+    Oj.default_options = { max_integer_digits: 100 }
+    val = '9' * 100
+
+    assert_equal(val.to_i, Oj.load(val))
+  end
+
+  def test_limit_rejects_value_over_limit
+    Oj.default_options = { max_integer_digits: 100 }
+
+    assert_raises(Oj::ParseError) do
+      Oj.load('1' * 101)
+    end
+  end
+
+  def test_limit_rejects_bignum_over_limit
+    Oj.default_options = { max_integer_digits: 50 }
+
+    assert_raises(Oj::ParseError) do
+      Oj.load('9' * 1000)
+    end
+  end
+
+  def test_negative_integer_does_not_count_minus_sign
+    Oj.default_options = { max_integer_digits: 10 }
+    val = '-' + '1' * 10
+
+    assert_equal(val.to_i, Oj.load(val))
+  end
+
+  def test_negative_integer_over_limit_raises
+    Oj.default_options = { max_integer_digits: 10 }
+    val = '-' + '1' * 11
+
+    assert_raises(Oj::ParseError) do
+      Oj.load(val)
+    end
+  end
+
+  def test_floats_not_affected
+    Oj.default_options = { max_integer_digits: 5 }
+
+    refute_nil(Oj.load('0.' + '1' * 100))
+    refute_nil(Oj.load('1.' + '1' * 100))
+  end
+
+  def test_numbers_with_exponent_not_affected
+    Oj.default_options = { max_integer_digits: 5 }
+
+    refute_nil(Oj.load('1e10'))
+    refute_nil(Oj.load('1.5e100'))
+  end
+
+  def test_per_call_option
+    Oj.default_options = { max_integer_digits: 0 }
+
+    assert_raises(Oj::ParseError) do
+      Oj.load('1' * 50, max_integer_digits: 20)
+    end
+  end
+
+  def test_per_call_overrides_default
+    Oj.default_options = { max_integer_digits: 5 }
+    val = '1' * 10
+
+    assert_equal(val.to_i, Oj.load(val, max_integer_digits: 20))
+  end
+
+  def test_nil_resets_to_zero
+    Oj.default_options = { max_integer_digits: 100 }
+    Oj.default_options = { max_integer_digits: nil }
+
+    assert_equal(0, Oj.default_options[:max_integer_digits])
+  end
+
+  def test_false_resets_to_zero
+    Oj.default_options = { max_integer_digits: 100 }
+    Oj.default_options = { max_integer_digits: false }
+
+    assert_equal(0, Oj.default_options[:max_integer_digits])
+  end
+
+  def test_negative_value_raises_argument_error
+    assert_raises(ArgumentError) do
+      Oj.default_options = { max_integer_digits: -1 }
+    end
+  end
+
+  def test_non_integer_raises_argument_error
+    assert_raises(ArgumentError) do
+      Oj.default_options = { max_integer_digits: 'abc' }
+    end
+  end
+
+  def test_applies_across_legacy_modes
+    # All legacy parse modes should refuse to parse an integer that exceeds the
+    # configured limit. Different modes raise different error classes (e.g.
+    # compat mode raises EncodingError to mimic the json gem), so we accept any
+    # StandardError that includes our marker message.
+    [:strict, :null, :compat, :object, :custom, :rails, :wab].each do |mode|
+      err = assert_raises(StandardError, "mode #{mode} did not enforce limit") do
+        Oj.load('1' * 100, mode: mode, max_integer_digits: 50)
+      end
+
+      assert_match(/max_integer_digits/, err.message, "mode #{mode} raised unexpected error")
+    end
+  end
+
+  def test_oj_doc_honors_default_options_limit
+    Oj.default_options = { max_integer_digits: 50 }
+
+    assert_raises(Oj::ParseError) do
+      Oj::Doc.open('9' * 100) { |doc| doc.fetch }
+    end
+  end
+
+  def test_oj_doc_within_limit_works
+    Oj.default_options = { max_integer_digits: 100 }
+    val = '9' * 50
+    result = Oj::Doc.open(val) { |doc| doc.fetch }
+
+    assert_equal(val.to_i, result)
+  end
+
+  def test_oj_parser_is_unaffected
+    # The new Oj::Parser API does not convert big numeric tokens via
+    # rb_cstr_to_inum and so is not subject to this limit. Confirm that
+    # setting :max_integer_digits does not break Oj::Parser parsing.
+    Oj.default_options = { max_integer_digits: 5 }
+    result = Oj::Parser.new(:usual).parse('9' * 50)
+
+    refute_nil(result)
+  end
+
+  def test_integer_in_array_enforced
+    Oj.default_options = { max_integer_digits: 10 }
+
+    assert_raises(Oj::ParseError) do
+      Oj.load('[1, 2, ' + ('9' * 100) + ']')
+    end
+  end
+
+  def test_integer_in_hash_enforced
+    Oj.default_options = { max_integer_digits: 10 }
+
+    assert_raises(Oj::ParseError) do
+      Oj.load('{"a": ' + ('9' * 100) + '}')
+    end
+  end
+
+  def test_get_option_via_hash
+    Oj.default_options = { max_integer_digits: 42 }
+
+    assert_equal(42, Oj.default_options[:max_integer_digits])
+  end
+end

--- a/test/tests.rb
+++ b/test/tests.rb
@@ -23,6 +23,7 @@ require 'test_wab'
 require 'test_writer'
 require 'test_integer_range'
 require 'test_long_strings'
+require 'test_max_integer_digits'
 
 at_exit do
   require 'helper'


### PR DESCRIPTION
Introduce a `max_integer_digits` option to cap parsed integer length in `Oj.load` and `Oj::Doc` legacy parsers.

This mitigates CPU DoS risk from untrusted JSON containing enormous integers while keeping default behavior unlimited.