### PR TITLE
Fix stack buffer overflow when an IO returns more than the requested number of bytes

### DIFF
--- a/ext/oj/reader.c
+++ b/ext/oj/reader.c
@@ -164,8 +164,14 @@ static VALUE partial_io_cb(VALUE rbuf) {
     }
     str = StringValuePtr(rstr);
     cnt = RSTRING_LEN(rstr);
-    strcpy(reader->tail, str);
-    reader->read_end = reader->tail + cnt;
+    if (cnt > (size_t)(reader->end - reader->tail)) {
+        // A misbehaving IO returned more than the requested number of bytes.
+        // Copying it in with strcpy() would overflow the reader buffer.
+        rb_raise(rb_eIOError, "read returned more than the requested number of bytes");
+    }
+    memcpy(reader->tail, str, cnt);
+    reader->tail[cnt] = '\0';
+    reader->read_end  = reader->tail + cnt;
 
     return Qtrue;
 }
@@ -184,8 +190,14 @@ static VALUE io_cb(VALUE rbuf) {
     }
     str = StringValuePtr(rstr);
     cnt = RSTRING_LEN(rstr);
-    strcpy(reader->tail, str);
-    reader->read_end = reader->tail + cnt;
+    if (cnt > (size_t)(reader->end - reader->tail)) {
+        // A misbehaving IO returned more than the requested number of bytes.
+        // Copying it in with strcpy() would overflow the reader buffer.
+        rb_raise(rb_eIOError, "read returned more than the requested number of bytes");
+    }
+    memcpy(reader->tail, str, cnt);
+    reader->tail[cnt] = '\0';
+    reader->read_end  = reader->tail + cnt;
 
     return Qtrue;
 }

--- a/test/test_strict.rb
+++ b/test/test_strict.rb
@@ -282,6 +282,29 @@ class StrictJuice < Minitest::Test
     assert_equal({ 'x' => true, 'y' => 58, 'z' => [1, 2, 3]}, obj)
   end
 
+  # An object that only responds to read() exercises the io_cb() reader path.
+  def test_io_read_object
+    json = %{{"x":true,"y":58,"z":[1,2,3]}}
+    reader = Object.new
+    reader.instance_variable_set(:@data, json.dup)
+    def reader.read(len = nil)
+      return nil if @data.empty?
+      len ? @data.slice!(0, len) : @data.slice!(0, @data.length)
+    end
+    obj = Oj.strict_load(reader)
+    assert_equal({ 'x' => true, 'y' => 58, 'z' => [1, 2, 3]}, obj)
+  end
+
+  # An IO whose read() returns more than the requested number of bytes used to
+  # overflow the fixed-size reader buffer (SIGSEGV). It must raise cleanly.
+  def test_io_read_over_length
+    bad = Object.new
+    def bad.read(_len = nil)
+      'A' * 100_000
+    end
+    assert_raises(IOError) { Oj.strict_load(bad) }
+  end
+
   def test_symbol
     json = Oj.dump(:abc)
     assert_equal('"abc"', json)


### PR DESCRIPTION

## Summary

`Oj.load(io, ...)` (the streaming reader path) overflows a stack buffer when `io` is a duck-typed object whose `read`/`readpartial` returns more bytes than were requested. On a normal build this crashes with a `SIGSEGV` on the stack guard page.

This is the untrusted-IO counterpart of the buffer-sizing bugs in the reader: the returned string length is trusted instead of the requested length.

## Reproduction

```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'oj'
end
io = Object.new
def io.read(len = nil) = 'A' * 100_000   # returns far more than the requested length
Oj.load(io, mode: :strict)               # -> [BUG] Segmentation fault
```

## Root cause

`io_cb()` and `partial_io_cb()` in `ext/oj/reader.c` request `reader->end - reader->tail` bytes, then `strcpy()` whatever the IO returns into the 4 KiB `reader->base` buffer without checking its length:

```c
args[0] = ULONG2NUM(reader->end - reader->tail);   // request N bytes
rstr    = rb_funcall2(reader->io, oj_read_id, 1, args);
str = StringValuePtr(rstr);
cnt = RSTRING_LEN(rstr);
strcpy(reader->tail, str);                          // no bound: overflows reader->base
```

`read(len)` is supposed to return at most `len` bytes, but a misbehaving or malicious IO can return more, overrunning the stack-allocated reader buffer. The same code is duplicated in both callbacks.

## Fix

In both callbacks, reject a read that exceeds the requested size and copy with `memcpy` (which, unlike `strcpy`, also stops truncating at an embedded NUL byte):

```c
if (cnt > (size_t)(reader->end - reader->tail)) {
    rb_raise(rb_eIOError, "read returned more than the requested number of bytes");
}
memcpy(reader->tail, str, cnt);
reader->tail[cnt] = '\0';
reader->read_end  = reader->tail + cnt;
```

## Scope / impact

- Affects `Oj.load` / streaming parses that read from an object responding to `read`/`readpartial` (not `String`, `StringIO`, or a real `File` backed by a file descriptor, which take other paths).
- A well-behaved IO that returns at most the requested number of bytes is unaffected.
- Also fixes silent truncation of the input stream when a chunk contains a NUL byte (`strcpy` -> `memcpy`).
