### PR TITLE
Fix per-call memory leaks and default corruption in option handling

### DIFF
--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -921,6 +921,9 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
 
             len = RSTRING_LEN(v);
             if (len != copts->create_id_len || 0 != strcmp(copts->create_id, str)) {
+                if (&oj_default_options == copts && oj_json_class != copts->create_id) {
+                    OJ_R_FREE((char *)copts->create_id);
+                }
                 copts->create_id = OJ_R_ALLOC_N(char, len + 1);
                 strcpy((char *)copts->create_id, str);
                 copts->create_id_len = len;
@@ -1052,7 +1055,11 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
             copts->array_class = v;
         }
     } else if (ignore_sym == k) {
-        OJ_R_FREE(copts->ignore);
+        // Only free when replacing the defaults; a per-call copy's ignore still
+        // aliases the default-owned buffer, which oj_free_call_options() frees.
+        if (&oj_default_options == copts) {
+            OJ_R_FREE(copts->ignore);
+        }
         copts->ignore = NULL;
         if (Qnil != v) {
             size_t cnt;
@@ -1125,15 +1132,15 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
         strncpy(copts->float_fmt, RSTRING_PTR(v), (size_t)RSTRING_LEN(v));
         copts->float_fmt[RSTRING_LEN(v)] = '\0';
     } else if (only_sym == k) {
-        if (NULL != copts->dump_opts.only) {
+        // Only free when replacing the defaults; a per-call copy's pointer still
+        // aliases the default-owned buffer, which oj_free_call_options() frees.
+        if (&oj_default_options == copts && NULL != copts->dump_opts.only) {
             OJ_R_FREE((void *)copts->dump_opts.only);
-            copts->dump_opts.only = NULL;
         }
         copts->dump_opts.only = make_only_value(v);
     } else if (except_sym == k) {
-        if (NULL != copts->dump_opts.except) {
+        if (&oj_default_options == copts && NULL != copts->dump_opts.except) {
             OJ_R_FREE((void *)copts->dump_opts.except);
-            copts->dump_opts.except = NULL;
         }
         copts->dump_opts.except = make_only_value(v);
     }
@@ -1151,6 +1158,31 @@ void oj_parse_options(VALUE ropts, Options copts) {
                             0 < copts->dump_opts.before_size || 0 < copts->dump_opts.hash_size ||
                             0 < copts->dump_opts.array_size);
     return;
+}
+
+// Free the option buffers that oj_parse_options() allocated for a single call.
+// A per-call options struct is a copy of oj_default_options, so its create_id,
+// ignore, only, and except members initially alias the ones owned by the
+// defaults. Only free a member when it differs from the default, i.e. when it
+// was allocated for this call; the default-owned buffers must be left alone.
+void oj_free_call_options(Options copts) {
+    if (NULL != copts->create_id && oj_default_options.create_id != copts->create_id) {
+        OJ_R_FREE((char *)copts->create_id);
+        copts->create_id     = NULL;
+        copts->create_id_len = 0;
+    }
+    if (NULL != copts->ignore && oj_default_options.ignore != copts->ignore) {
+        OJ_R_FREE(copts->ignore);
+        copts->ignore = NULL;
+    }
+    if (NULL != copts->dump_opts.only && oj_default_options.dump_opts.only != copts->dump_opts.only) {
+        OJ_R_FREE((void *)copts->dump_opts.only);
+        copts->dump_opts.only = NULL;
+    }
+    if (NULL != copts->dump_opts.except && oj_default_options.dump_opts.except != copts->dump_opts.except) {
+        OJ_R_FREE((void *)copts->dump_opts.except);
+        copts->dump_opts.except = NULL;
+    }
 }
 
 static int match_string_cb(VALUE key, VALUE value, VALUE rx) {
@@ -1444,6 +1476,7 @@ static VALUE dump_ensure(VALUE a) {
     volatile struct dump_arg *arg = (void *)a;
 
     oj_out_free(arg->out);
+    oj_free_call_options(arg->copts);
 
     return Qnil;
 }
@@ -1559,6 +1592,7 @@ static VALUE to_file(int argc, VALUE *argv, VALUE self) {
         oj_parse_options(argv[2], &copts);
     }
     oj_write_obj_to_file(argv[1], StringValuePtr(*argv), &copts);
+    oj_free_call_options(&copts);
 
     return Qnil;
 }
@@ -1580,6 +1614,7 @@ static VALUE to_stream(int argc, VALUE *argv, VALUE self) {
         oj_parse_options(argv[2], &copts);
     }
     oj_write_obj_to_stream(argv[1], *argv, &copts);
+    oj_free_call_options(&copts);
 
     return Qnil;
 }

--- a/ext/oj/oj.h
+++ b/ext/oj/oj.h
@@ -256,6 +256,7 @@ extern VALUE oj_custom_parse_cstr(int argc, VALUE *argv, char *json, size_t len)
 
 extern bool oj_hash_has_key(VALUE hash, VALUE key);
 extern void oj_parse_options(VALUE ropts, Options copts);
+extern void oj_free_call_options(Options copts);
 
 extern void  oj_dump_obj_to_json(VALUE obj, Options copts, Out out);
 extern void  oj_dump_obj_to_json_using_params(VALUE obj, Options copts, Out out, int argc, VALUE *argv);

--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -1309,6 +1309,7 @@ CLEANUP:
     if (pi->str_rx.head != oj_default_options.str_rx.head) {
         oj_rxclass_cleanup(&pi->str_rx);
     }
+    oj_free_call_options(&pi->options);
     if (err_has(&pi->err)) {
         rb_set_errinfo(Qnil);
         if (Qnil != pi->err_class) {

--- a/ext/oj/sparse.c
+++ b/ext/oj/sparse.c
@@ -907,6 +907,7 @@ CLEANUP:
         oj_circ_array_free(pi->circ_array);
     }
     stack_cleanup(&pi->stack);
+    oj_free_call_options(&pi->options);
     if (0 != fd) {
 #ifdef _WIN32
         rb_w32_close(fd);


### PR DESCRIPTION
## Problem

Passing `create_id`, `ignore`, `only`, or `except` to `Oj.load` / `Oj.dump` leaks memory on every call, and changing `Oj.default_options[:create_id]` leaks the previous default string.

A per-call options struct is a by-value copy of `oj_default_options`, so `oj_parse_options` allocates a fresh heap buffer for these options into that copy — and nothing ever frees it. The default `create_id` is likewise replaced without freeing the old one. The leak is O(n) in the number of calls. Every one of the following call forms leaks one block per iteration:

```ruby
require 'oj'
class Foo; def initialize; @a = 1; end; end
n = Integer(ARGV[0] || 100)

n.times { Oj.load('{"a":1}', mode: :compat, create_id: 'c') }   # create_id
n.times { Oj.dump(Foo.new, mode: :object, ignore: [String]) }   # ignore
n.times { Oj.dump({'a'=>1,'b'=>2}, only: ['a']) }               # only
n.times { Oj.dump({'a'=>1,'b'=>2}, except: ['b']) }             # except
n.times { |i| Oj.default_options = { create_id: "c#{i}" } }     # default create_id
```

Confirmed under Valgrind (`--leak-check=full --show-leak-kinds=definite`), each vector run on its own:

```
Before:  N=50  -> ~50 blocks definitely lost,   N=500 -> ~500 blocks definitely lost   (per vector)
After:   no create_id / ignore / only / except blocks lost at any N
```

There is also a **use-after-free** for `only` / `except` / `ignore`: because the per-call copy's pointer still aliases the default-owned buffer, `parse_options_cb` frees the default's buffer, and the reused address then reads back as the "new" default value — silently mutating `Oj.default_options`:

```ruby
Oj.default_options = { only: ['a'] }
Oj.dump({'a'=>1,'b'=>2}, only: ['x'])
Oj.default_options[:only]   # before this fix: [:x]  (corrupted); after: [:a]
```

## Fix

- Add `oj_free_call_options()` which frees the `create_id` / `ignore` / `only` / `except` buffers that a single call allocated. It only frees a member when it differs from the corresponding `oj_default_options` member, so default-owned buffers are left untouched. It is called where per-call options go out of scope: the parse cleanup (`oj_pi_parse` and `oj_pi_sparse`, next to the existing `str_rx` cleanup), `dump_ensure`, and `to_file` / `to_stream`.
- Guard the `ignore` / `only` / `except` frees in `parse_options_cb` so they only run when replacing the defaults (`copts == &oj_default_options`); a per-call copy must not free the default-owned buffer.
- Free the previous default `create_id` before replacing it (default path only; a per-call copy aliases it and is handled by `oj_free_call_options()`).

## Verification

- Under Valgrind the leaks are gone: per-call `create_id` / `ignore` / `only` / `except` and repeated `Oj.default_options = { create_id: ... }` all show no growth from N=50 to N=500.
- A stress test that sets defaults for all four options and then mixes per-call overrides with non-overrides, re-sets the defaults repeatedly, and clears them shows no `Invalid read/write`, no double free, and the defaults are preserved (the use-after-free above is fixed).
- `test/tests.rb` passes (472 runs, 0 failures, 0 errors).
- `clang-format` reports no changes for the edited files.

## Notes

The same per-call allocation pattern also reaches the string/stream writers (`Oj::StringWriter` / `Oj::StreamWriter`) and the rails encoder, where the options live with a longer-lived object. Those are lower frequency and have a different lifecycle, so they are left for a follow-up rather than mixed into this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
