### PR TITLE
Add Valgrind memcheck (ruby_memcheck) for the C extension

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :development do
   gem 'rubocop', '~> 1.47', require: false
   gem 'rubocop-minitest', '~> 0.28.0', require: false
   gem 'test-unit', '~> 3.0'
+  gem 'ruby_memcheck', '~> 3.0' if RUBY_PLATFORM.include?('linux')
 end

--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,11 @@ if RUBY_PLATFORM.include?('linux')
       binary_name: 'oj',
       # Valgrind and YJIT interfere with each other, adding noise and slowdown,
       # so keep YJIT disabled while running under Valgrind.
-      ruby: "#{FileUtils::RUBY} --disable-yjit"
+      ruby: "#{FileUtils::RUBY} --disable-yjit",
+      # Keep the suppression file under test/ (it is only used by this task and
+      # is not part of the packaged gem). ruby_memcheck still loads its own
+      # bundled interpreter suppressions in addition to this directory.
+      valgrind_suppressions_dir: 'test/valgrind'
     )
 
     # ruby_memcheck runs every listed file in a single process. Only the files

--- a/Rakefile
+++ b/Rakefile
@@ -9,6 +9,48 @@ Rake::ExtensionTask.new('oj') do |ext|
   ext.lib_dir = 'lib/oj'
 end
 
+if RUBY_PLATFORM.include?('linux')
+  begin
+    require 'ruby_memcheck'
+
+    RubyMemcheck.config(
+      binary_name: 'oj',
+      # Valgrind and YJIT interfere with each other, adding noise and slowdown,
+      # so keep YJIT disabled while running under Valgrind.
+      ruby: "#{FileUtils::RUBY} --disable-yjit"
+    )
+
+    # ruby_memcheck runs every listed file in a single process. Only the files
+    # that test/tests.rb loads are known to coexist that way; the other
+    # test_*.rb files mutate global state (Oj.default_options, mimic_JSON, ...)
+    # or fork, and upstream runs those in their own processes. Mirror the
+    # tests.rb set here, minus test_scp which forks and talks over a socket.
+    memcheck_test_files = %w[
+      test_compat test_custom test_fast test_file test_gc test_hash
+      test_integer_range test_long_strings test_max_integer_digits test_null
+      test_object test_rails test_saj test_strict test_wab test_writer
+    ].map { |name| "test/#{name}.rb" }
+
+    namespace :test do
+      task :check_valgrind do
+        unless system('command -v valgrind > /dev/null 2>&1')
+          abort("\nValgrind is required for `rake test:valgrind` but was not found.\n" \
+                "Install it first (Linux only), e.g. `sudo apt-get install valgrind`.\n")
+        end
+      end
+
+      RubyMemcheck::TestTask.new(valgrind: [:check_valgrind, :compile]) do |t|
+        t.libs << 'test'
+        t.test_files = memcheck_test_files
+        t.verbose    = true
+      end
+    end
+  rescue LoadError
+    # ruby_memcheck is an optional, Linux-only development dependency. If it is
+    # not installed just skip defining the task instead of breaking the Rakefile.
+  end
+end
+
 =begin
 Rake::TestTask.new(:test) do |test|
   test.libs << 'test'

--- a/test/valgrind/ruby.supp
+++ b/test/valgrind/ruby.supp
@@ -1,0 +1,32 @@
+# Valgrind suppressions for `rake test:valgrind` (ruby_memcheck).
+#
+# The file name is dictated by ruby_memcheck, which only loads suppression files
+# named after the Ruby engine/version (ruby.supp applies to all MRI versions);
+# the directory is set via valgrind_suppressions_dir in the Rakefile.
+#
+# These stanzas silence memcheck reports that are false positives for the oj
+# extension: allocations that live for the lifetime of a process-global cache
+# and are intentionally never freed (the OS reclaims them at exit). They were
+# each verified to be bounded — re-parsing the same input does not grow them —
+# so suppressing them does not hide a real, growing leak. Every stanza is scoped
+# to a single oj function so unrelated reports are not swallowed.
+#
+# NOTE: this file deliberately does NOT suppress the Oj::Doc (fast.c) allocation
+# reported by the memcheck run. That one reproduces as an O(n) growing leak and
+# is tracked separately as a real bug.
+
+{
+   oj: process-lifetime string intern cache (lockless_intern, cache.c)
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect
+   ...
+   fun:lockless_intern
+}
+
+{
+   oj: process-lifetime string intern cache (locking_intern, cache.c)
+   Memcheck:Leak
+   match-leak-kinds: definite,indirect
+   ...
+   fun:locking_intern
+}


### PR DESCRIPTION
## Summary

This adds [Shopify's `ruby_memcheck`](https://github.com/Shopify/ruby_memcheck) so the test suite can be run under Valgrind's memcheck and surface memory errors and leaks in the C extension. `ruby_memcheck` wraps Valgrind and applies a heuristic that filters out the large volume of false positives the Ruby interpreter itself produces, reporting only errors whose stack trace passes through the extension's `.so`. It is the same tool Shopify runs on nokogiri and liquid-c.

The task layout mirrors [rmagick/rmagick#1716](https://github.com/rmagick/rmagick/pull/1716) (Linux-only guard, `valgrind: :compile` prerequisite, dependency added with a platform guard), adapted from that PR's RSpec task to oj's minitest suite: the task is `rake test:valgrind` under a `namespace :test` instead of `spec:valgrind`.

## What is in this PR

- `ruby_memcheck` is added as a **Linux-only** development dependency in the `Gemfile`. Valgrind is not usable in practice on macOS or Windows, and the `RUBY_PLATFORM.include?('linux')` guard keeps `bundle install` working there.
- A `rake test:valgrind` task (Rakefile). It disables YJIT under Valgrind (they interfere, adding noise and slowdown), fails early with a clear message when Valgrind is not installed, and excludes the handful of tests that either fork / use sockets or irreversibly switch Oj into JSON-mimic mode, because `ruby_memcheck` runs every listed file in a single process.
- A narrow Valgrind suppression file (`test/valgrind/ruby.supp`) for oj's process-lifetime string-intern cache (see triage below). It lives under `test/` so it stays with the tests and out of the packaged gem; the `ruby.supp` file name is dictated by ruby_memcheck's suppression loader (it only reads files named after the Ruby engine/version), and the directory is set via `valgrind_suppressions_dir` in the Rakefile.

## Triage of the reported errors

The memcheck run reports **12** distinct allocations whose stack passes through the oj extension. Each was triaged into one of three buckets; the classifications for the caches and options paths were confirmed with standalone Valgrind reproductions that vary the iteration count, to tell a genuinely growing leak apart from a one-time or process-lifetime allocation.

### 1. Genuine leak — surfaced here, fixed in #1027 (1 underlying bug, 2 records)

`Oj::Doc.open` and `Oj::Doc.open_file` (the "fast" parser) leak. In `doc_open` / `doc_open_file` (fast.c) the copied JSON buffer is never freed — the `OJ_R_FREE(json)` is literally commented out with a `TBD is this needed` note — and the `struct _doc` allocated in `parse_json` (fast.c:762) goes with it. This reproduces as a clean O(n) leak:

```ruby
require 'oj'
n = Integer(ARGV[0] || 100)
n.times { Oj::Doc.open('[1,2,3]') { |doc| doc.size } }
```

```
N=100   -> 100 blocks,   407,200 bytes definitely lost
N=1000  -> 1000 blocks, 4,072,000 bytes definitely lost   (≈4,072 bytes per call)
```

This is fixed separately in #1027, kept out of this PR so the tooling change and the behavior change stay independent — but it is the leak that this tooling surfaced. The 12-record count above is what the run reports on `develop` before that fix lands.

### 2. Intentional process-lifetime cache — suppressed (3 records)

`cache.c` `lockless_intern` / `locking_intern` are oj's string-intern cache. Those slots are kept for the whole process lifetime by design and reclaimed by the OS at exit; re-parsing the same input does not grow them (verified: repeated identical keys plus a GC leak nothing). These are classic false positives, so they are silenced with two narrow, per-function stanzas in `test/valgrind/ruby.supp`. The suppression file deliberately does **not** cover the `Oj::Doc` allocation above.

### 3. Benign, recorded only — not a growing leak (7 records)

- `parse_options_cb` (oj.c) — 5 records, a few bytes each (8/11/16/36/51 bytes) for string/array options (`create_id`, `ignore`, `only`, `except`) that end up on the process-global default-options struct. Verified bounded: a loop of 50 vs 500 `Oj.load(json, create_id: ...)` calls leaves the same single block, i.e. it does not grow per call.
- `parser_safe` (parser.c:1688) — 1 record, the parser structs that a few tests keep alive until process exit. Verified: creating parsers and letting them go out of scope leaks nothing, so this is alive-at-exit noise, not a leak.
- `str_dup` via `opt_create_id_set` / `parser_missing` (usual.c) — 1 record, 2 bytes, the `create_id` string held by a live `Oj::Parser`.

These were left unsuppressed on purpose: they pass through multi-purpose functions where a blanket suppression could hide a future real leak, and they are small and bounded. They are documented here instead.

## Limitations of this tooling

`ruby_memcheck` is a **regression net, not an audit**. Its heuristic only surfaces errors whose stack trace passes through the extension's `.so`, so a report count of zero does not mean the extension is free of memory bugs — anything that manifests purely inside Ruby frames, or that never trips Valgrind's checks on the exercised inputs, will not show up. It is also only as good as the test suite's coverage. This is complementary to, not a replacement for, ASan/UBSan builds, fuzzing, or manual review. Its value is catching regressions in code paths the tests already exercise.

Note also that, once the `Oj::Doc` leak fix (#1027) lands, the only remaining oj-attributed reports are the bucket-3 records, which are benign but left unsuppressed, so the task still exits non-zero. Whether to formalize suppressions for those is left to the maintainers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
