### PR TITLE
Add SWAR integer parsing to both JSON number parsers

### DIFF
--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -16,6 +16,7 @@
 #include "oj.h"
 #include "rxclass.h"
 #include "simd.h"
+#include "swar.h"
 #include "val_stack.h"
 
 // Workaround in case INFINITY is not defined in math.h or if the OS is CentOS
@@ -24,6 +25,12 @@
 // #define EXP_MAX		1023
 #define EXP_MAX 100000
 #define DEC_MAX 15
+
+// Largest ni.i for which applying one more SWAR 8-digit chunk (ni.i*1e8 + d8,
+// d8 <= 99999999) is guaranteed to stay within int64, so the fast path never
+// overflows and stays bit-identical to the scalar loop. Values beyond this are
+// left to the scalar loop, which detects big/overflow exactly as before.
+#define SWAR_LOAD_MAX (((int64_t)INT64_MAX - 99999999LL) / 100000000LL)
 
 static void next_non_white(ParseInfo pi) {
     for (; 1; pi->cur++) {
@@ -648,6 +655,12 @@ static void read_num(ParseInfo pi) {
             zero1 = true;
         }
 
+        // Fold eight in-range digits at a time while it stays within int64 and
+        // bit-identical to the scalar loop below; dec_cnt is kept in step. The
+        // scalar loop that follows handles the remaining digits and the big
+        // detection exactly as before.
+        pi->cur = (const char *)
+            oj_swar_accum((const uint8_t *)pi->cur, (const uint8_t *)pi->end, &ni.i, SWAR_LOAD_MAX, &dec_cnt);
         for (; '0' <= *pi->cur && *pi->cur <= '9'; pi->cur++) {
             int d = (*pi->cur - '0');
 

--- a/ext/oj/parser.c
+++ b/ext/oj/parser.c
@@ -6,6 +6,7 @@
 
 #include "oj.h"
 #include "simd.h"
+#include "swar.h"
 
 #define DEBUG 0
 
@@ -19,6 +20,12 @@
 // 9,223,372,036,854,775,807
 #define BIG_LIMIT LLONG_MAX / 10
 #define FRAC_LIMIT 10000000000000000ULL
+
+// Largest fixnum accumulator for which applying one more SWAR 8-digit chunk
+// (fixnum*1e8 + d8, d8 <= 99999999) is guaranteed to stay below BIG_LIMIT, so
+// the fast path never crosses the Fixnum/Bignum boundary and hands a value
+// bit-identical to the scalar loop to the following code.
+#define SWAR_INT_MAX (((uint64_t)(LLONG_MAX / 10) - 99999999ULL) / 100000000ULL)
 
 // Give better performance with indented JSON but worse with unindented.
 // #define SPACE_JUMP
@@ -649,6 +656,27 @@ static inline const byte *oj_scan_str_simd(const byte *b, const byte *end) {
     return b;
 }
 
+// Consume a run of integer digits into p->num.fixnum, folding whole 8-digit
+// chunks with SWAR first and letting the scalar tail cross into a Bignum via
+// big_change() at BIG_LIMIT. Returns b positioned at the last consumed digit;
+// the caller's state-machine loop performs the trailing b++ (this replaces the
+// b-- that each digit case used to do inline).
+static inline const byte *accum_digits(ojParser p, const byte *b, const byte *end) {
+    b = oj_swar_accum(b, end, &p->num.fixnum, SWAR_INT_MAX, NULL);
+    for (; NUM_DIGIT == digit_map[*b]; b++) {
+        uint64_t x = (uint64_t)p->num.fixnum * 10 + (uint64_t)(*b - '0');
+
+        if (x < BIG_LIMIT) {
+            p->num.fixnum = (int64_t)x;
+        } else {
+            big_change(p);
+            p->map = big_digit_map;
+            break;
+        }
+    }
+    return b - 1;
+}
+
 static void parse(ojParser p, const byte *json, size_t len, bool more) {
     const byte *start;
     const byte *b   = json;
@@ -815,36 +843,9 @@ static void parse(ojParser p, const byte *json, size_t len, bool more) {
             p->num.exp_neg = false;
             p->num.len     = 0;
             p->map         = digit_map;
-            for (; NUM_DIGIT == digit_map[*b]; b++) {
-                uint64_t x = (uint64_t)p->num.fixnum * 10 + (uint64_t)(*b - '0');
-
-                // Tried just checking for an int less than zero but that
-                // fails when optimization is on for some reason with the
-                // clang compiler so us a bit mask instead.
-                if (x < BIG_LIMIT) {
-                    p->num.fixnum = (int64_t)x;
-                } else {
-                    big_change(p);
-                    p->map = big_digit_map;
-                    break;
-                }
-            }
-            b--;
+            b              = accum_digits(p, b, end);
             break;
-        case NUM_DIGIT:
-            for (; NUM_DIGIT == digit_map[*b]; b++) {
-                uint64_t x = p->num.fixnum * 10 + (uint64_t)(*b - '0');
-
-                if (x < BIG_LIMIT) {
-                    p->num.fixnum = (int64_t)x;
-                } else {
-                    big_change(p);
-                    p->map = big_digit_map;
-                    break;
-                }
-            }
-            b--;
-            break;
+        case NUM_DIGIT: b = accum_digits(p, b, end); break;
         case NUM_DOT:
             p->type = OJ_DECIMAL;
             p->map  = dot_map;
@@ -871,18 +872,7 @@ static void parse(ojParser p, const byte *json, size_t len, bool more) {
             break;
         case NUM_ZERO: p->map = zero_map; break;
         case NEG_DIGIT:
-            for (; NUM_DIGIT == digit_map[*b]; b++) {
-                uint64_t x = p->num.fixnum * 10 + (uint64_t)(*b - '0');
-
-                if (x < BIG_LIMIT) {
-                    p->num.fixnum = (int64_t)x;
-                } else {
-                    big_change(p);
-                    p->map = big_digit_map;
-                    break;
-                }
-            }
-            b--;
+            b      = accum_digits(p, b, end);
             p->map = digit_map;
             break;
         case EXP_SIGN:

--- a/ext/oj/swar.h
+++ b/ext/oj/swar.h
@@ -1,0 +1,102 @@
+// Copyright (c) 2026 Peter Ohler. All rights reserved.
+// Licensed under the MIT License. See LICENSE file in the project root for license details.
+
+#ifndef OJ_SWAR_H
+#define OJ_SWAR_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+// SWAR (SIMD Within A Register) helpers for parsing eight consecutive ASCII
+// digits at a time using 64-bit integer math only (no vector intrinsics, so
+// this is architecture independent).
+//
+// oj_parse_8_digits() assumes little-endian lane order. is_8_digits() is a
+// per-byte test and is therefore endian independent. On big-endian targets we
+// disable the fast path entirely (OJ_SWAR_LE == 0) and callers fall back to the
+// existing scalar digit loops, which keeps behaviour identical everywhere.
+
+#if defined(__BYTE_ORDER__) && defined(__ORDER_BIG_ENDIAN__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define OJ_SWAR_LE 0
+#else
+#define OJ_SWAR_LE 1
+#endif
+
+// True when all four bytes of val are ASCII digits. Used as a cheap
+// entry prefilter: an eight-digit run is impossible unless the high four bytes
+// (offsets 4..7) are all digits, and for any run shorter than eight digits in a
+// dense array a delimiter always lands within those four bytes. Rejecting here
+// avoids the wider load and is_8_digits test for the common short-integer case,
+// keeping the non-firing fast path free of regression across all short lengths.
+static inline bool oj_is_4_digits(uint32_t val) {
+    return (((val & 0xF0F0F0F0u) | (((val + 0x06060606u) & 0xF0F0F0F0u) >> 4)) == 0x33333333u);
+}
+
+// True when all eight bytes of val (as loaded from memory) are ASCII digits
+// ('0'..'9'). Bytes adjacent to the digit range such as '/' (0x2F) and ':'
+// (0x3A) are correctly rejected.
+static inline bool oj_is_8_digits(uint64_t val) {
+    return (((val & 0xF0F0F0F0F0F0F0F0ULL) | (((val + 0x0606060606060606ULL) & 0xF0F0F0F0F0F0F0F0ULL) >> 4)) ==
+            0x3333333333333333ULL);
+}
+
+// Convert eight ASCII digit bytes (little-endian lane order, i.e. as produced
+// by memcpy from the input buffer) into the integer 0..99999999.
+static inline uint32_t oj_parse_8_digits(uint64_t val) {
+    const uint64_t mask = 0x000000FF000000FFULL;
+    const uint64_t mul1 = 0x000F424000000064ULL;  // 100 + (1000000 << 32)
+    const uint64_t mul2 = 0x0000271000000001ULL;  // 1 + (10000 << 32)
+
+    val -= 0x3030303030303030ULL;
+    val = (val * 10) + (val >> 8);
+    val = (((val & mask) * mul1) + (((val >> 16) & mask) * mul2)) >> 32;
+    return (uint32_t)val;
+}
+
+// Fold as many full eight-digit chunks as fit safely into *accum without the
+// accumulator reaching `limit`, so the result is bit-identical to a scalar
+// digit loop and never overflows past the caller's boundary (Fixnum/Bignum for
+// Oj::Parser, int64 for Oj.load); the caller passes the appropriate limit and
+// leaves the boundary/big handling to its own scalar loop. Advances and returns
+// the input pointer. When dec_cnt is non-NULL it is bumped by the number of
+// digits consumed after the first significant one (+8 per chunk, or +7 for the
+// first chunk that carries the first significant digit), matching Oj.load's
+// dec_cnt rule. Only fires on little-endian targets and never reads past end.
+static inline const uint8_t *
+oj_swar_accum(const uint8_t *b, const uint8_t *end, int64_t *accum, uint64_t limit, int *dec_cnt) {
+#if OJ_SWAR_LE
+    // Entry prefilter over the high four bytes: only engage SWAR when a long
+    // run is plausible (b[4..7] all digits). This rejects short integers of any
+    // length before the wider load, and the loop below stays free of per-chunk
+    // prefilter cost on long runs.
+    if (b + 8 <= end) {
+        uint32_t hi;
+
+        memcpy(&hi, b + 4, 4);
+        if (oj_is_4_digits(hi)) {
+            while (b + 8 <= end && (uint64_t)*accum < limit) {
+                uint64_t v;
+
+                memcpy(&v, b, 8);
+                if (!oj_is_8_digits(v)) {
+                    break;
+                }
+                if (NULL != dec_cnt) {
+                    *dec_cnt += (0 != *accum) ? 8 : 7;
+                }
+                *accum = *accum * 100000000LL + (int64_t)oj_parse_8_digits(v);
+                b += 8;
+            }
+        }
+    }
+#else
+    (void)end;
+    (void)accum;
+    (void)limit;
+    (void)dec_cnt;
+#endif
+    return b;
+}
+
+#endif /* OJ_SWAR_H */


### PR DESCRIPTION
## Summary

Both number parsers accumulate integer digits one byte at a time (`acc = acc * 10 + digit`): `Oj.load` in `read_num()` (`ext/oj/parse.c`) and `Oj::Parser` in the `parse()` state machine (`ext/oj/parser.c`).
This PR folds **eight in-range digits at a time** using SWAR (SIMD Within A Register) with 64-bit integer math only, so it is architecture independent (the same code runs on x86-64 and ARM64, no vector intrinsics and no `simd.h` involvement).
The output is byte-for-byte identical to before; long integer runs get faster, while the most common short integers (1-7 digits) see a small measured regression (about 3%) from the one probe per number that the fast path adds (quantified in Benchmark).

A new header `ext/oj/swar.h` holds the primitives and the shared accumulation loop, and both parsers call into the single implementation:

```c
const uint8_t *oj_swar_accum(const uint8_t *b, const uint8_t *end,
                             int64_t *accum, uint64_t limit, int *dec_cnt);
```

In `parser.c` this is wrapped once in a small `accum_digits()` helper that is reused by all three integer cases (`VAL_DIGIT`, `NUM_DIGIT`, `NEG_DIGIT`), which previously held three near-identical digit loops.

## How it works

`oj_swar_accum()` folds whole 8-digit chunks into the accumulator and hands everything else back to the caller's existing scalar digit loop, which keeps the boundary logic exactly as it was:

- `oj_parse_8_digits(v)` converts eight ASCII digit bytes to `0..99999999` using Lemire's technique ("Number parsing at a gigabyte per second").
- `oj_is_8_digits(v)` / `oj_is_4_digits(v)` reject any non-digit byte, so delimiters (`,` `]` `}`), `.`, `e`, whitespace, and the range-adjacent bytes `/` (0x2F) and `:` (0x3A) all end the run naturally.
- The magic constants are not copied blindly: `oj_parse_8_digits` was checked against all 10^8 eight-digit strings, and both digit predicates were checked over their whole input domains, before any wiring (see Verification).

## Why the output stays identical

SWAR only accelerates the safe interior of a digit run; the Fixnum/Bignum boundary, overflow, decimals, exponents, and sign are untouched and remain on the scalar path.

- The two parsers detect "too big" at different points, so each passes its own `limit` and stops before the accumulator could reach it: `Oj::Parser` converts to a Bignum **per digit** at `BIG_LIMIT` (`LLONG_MAX / 10`), while `Oj.load` decides **after the loop** via `INT64_MAX <= ni.i`. A chunk is only applied while `accum < limit`, so the value handed to the scalar loop is exactly what a pure scalar accumulation would have produced, and the scalar loop performs the `big_change` / overflow decision unchanged.
- `Oj.load`'s `dec_cnt` bookkeeping (significant-digit count for the `DEC_MAX` rule) is reproduced exactly: a chunk adds 8, or 7 for the first chunk that carries the first significant digit.
- Streaming re-entry in `Oj::Parser` (a number split across read chunks) is preserved: `accum` arrives as an arbitrary partial value and the `BIG_LIMIT`-derived limit is what keeps that path correct (this is why the two limits are genuinely different and not interchangeable).

## Overread safety

The 8-byte load is issued only while `b + 8 <= end` (`Oj::Parser` uses the `end` threaded through `parse()`; `Oj.load` uses `pi->end`), so it never reads past the buffer.
The sub-8-byte tail and the chunk-boundary re-entry fall back to the scalar loops, which stop at the guaranteed terminator.
`oj_parse_8_digits` assumes little-endian lane order, so the fast path is compiled only when `OJ_SWAR_LE` is set; big-endian targets keep the scalar path entirely.

## Keeping the short-integer cost small

SWAR never fires for runs under 8 digits, so short integers can only lose time, never gain it.
A naive "probe before every number" made that loss large: wiring the raw 8-byte load plus digit test in front of every number cost about 16% on arrays of 3-5 digit integers, which are the most common integer size in real JSON.
To shrink that, `oj_swar_accum()` uses a cheap 4-byte **entry prefilter**: it engages the SWAR loop only when `b[4..7]` are all digits, and for any run shorter than eight digits in a dense array a delimiter always lands within those four bytes, so short integers are rejected before the wider load and long runs pay no per-chunk prefilter cost.
This brings the short-integer cost down to a small but real regression (about 3%, see Benchmark): the fast path still pays one 4-byte probe per number even when SWAR does not fire, and that is the residual price for the 1.15-1.25x gains on long integers.

## Benchmark
- OS: Linux (x86-64)
- CPU: Intel Core Ultra 9 275HX
- Compiler: gcc 16.1.1
- Ruby: 4.0.5

```ruby
require "benchmark/ips"
require "oj"

srand(1)

def array_of(count)
  "[" + Array.new(count) { yield }.join(",") + "]"
end

PAYLOADS = {
  "int 3-digit"     => array_of(5_000) { rand(900).to_s },
  "int 5-digit"     => array_of(5_000) { rand(90_000).to_s },
  "int 7-digit"     => array_of(5_000) { rand(9_000_000).to_s },
  "int 10-digit id" => array_of(5_000) { (10**9 + rand(9 * 10**9)).to_s },
  "int 13-digit ms" => array_of(5_000) { (1_600_000_000_000 + rand(100_000_000_000)).to_s },
  "int 18-digit"    => array_of(5_000) { (10**17 + rand(9 * 10**17)).to_s },
  "string heavy"    => array_of(5_000) { %Q("s#{rand(100_000)}abcdef") },
}.freeze

PAYLOADS.each do |name, data|
  parser = Oj::Parser.new(:usual)

  Oj.load(data)
  parser.parse(data)

  Benchmark.ips do |x|
    x.config(warmup: 2, time: 5)
    x.report("Oj.load     #{name} (#{data.bytesize} B)") { Oj.load(data) }
    x.report("Oj::Parser  #{name} (#{data.bytesize} B)") { parser.parse(data) }
  end
end
```

The numbers below are the **mean of 12 alternating runs** of each build, not a best-of (a best-of rewards the noisier build); the per-run coefficient of variation is 1-2%, and base/after are alternated per repetition to cancel drift and CPU-frequency ordering effects.
The `string heavy` row is a control that SWAR never touches: it stays at 1.00x (Welch p = 0.97), which sets the noise floor, so the differences below are real, not noise.

`Oj::Parser` (`parser.c`):

| payload | before (i/s) | after (i/s) | speedup |
|---------|-------------:|------------:|:-------:|
| int 3-digit | 33.6 k | 32.9 k | 0.98x |
| int 5-digit | 30.1 k | 29.2 k | 0.97x |
| int 7-digit | 30.2 k | 29.3 k | 0.97x |
| int 10-digit ids | 28.8 k | 36.0 k | 1.25x |
| int 13-digit ms timestamps | 24.7 k | 28.3 k | 1.15x |
| int 18-digit | 8.88 k | 11.0 k | 1.24x |
| string heavy (control) | 9.01 k | 9.01 k | 1.00x |

`Oj.load` (`parse.c`):

| payload | before (i/s) | after (i/s) | speedup |
|---------|-------------:|------------:|:-------:|
| int 3-digit | 12.3 k | 11.9 k | 0.97x |
| int 5-digit | 11.9 k | 11.5 k | 0.97x |
| int 7-digit | 11.4 k | 11.1 k | 0.97x |
| int 10-digit ids | 11.5 k | 12.3 k | 1.07x |
| int 13-digit ms timestamps | 11.0 k | 11.5 k | 1.04x |
| int 18-digit | 4.76 k | 4.85 k | 1.02x |
| string heavy (control) | 7.55 k | 7.58 k | 1.00x |

SWAR helps once a number has a run of 8 or more digits: `Oj::Parser` gains 1.15-1.25x on 10-18 digit integers (millisecond timestamps, large ids, integer matrices), and `Oj.load` gains 1.02-1.07x (it gains less because constructing the Ruby value dominates its per-number cost).
The trade is a small but real ~3% regression on 1-7 digit integers on both parsers (statistically significant here, p < 0.001, not noise): SWAR cannot fire on those runs, so the one 4-byte probe per number is pure overhead there.
Floats and strings never reach the integer path and are unaffected.
Whether this is a good trade depends on the workload: payloads rich in long integers benefit clearly, while payloads dominated by small integers pay a few percent; re-running the script on your target hardware is the best way to judge (SWAR's dependency-breaking gain shows only at turbo clocks, so a CPU pinned to a low fixed frequency will understate it).

## Verification

- **Exhaustive primitives**: `oj_parse_8_digits` matches the expected integer for all 10^8 eight-digit strings (0 mismatches); `oj_is_8_digits` and `oj_is_4_digits` produce 0 false positives / false negatives over all 2^32 (4-byte) and full-domain (8-byte) checks.
- **Byte-exact output**: a boundary corpus (every digit length 1-30, Fixnum/Bignum and int64-overflow boundaries, 8k / 8k+-1 lengths, negatives, decimals with long fraction runs, exponents, mixed arrays) produces identical Ruby values before and after, for both `Oj.load` and `Oj::Parser`.
- **Differential fuzzing**: 2,000,000 random values (integers up to 26 digits, long-fraction decimals, exponents) produce an identical fingerprint (class + exact value / float bit pattern) between the prior build and this one, on both parsers and through both the string and IO/streaming paths.
- **Overread safety**: clean under ASan/UBSan with exactly-sized buffers and at buffer / chunk boundaries, so any read at or past `end` would be caught. The only UBSan output is the pre-existing intentional signed overflow of the scalar big-number accumulator (identical on the base build).
- The existing parser and load test suites pass.

## Notes

- Decimal fraction runs are intentionally left on the scalar path: `Oj::Parser`'s `FRAC_LIMIT` caps a fraction to about one SWAR chunk, so the payoff did not justify the extra `shift` bookkeeping.
- Little-endian only; big-endian falls back to the existing scalar loops.
- No changes to the Fixnum/Bignum boundary, overflow, decimal, exponent, or sign logic, nor to the public API or output format; the diff is limited to `parse.c`, `parser.c`, and the new `swar.h`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
