### PR TITLE
Add NEON string scanning to Oj::Parser

### DIFF
--- a/ext/oj/parser.c
+++ b/ext/oj/parser.c
@@ -5,6 +5,7 @@
 #include <fcntl.h>
 
 #include "oj.h"
+#include "simd.h"
 
 #define DEBUG 0
 
@@ -594,9 +595,64 @@ static void big_change(ojParser p) {
     }
 }
 
-static void parse(ojParser p, const byte *json, bool more) {
+// Scan forward over string content, returning the first byte that is not
+// STR_OK in string_map. This is a pure drop-in for the scalar loop
+//
+//     for (; STR_OK == string_map[*b]; b++) {}
+//
+// and must return the exact same stop position. The stop set (bytes whose
+// string_map class is not 'R'/STR_OK) is:
+//
+//     * control bytes  0x00..0x1F  (class '.', also stops at the NUL terminator)
+//     * the quote      0x22 '"'    (class 'z')
+//     * the backslash  0x5C '\'    (class 'A')
+//     * every high byte 0x80..0xFF (UTF-8 lead/continuation, classes M/P/Q/'.')
+//
+// Note this differs from parse.c's string_scan_neon, which stops only on
+// \0 \\ " -- parser.c hands multi-byte UTF-8 to its state machine, so the
+// scanner must stop on the high bytes too. The predictor below is derived from
+// string_map, not copied from parse.c.
+//
+// The NEON path only loads a full 16-byte vector when [b, b+16) stays within
+// [., end), so it never reads past the string's allocation; the sub-16-byte
+// tail (and the whole scan on non-NEON builds) uses the scalar loop, which
+// stops naturally at the guaranteed NUL terminator.
+static inline const byte *oj_scan_str_simd(const byte *b, const byte *end) {
+#ifdef HAVE_SIMD_NEON
+    if (SIMD_NEON == SIMD_Impl) {
+        const uint8x16_t quote  = vdupq_n_u8('"');
+        const uint8x16_t bslash = vdupq_n_u8('\\');
+        const uint8x16_t space  = vdupq_n_u8(0x20);
+        const uint8x16_t high   = vdupq_n_u8(0x80);
+
+        while (b + sizeof(uint8x16_t) <= end) {
+            const uint8x16_t chunk = vld1q_u8((const uint8_t *)b);
+            // special lane == 0xFF for any byte that stops the scan.
+            const uint8x16_t special = vorrq_u8(vorrq_u8(vceqq_u8(chunk, quote), vceqq_u8(chunk, bslash)),
+                                                vorrq_u8(vcltq_u8(chunk, space), vcgeq_u8(chunk, high)));
+            // Reduce to a 64-bit mask with 4 bits per lane (same idiom as
+            // parse.c's string_scan_neon) and locate the first set lane.
+            const uint8x8_t res  = vshrn_n_u16(vreinterpretq_u16_u8(special), 4);
+            uint64_t        mask = vget_lane_u64(vreinterpret_u64_u8(res), 0);
+            if (0 != mask) {
+                mask &= 0x8888888888888888ull;
+                return b + (OJ_CTZ64(mask) >> 2);
+            }
+            b += sizeof(uint8x16_t);
+        }
+    }
+#else
+    (void)end;
+#endif
+    for (; STR_OK == string_map[*b]; b++) {
+    }
+    return b;
+}
+
+static void parse(ojParser p, const byte *json, size_t len, bool more) {
     const byte *start;
-    const byte *b = json;
+    const byte *b   = json;
+    const byte *end = json + len;
     int         i;
 
     p->line = 1;
@@ -629,8 +685,7 @@ static void parse(ojParser p, const byte *json, bool more) {
             b++;
             p->key.tail = p->key.head;
             start       = b;
-            for (; STR_OK == string_map[*b]; b++) {
-            }
+            b           = oj_scan_str_simd(b, end);
             buf_append_string(&p->key, (const char *)start, b - start);
             if ('"' == *b) {
                 p->map = colon_map;
@@ -654,8 +709,7 @@ static void parse(ojParser p, const byte *json, bool more) {
             b++;
             start       = b;
             p->buf.tail = p->buf.head;
-            for (; STR_OK == string_map[*b]; b++) {
-            }
+            b           = oj_scan_str_simd(b, end);
             buf_append_string(&p->buf, (const char *)start, b - start);
             if ('"' == *b) {
                 p->cur = b - json;
@@ -905,8 +959,7 @@ static void parse(ojParser p, const byte *json, bool more) {
             break;
         case STR_OK:
             start = b;
-            for (; STR_OK == string_map[*b]; b++) {
-            }
+            b     = oj_scan_str_simd(b, end);
             if (':' == p->next_map[256]) {
                 buf_append_string(&p->key, (const char *)start, b - start);
             } else {
@@ -1419,7 +1472,7 @@ static VALUE parser_parse(VALUE self, VALUE json) {
 
     parser_reset(p);
     p->start(p);
-    parse(p, ptr, false);
+    parse(p, ptr, (size_t)RSTRING_LEN(json), false);
     validate_document_end(p);
 
     return p->result(p);
@@ -1440,7 +1493,7 @@ static VALUE load(VALUE self) {
     while (true) {
         rb_funcall(p->reader, oj_readpartial_id, 2, INT2NUM(16385), rbuf);
         if (0 < RSTRING_LEN(rbuf)) {
-            parse(p, (byte *)StringValuePtr(rbuf), true);
+            parse(p, (byte *)StringValuePtr(rbuf), (size_t)RSTRING_LEN(rbuf), true);
         }
         if (Qtrue == rb_funcall(p->reader, oj_eofq_id, 0)) {
             if (0 < p->depth) {
@@ -1510,7 +1563,7 @@ static VALUE parser_file(VALUE self, VALUE filename) {
     while (true) {
         if (0 < (rsize = read(fd, buf, size))) {
             buf[rsize] = '\0';
-            parse(p, buf, true);
+            parse(p, buf, rsize, true);
         }
         if (rsize <= 0) {
             if (0 != rsize) {


### PR DESCRIPTION
## Summary

The new `Oj::Parser` interface (`ext/oj/parser.c`) has no SIMD, while the older `Oj.load` parser (`parse.c`) and the dumper (`dump.c`) already ship mature NEON implementations.
This PR ports an equivalent NEON string scanner into `parser.c` so that reading string content is vectorized on ARM64 (Apple Silicon and other AArch64 targets).
The output is byte-for-byte identical to before; this is a pure performance change.

A new helper `oj_scan_str_simd(b, end)` replaces the three identical inner scan loops:

```c
for (; STR_OK == string_map[*b]; b++) {}
```

These are the key-string scan (`KEY_QUOTE`), the value-string scan (`VAL_QUOTE`), and the chunk-boundary re-entry scan (`STR_OK`).
The helper is a drop-in that returns the exact same stop position, so all surrounding logic (`buf_append_string`, escape handling, streaming, error paths) is untouched.

## Why the stop set is derived from `string_map`, not copied from `parse.c`

`parse.c`'s `string_scan_neon` stops on only three bytes: `\0`, `\`, and `"`.
`parser.c` is different: its `string_map` marks a byte as `STR_OK` only for `[0x20, 0x7F]` except `"` and `\`, and it hands every multi-byte UTF-8 byte to the state machine.
So the scanner here must additionally stop on all high bytes `0x80..0xFF`, in addition to control bytes `0x00..0x1F`, `"`, and `\`.
Copying `parse.c`'s predictor would have created a behavioral difference between the two parsers on unescaped control characters and multi-byte input.
The NEON predictor is therefore built directly from `string_map`:

```c
uint8x16_t special =
    vorrq_u8(vorrq_u8(vceqq_u8(chunk, quote), vceqq_u8(chunk, bslash)),
             vorrq_u8(vcltq_u8(chunk, space), vcgeq_u8(chunk, high)));
```

I verified this predictor matches `string_map[0..255]` byte-for-byte, at every position and alignment, over all 256 byte values (220,416 cases, 0 mismatches).

## Overread safety

`parse()` is NUL-terminated and previously had no length argument, so a 16-byte vector load near the terminator could read past the string's allocation.
`parse()` now takes a `size_t len`, and the three call sites pass `RSTRING_LEN(...)` / the read size.
The NEON path loads a full 16-byte vector only while `b + 16 <= end`, so it never reads past the allocation; the sub-16-byte tail (and the whole scan on non-NEON builds) falls back to the scalar loop, which stops at the guaranteed NUL terminator.
The scanner is guarded by `HAVE_SIMD_NEON` with a scalar fallback and is selected at runtime via `SIMD_Impl`.

## Benchmark

- OS: macOS Golden Gate 27.0 Beta
- CPU: Apple M1 Max
- Compiler: Apple clang version 21.0.0
- Ruby: 3.2.6

```ruby
require "benchmark/ips"
require "oj"
require "json"

srand(1)

# Random content that stays inside the fast-scan set (printable ASCII, no quote
# or backslash), so the scanner runs in long uninterrupted stretches.
def ascii(n)
  Array.new(n) { (0x20 + rand(0x5e)).chr }.join.gsub(/["\\]/, "x")
end

PAYLOADS = {
  "one_1MB_string" => '"' + ascii(1_000_000) + '"',
  "50x2KB_strings" => JSON.generate(Array.new(50) { ascii(2_000) }),
  "string_heavy"   => JSON.generate(Array.new(400) { ascii(200) }),
  "key_heavy"      => JSON.generate(Array.new(400) { h = {}; 12.times { |i| h["field_name_#{i}"] = i }; h }),
  "mixed"          => JSON.generate(Array.new(500) { { "id" => rand(1_000_000), "name" => ascii(rand(40)), "bio" => ascii(rand(120)), "tags" => Array.new(rand(6)) { ascii(8) } } }),
  "number_heavy"   => JSON.generate(Array.new(5_000) { rand < 0.5 ? rand(1_000_000) : rand * 1e6 }),
  "tiny_strings"   => JSON.generate(Array.new(2_000) { ascii(rand(6)) }),
  "utf8_heavy"     => JSON.generate(Array.new(400) { "あいうえお日本語" * rand(6) }),
}

PAYLOADS.each do |name, data|
  parser = Oj::Parser.new(:usual)
  Benchmark.ips do |x|
    x.config(warmup: 2, time: 5)
    x.report("#{name} (#{data.bytesize} B)") { parser.parse(data) }
  end
end
```

Results:

| case | before (i/s) | after (i/s) | speedup |
|------|--------------|-------------|---------|
| one 1MB string | 2.74 k | 9.82 k | 3.59x |
| 50 x 2KB strings | 23.59 k | 61.52 k | 2.61x |
| string-heavy (400 x 200B) | 20.88 k | 47.40 k | 2.27x |
| key-heavy (short keys) | 2.96 k | 3.14 k | 1.06x |
| mixed | 4.30 k | 4.57 k | 1.06x |
| number-heavy | 4.14 k | 4.13 k | 1.00x |
| tiny strings (< 6B) | 19.30 k | 19.27 k | 1.00x |
| utf8-heavy (dense CJK) | 13.25 k | 13.12 k | 0.99x |

Long runs of string content are where NEON helps; number-heavy, tiny-string, and dense multi-byte inputs are unchanged, i.e. no regression.
At the raw-scan level (no Ruby, no allocation) the scanner goes from 3.1 GB/s to 22.6 GB/s, a ~7x improvement.
Note that creating a fresh `Oj::Parser` inside the timed block rather than reusing one makes GC of the per-parser buffers dominate and hides the difference, so the benchmark reuses the parser, which is how it is meant to be used.

## Verification

- Byte-exact output: a corpus of 503 samples (empty/tiny strings, 15/16/17-byte boundaries, escapes straddling the 16-byte boundary, control characters, multi-byte UTF-8, emoji, deeply nested, large strings, many short keys, numbers) produces identical results before and after, through both the `parse(String)` and `file(path)` (streaming) code paths.
- Stop-set equivalence: NEON vs the `string_map` scalar loop match for all 256 byte values at every position and length (220,416 checks, 0 fails).
- Overread safety: the scanner runs clean under ASan/UBSan with exactly-sized `malloc(len + 1)` buffers, so any read at or past `end` would be caught (16,200 cases, 0 findings).
- Differential fuzzing against the standard library `JSON` parser: 600k+ boundary-biased random strings, 0 mismatches.
- The existing parser test suites pass (`test/test_parser_usual.rb`, `test/test_parser.rb`, `test/test_parser_safe.rb`).

## Notes

- NEON only; SSE/AVX for `parser.c` are out of scope.
- No changes to escape handling, number parsing, UTF-8 validation, the public API, or the output format; the diff is limited to `parser.c`.
