### PR TITLE
Fix heap buffer overflow when dumping nested arrays with an integer :indent in compat mode

### DIFF
--- a/ext/oj/dump_compat.c
+++ b/ext/oj/dump_compat.c
@@ -162,6 +162,7 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
                     }
                 }
             } else {
+                assure_size(out, size);
                 fill_indent(out, d2);
             }
             oj_dump_compat_val(RARRAY_AREF(a, i), d2, out, true);

--- a/test/test_compat.rb
+++ b/test/test_compat.rb
@@ -172,6 +172,21 @@ class CompatJuice < Minitest::Test
     dump_and_load([1, [2, [3, [4, [5, [6, [7, [8, [9, [10, [11, [12, [13, [14, [15, [16, [17, [18, [19, [20]]]]]]]]]]]]]]]]]]]], false)
   end
 
+  # A deeply nested array dumped in compat mode with an integer :indent used to
+  # overflow the output buffer because the integer-indent branch of dump_array
+  # called fill_indent() without a preceding assure_size(). Any nesting deep
+  # enough that depth*indent exceeds the buffer slack corrupted the heap.
+  def test_array_deep_indent
+    [1, 2, 16].each do |indent|
+      [50, 120, 250].each do |depth|
+        nested = eval('[[' * depth + '1' + ']]' * depth)
+        json   = Oj.dump(nested, :mode => :compat, :indent => indent)
+        # round-trips back to the same structure and does not crash
+        assert_equal(nested, Oj.compat_load(json))
+      end
+    end
+  end
+
   def test_symbol
     json = Oj.dump(:abc, :mode => :compat)
     assert_equal('"abc"', json)


### PR DESCRIPTION

## Summary

`Oj.dump(obj, mode: :compat, indent: <Fixnum>)` overflows the output buffer when `obj` contains a sufficiently deep nested `Array`. On a normal build this shows up as `realloc(): invalid next size` (heap metadata corruption / abort); under AddressSanitizer it is a `heap-buffer-overflow` write in `fill_indent`.

This is the same bug class as the dump-side size-accounting overflow fixed by CVE-2026-54896, but in a different code path (compat-mode array dump, integer indent) that the earlier fix did not cover.

## Reproduction

```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'oj'
end
nested = eval('[[' * 50 + '1' + ']]' * 50)   # deeply nested array
Oj.dump(nested, mode: :compat, indent: 16)   # -> realloc(): invalid next size / [BUG] Aborted
```

It triggers with any integer indent (even `indent: 1`) once the nesting is deep enough that `depth * indent` exceeds the current output-buffer slack.

## Root cause

In `dump_array()` (`ext/oj/dump_compat.c`), the integer-indent branch calls `fill_indent()` without a preceding `assure_size()`:

```c
} else {
    fill_indent(out, d2);          // writes 1 + d2*out->indent bytes, no reservation
}
```

`fill_indent()` `memset`s `1 + d2*out->indent` bytes at `out->cur`. The `size` value computed just above (`size = d2 * out->indent + 2`) is only consumed by the string-indent (`dump_opts.use`) branch, which *does* guard with `assure_size(out, size)`. Every other dumper (`dump_strict.c`, `dump_object.c`, `custom.c`, `rails.c`, `wab.c`, and the null dumper) reserves `size * cnt` before the loop; only compat's `dump_array` omitted the reservation (it only does `assure_size(out, 2)`).

## Fix

Reserve the space before the write in the integer-indent branch, mirroring the guarded string-indent branch:

```c
} else {
    assure_size(out, size);
    fill_indent(out, d2);
}
```

## Scope / impact

- Affects `Oj.dump` / `Oj.to_json` with `mode: :compat` **and an integer `:indent`**.
- `JSON.pretty_generate` / `JSON.generate(indent: ...)` are **not** affected — they take the guarded `dump_opts.use` string-indent path.
- The overflowing bytes are spaces + a newline, of attacker-influenced length (via nesting depth and indent).
