### PR TITLE
Harden object-mode ^u (Struct) handling against two crashes from untrusted JSON

### DIFF
--- a/ext/oj/object.c
+++ b/ext/oj/object.c
@@ -319,19 +319,25 @@ static int hat_value(ParseInfo pi, Val parent, const char *key, size_t klen, vol
             e1 = *RARRAY_CONST_PTR(value);
             // check for anonymous Struct
             if (T_ARRAY == rb_type(e1)) {
-                VALUE          args[1024];
-                volatile VALUE rstr;
+                // Build the member-name list in a GC-managed Ruby array. Using a
+                // fixed C buffer (VALUE args[1024]) here overflowed the stack when
+                // the JSON supplied more than 1024 member names.
+                volatile VALUE names = rb_ary_new2(RARRAY_LEN(e1));
                 size_t         i;
                 size_t         cnt = RARRAY_LEN(e1);
 
                 for (i = 0; i < cnt; i++) {
-                    rstr    = RARRAY_AREF(e1, i);
-                    args[i] = rb_funcall(rstr, oj_to_sym_id, 0);
+                    rb_ary_push(names, rb_funcall(RARRAY_AREF(e1, i), oj_to_sym_id, 0));
                 }
-                sc = rb_funcall2(rb_cStruct, oj_new_id, (int)cnt, args);
+                sc = rb_apply(rb_cStruct, oj_new_id, names);
             } else {
                 // If struct is not defined then we let this fail and raise an exception.
                 sc = oj_name2struct(pi, *RARRAY_CONST_PTR(value), rb_eArgError);
+            }
+            if (Qundef == sc || Qnil == sc) {
+                // oj_name2struct already recorded the error; do not pass an
+                // unresolved (Qundef) class on to rb_obj_alloc/rb_class_new_instance.
+                return 1;
             }
             if (sc == rb_cRange) {
                 parent->val = rb_class_new_instance((int)(len - 1), RARRAY_CONST_PTR(value) + 1, rb_cRange);

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -656,6 +656,26 @@ class ObjectJuice < Minitest::Test
     dump_and_load(obj, false)
   end
 
+  # An anonymous ^u (Struct) directive with a large member-name list used to
+  # overflow a fixed 1024-entry stack buffer (VALUE args[1024]).
+  def test_json_anonymous_struct_many_members
+    names = (0...3000).map { |i| "\"m#{i}\"" }.join(',')
+    obj   = Oj.load(%({"^u":[[#{names}],1]}), :mode => :object)
+    assert_kind_of(Struct, obj)
+  end
+
+  # A ^u (Struct) directive naming a class that is not defined used to abort the
+  # process with "[BUG] undef leaked to the Ruby space" because the unresolved
+  # (Qundef) class was passed to rb_obj_alloc. It must raise cleanly instead.
+  def test_json_struct_undefined_class
+    assert_raises(ArgumentError) do
+      Oj.load(%({"^u":["NoSuchStructClass99",1,2]}), :mode => :object)
+    end
+    assert_raises(ArgumentError) do
+      Oj.load(%({"^u":["NoSuchStructClass99",1,2]}), :mode => :object, :auto_define => true)
+    end
+  end
+
   def test_json_anonymous_struct
     s = Struct.new(:x, :y)
     obj = s.new(1, 2)


### PR DESCRIPTION

## Summary

Two memory-safety issues in `hat_value()` (`ext/oj/object.c`) are reachable from untrusted JSON parsed with `mode: :object` via the `^u` (Struct) directive. Both crash the process.

1. **Anonymous Struct — stack buffer overflow.** The member-name list is collected into a fixed `VALUE args[1024]` stack buffer with no bound check, so a `^u` whose first element is an array of more than 1024 names overflows the stack (SIGABRT, or SIGSEGV for larger inputs).
2. **Undefined Struct class — process abort.** When the named Struct class is not defined, `oj_name2struct()` returns `Qundef` (recording a deferred error), but execution continues and passes `Qundef` to `rb_obj_alloc()`, tripping `[BUG] undef leaked to the Ruby space` (SIGABRT).

## Reproduction

```ruby
require 'bundler/inline'
gemfile do
  source 'https://rubygems.org'
  gem 'oj'
end

# 1. Anonymous Struct with more than 1024 member names -> stack buffer overflow
names = (0...2000).map { |i| %("m#{i}") }.join(',')
Oj.load(%({"^u":[[#{names}],1]}), mode: :object)   # -> SIGABRT / SIGSEGV

# 2. Struct directive naming an undefined class -> process abort
Oj.load(%({"^u":["NoSuchStructClass",1]}), mode: :object)   # -> [BUG] undef leaked to the Ruby space
```

## Root cause

In `hat_value()`:

```c
if (T_ARRAY == rb_type(e1)) {            // anonymous Struct
    VALUE  args[1024];                    // fixed stack buffer
    size_t cnt = RARRAY_LEN(e1);          // attacker-controlled length
    for (i = 0; i < cnt; i++) {
        args[i] = rb_funcall(RARRAY_AREF(e1, i), oj_to_sym_id, 0);  // OOB write when i >= 1024
    }
    sc = rb_funcall2(rb_cStruct, oj_new_id, (int)cnt, args);
} else {
    sc = oj_name2struct(pi, *RARRAY_CONST_PTR(value), rb_eArgError); // returns Qundef for unknown class
}
...
parent->val = rb_obj_alloc(sc);           // sc == Qundef -> rb_bug()
```

## Fix

- Build the member-name list in a GC-managed Ruby array and splat it with `rb_apply()`, removing the fixed-size buffer entirely (no bound, no leak on raise, GC-safe).
- Bail out when the resolved class is unresolved (`Qundef`/`Qnil`) so the error already recorded by `oj_name2struct()` is raised cleanly instead of reaching `rb_obj_alloc()`.

```c
if (T_ARRAY == rb_type(e1)) {
    volatile VALUE names = rb_ary_new2(RARRAY_LEN(e1));
    size_t         cnt   = RARRAY_LEN(e1);
    for (i = 0; i < cnt; i++) {
        rb_ary_push(names, rb_funcall(RARRAY_AREF(e1, i), oj_to_sym_id, 0));
    }
    sc = rb_apply(rb_cStruct, oj_new_id, names);
} else {
    sc = oj_name2struct(pi, *RARRAY_CONST_PTR(value), rb_eArgError);
}
if (Qundef == sc || Qnil == sc) {
    return 1;
}
```

## Scope / impact

- Both issues require `mode: :object` and a crafted `^u` directive; they do not affect other modes.
- After the fix, an anonymous Struct with any number of members is created normally, an undefined Struct class raises `ArgumentError`, and valid `^u` Structs / Ranges continue to round-trip.
