### PR TITLE
Fix memory leak in Oj::Doc.open and Oj::Doc.open_file

### DIFF
--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -790,14 +790,11 @@ static VALUE parse_json(VALUE clas, char *json, bool given) {
     doc->self = self;
     result    = rb_protect(protect_open_proc, (VALUE)&pi, &ex);
     if (given || 0 != ex) {
+        // The doc is detached from its wrapper so the GC will not free it.
+        // doc_free() releases both the doc and its json buffer (doc->json), so
+        // the caller must not free json separately.
         DATA_PTR(doc->self) = NULL;
-        // TBD is this needed?
-        /*
         doc_free(pi.doc);
-        if (0 != ex) {  // will jump so caller will not free
-            OJ_R_FREE(json);
-        }
-        */
     } else {
         result = doc->self;
     }
@@ -1105,12 +1102,7 @@ static VALUE doc_open(VALUE clas, VALUE str) {
 
     memcpy(json, StringValuePtr(str), len);
     obj = parse_json(clas, json, given);
-    // TBD is this needed
-    /*
-    if (given) {
-        OJ_R_FREE(json);
-    }
-    */
+    // json is owned by the doc and freed by doc_free(); do not free it here.
     return obj;
 }
 
@@ -1160,12 +1152,7 @@ static VALUE doc_open_file(VALUE clas, VALUE filename) {
     fclose(f);
     json[len] = '\0';
     obj       = parse_json(clas, json, given);
-    // TBD is this needed
-    /*
-    if (given) {
-        OJ_R_FREE(json);
-    }
-    */
+    // json is owned by the doc and freed by doc_free(); do not free it here.
     return obj;
 }
 


### PR DESCRIPTION
## Problem

`Oj::Doc.open` and `Oj::Doc.open_file` leak memory on every call when a block is given (the common form, e.g. `Oj::Doc.open(json) { |doc| ... }`).

In `parse_json` (ext/oj/fast.c) the parsed document is wrapped in a Ruby object and, once the block returns, the doc is detached from that wrapper with `DATA_PTR(doc->self) = NULL` so the GC will not free it. The matching manual free was left commented out with a `TBD is this needed?` note, so nothing ever frees the `struct _doc` or the copied JSON buffer it owns (`doc->json`). The two callers `doc_open` / `doc_open_file` also had their `OJ_R_FREE(json)` commented out, so the buffer had no owner at all.

The leak is O(n) in the number of calls. Confirmed under Valgrind with a tiny input:

```ruby
require 'oj'
n = Integer(ARGV[0] || 100)
n.times { Oj::Doc.open('[1,2,3]') { |doc| doc.size } }
```

```
Before:  N=100  -> 100 blocks,   407,200 bytes definitely lost
         N=1000 -> 1000 blocks, 4,072,000 bytes definitely lost   (≈4,072 bytes per call)
After:   no doc/json blocks lost at any N (total lost is constant interpreter startup noise)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
