### PR TITLE
Fix option buffer leaks in the writers and the Rails encoder

### DIFF
--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -1185,6 +1185,85 @@ void oj_free_call_options(Options copts) {
     }
 }
 
+static char *dup_option_str(const char *str, size_t len) {
+    char *buf = OJ_R_ALLOC_N(char, len + 1);
+
+    memcpy(buf, str, len);
+    buf[len] = '\0';
+
+    return buf;
+}
+
+// Give an options struct private copies of the option buffers it still shares
+// with the defaults so that it owns all of them.
+//
+// An options struct that outlives the call it was created in can not rely on
+// the default-owned buffers it aliases: Oj.default_options= is free to replace
+// them at any time, which would leave the alias dangling. Call this once, in
+// the call that creates such an object and after oj_parse_options(), then free
+// the buffers with oj_options_release() when the object is collected.
+void oj_options_take_ownership(Options copts) {
+    if (NULL != copts->create_id && oj_default_options.create_id == copts->create_id) {
+        copts->create_id = dup_option_str(copts->create_id, copts->create_id_len);
+    }
+    if (NULL != copts->ignore && oj_default_options.ignore == copts->ignore) {
+        VALUE *vp;
+        VALUE *buf;
+        size_t cnt = 0;
+
+        for (vp = copts->ignore; Qnil != *vp; vp++) {
+            cnt++;
+        }
+        buf = OJ_R_ALLOC_N(VALUE, cnt + 1);
+        memcpy(buf, copts->ignore, sizeof(VALUE) * (cnt + 1));
+        copts->ignore = buf;
+    }
+    if (NULL != copts->dump_opts.only && oj_default_options.dump_opts.only == copts->dump_opts.only) {
+        copts->dump_opts.only = dup_option_str(copts->dump_opts.only, strlen(copts->dump_opts.only));
+    }
+    if (NULL != copts->dump_opts.except && oj_default_options.dump_opts.except == copts->dump_opts.except) {
+        copts->dump_opts.except = dup_option_str(copts->dump_opts.except, strlen(copts->dump_opts.except));
+    }
+}
+
+// Free the option buffers of an options struct that owns all of them, i.e. one
+// that oj_options_take_ownership() was called on. Unlike oj_free_call_options()
+// this never looks at the defaults, so it is safe to call from a GC free
+// function, where the defaults may have been replaced since the object was
+// created.
+void oj_options_release(Options copts) {
+    if (NULL != copts->create_id) {
+        OJ_R_FREE((char *)copts->create_id);
+        copts->create_id     = NULL;
+        copts->create_id_len = 0;
+    }
+    if (NULL != copts->ignore) {
+        OJ_R_FREE(copts->ignore);
+        copts->ignore = NULL;
+    }
+    if (NULL != copts->dump_opts.only) {
+        OJ_R_FREE((void *)copts->dump_opts.only);
+        copts->dump_opts.only = NULL;
+    }
+    if (NULL != copts->dump_opts.except) {
+        OJ_R_FREE((void *)copts->dump_opts.except);
+        copts->dump_opts.except = NULL;
+    }
+}
+
+// Mark the Ruby objects held by an owned options struct. The ignore member is a
+// private array of classes that is not reachable from anywhere else, so without
+// this the classes could be collected while the owner is still alive.
+void oj_options_mark(Options copts) {
+    if (NULL != copts->ignore) {
+        VALUE *vp;
+
+        for (vp = copts->ignore; Qnil != *vp; vp++) {
+            rb_gc_mark(*vp);
+        }
+    }
+}
+
 static int match_string_cb(VALUE key, VALUE value, VALUE rx) {
     RxClass rc = (RxClass)rx;
 

--- a/ext/oj/oj.h
+++ b/ext/oj/oj.h
@@ -257,6 +257,9 @@ extern VALUE oj_custom_parse_cstr(int argc, VALUE *argv, char *json, size_t len)
 extern bool oj_hash_has_key(VALUE hash, VALUE key);
 extern void oj_parse_options(VALUE ropts, Options copts);
 extern void oj_free_call_options(Options copts);
+extern void oj_options_take_ownership(Options copts);
+extern void oj_options_release(Options copts);
+extern void oj_options_mark(Options copts);
 
 extern void  oj_dump_obj_to_json(VALUE obj, Options copts, Out out);
 extern void  oj_dump_obj_to_json_using_params(VALUE obj, Options copts, Out out, int argc, VALUE *argv);

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -623,6 +623,7 @@ static void encoder_free(void *ptr) {
     if (NULL != ptr) {
         Encoder e = (Encoder)ptr;
 
+        oj_options_release(&e->opts);
         if (NULL != e->ropts.table) {
             OJ_R_FREE(e->ropts.table);
         }
@@ -634,6 +635,7 @@ static void encoder_mark(void *ptr) {
     if (NULL != ptr) {
         Encoder e = (Encoder)ptr;
 
+        oj_options_mark(&e->opts);
         if (Qnil != e->arg) {
             rb_gc_mark(e->arg);
         }
@@ -669,6 +671,7 @@ static VALUE encoder_new(int argc, VALUE *argv, VALUE self) {
         e->arg = rb_hash_new();
     }
     oj_parse_options(e->arg, &e->opts);
+    oj_options_take_ownership(&e->opts);
 
     return TypedData_Wrap_Struct(encoder_class, &oj_encoder_type, e);
 }

--- a/ext/oj/stream_writer.c
+++ b/ext/oj/stream_writer.c
@@ -16,15 +16,22 @@ static void stream_writer_free(void *ptr) {
         return;
     }
     sw = (StreamWriter)ptr;
+    oj_options_release(&sw->sw.opts);
     OJ_R_FREE(sw->sw.out.buf);
     OJ_R_FREE(sw->sw.types);
     OJ_R_FREE(ptr);
 }
 
+static void stream_writer_mark(void *ptr) {
+    if (NULL != ptr) {
+        oj_options_mark(&((StreamWriter)ptr)->sw.opts);
+    }
+}
+
 static const rb_data_type_t oj_stream_writer_type = {
     "Oj/stream_writer",
     {
-        NULL,
+        stream_writer_mark,
         stream_writer_free,
         NULL,
     },
@@ -116,6 +123,7 @@ static VALUE stream_writer_new(int argc, VALUE *argv, VALUE self) {
         oj_str_writer_init(&sw->sw, 4096);
         sw->flush_limit = 0;
     }
+    oj_options_take_ownership(&sw->sw.opts);
     sw->sw.out.indent = sw->sw.opts.indent;
     sw->stream        = stream;
     sw->type          = type;

--- a/ext/oj/string_writer.c
+++ b/ext/oj/string_writer.c
@@ -234,15 +234,22 @@ static void string_writer_free(void *ptr) {
     sw = (StrWriter)ptr;
 
     oj_out_free(&sw->out);
+    oj_options_release(&sw->opts);
 
     OJ_R_FREE(sw->types);
     OJ_R_FREE(ptr);
 }
 
+static void string_writer_mark(void *ptr) {
+    if (NULL != ptr) {
+        oj_options_mark(&((StrWriter)ptr)->opts);
+    }
+}
+
 static const rb_data_type_t oj_string_writer_type = {
     "Oj/string_writer",
     {
-        NULL,
+        string_writer_mark,
         string_writer_free,
         NULL,
     },
@@ -279,6 +286,7 @@ static VALUE str_writer_new(int argc, VALUE *argv, VALUE self) {
     if (1 == argc) {
         oj_parse_options(argv[0], &sw->opts);
     }
+    oj_options_take_ownership(&sw->opts);
     sw->out.argc   = argc - 1;
     sw->out.argv   = argv + 1;
     sw->out.indent = sw->opts.indent;

--- a/test/test_rails.rb
+++ b/test/test_rails.rb
@@ -32,4 +32,23 @@ class RailsJuice < Minitest::Test
     }
   end
 
+  # ActiveSupport creates a new encoder for every encode call that is given
+  # options, so the buffers the :only and :except options allocate in the
+  # encoder must be freed when the encoder is collected. The encoders are not
+  # kept alive here so that a leak checker sees the buffers as lost.
+
+  def test_encoder_only
+    3.times do
+      json = Oj::Rails::Encoder.new(only: [:id]).encode({id: 1, secret: 2})
+      assert_equal('{"id":1}', json)
+    end
+  end
+
+  def test_encoder_except
+    3.times do
+      json = Oj::Rails::Encoder.new(except: [:secret]).encode({id: 1, secret: 2})
+      assert_equal('{"id":1}', json)
+    end
+  end
+
 end

--- a/test/test_writer.rb
+++ b/test/test_writer.rb
@@ -8,6 +8,15 @@ require 'open3'
 
 class OjWriter < Minitest::Test
 
+  class Jeez
+    attr_accessor :x, :y
+
+    def initialize(x, y)
+      @x = x
+      @y = y
+    end
+  end # Jeez
+
   def setup
     @default_options = Oj.default_options
   end
@@ -216,6 +225,62 @@ class OjWriter < Minitest::Test
     w.push_array()
     w.pop_all()
     assert_equal(%|{"a1":{},"a2":[3,[]]}\n|, w.to_s)
+  end
+
+  # The :only, :except, :create_id, and :ignore options each allocate a buffer
+  # in the writer that the writer must free when it is collected. The writers
+  # are not kept alive here so that a leak checker sees the buffers as lost.
+
+  def test_string_writer_only
+    w = Oj::StringWriter.new(:mode => :compat, :indent => 0, :only => ['a'])
+    w.push_value({'a' => 1, 'b' => 2})
+    assert_equal(%|{"a":1}|, w.to_s)
+  end
+
+  def test_string_writer_except
+    w = Oj::StringWriter.new(:mode => :compat, :indent => 0, :except => ['b'])
+    w.push_value({'a' => 1, 'b' => 2})
+    assert_equal(%|{"a":1}|, w.to_s)
+  end
+
+  def test_string_writer_create_id
+    w = Oj::StringWriter.new(:mode => :custom, :indent => 0, :create_id => '^custom', :create_additions => true)
+    w.push_value(Jeez.new(3, 'z'))
+    assert_equal(%|{"^custom":"OjWriter::Jeez","x":3,"y":"z"}|, w.to_s)
+  end
+
+  def test_string_writer_ignore
+    w = Oj::StringWriter.new(:mode => :object, :indent => 0, :ignore => [Jeez])
+    w.push_value({'a' => Jeez.new(3, 'z'), 'b' => 1})
+    assert_equal(%|{"b":1}|, w.to_s)
+  end
+
+  def test_stream_writer_only
+    output = StringIO.open('', 'w+')
+    w = Oj::StreamWriter.new(output, :mode => :compat, :indent => 0, :only => ['a'])
+    w.push_value({'a' => 1, 'b' => 2})
+    assert_equal(%|{"a":1}|, output.string())
+  end
+
+  def test_stream_writer_create_id
+    output = StringIO.open('', 'w+')
+    w = Oj::StreamWriter.new(output, :mode => :custom, :indent => 0, :create_id => '^custom', :create_additions => true)
+    w.push_value(Jeez.new(3, 'z'))
+    assert_equal(%|{"^custom":"OjWriter::Jeez","x":3,"y":"z"}|, output.string())
+  end
+
+  # A writer keeps the options it was created with, so replacing the defaults
+  # afterwards must neither change what the writer dumps nor free the buffers
+  # the writer is still using.
+  def test_string_writer_default_options_replaced
+    Oj.default_options = {:mode => :custom, :indent => 0, :create_id => '^d', :create_additions => true}
+    w = Oj::StringWriter.new()
+    Oj.default_options = {:create_id => '^e'}
+    w.push_value(Jeez.new(3, 'z'))
+    assert_equal(%|{"^d":"OjWriter::Jeez","x":3,"y":"z"}|, w.to_s)
+
+    w = nil
+    GC.start
   end
 
   def test_string_writer_reset


### PR DESCRIPTION
## Problem

An `Options` struct is a copy of `oj_default_options`, so its `create_id`, `ignore`, `dump_opts.only`, and `dump_opts.except` members alias buffers owned by the defaults until `oj_parse_options()` replaces one with a buffer allocated for that copy.

`Oj::StringWriter`, `Oj::StreamWriter`, and `Oj::Rails::Encoder` keep such a copy for the life of the object, but their free functions never released those buffers. Every writer or encoder created with one of those options leaked it. #1029 fixed the same pattern for the per-call paths (`Oj.load`, `Oj.dump`, ...) via `oj_free_call_options()`; these three objects were not covered because they are freed by the GC rather than at the end of the call.

The leak matters most for `Oj::Rails::Encoder`. `Oj.optimize_rails` sets `ActiveSupport.json_encoder = Oj::Rails::Encoder`, and ActiveSupport creates a new encoder for every `encode` call that is given options:

```ruby
# activesupport lib/active_support/json/encoding.rb
def encode(value, options = nil)
  if options.nil? || options.empty?
    Encoding.encode_without_options(value)
  else
    Encoding.json_encoder.new(options).encode(value)
  end
end
```

So a Rails application that calls `to_json(only: [...])` or `to_json(except: [...])` — directly or through `render json:` — leaks on every call, without bound, for the life of the process.

## Reproduction

```ruby
require 'oj'
require 'stringio'

n = Integer(ARGV[0] || 100)
n.times { |i| Oj::StringWriter.new(mode: :rails, only: ["a#{i}"]) }
n.times { |i| Oj::StreamWriter.new(StringIO.new, mode: :rails, only: ["b#{i}"]) }
n.times { |i| Oj::Rails::Encoder.new(only: ["c#{i}"]) }
GC.start
```

`valgrind --leak-check=full --show-leak-kinds=definite` on `develop`, counting blocks (valgrind merges same-stack allocations into one record, so the block count is what shows the growth):

| N | definitely lost |
|---|---|
| 50 | 870 bytes in 150 blocks (50 blocks per path) |
| 500 | 10,170 bytes in 1,500 blocks (500 blocks per path) |

Every report goes through `make_only_value` → `oj_parse_options` → `str_writer_new` / `stream_writer_new` / `encoder_new`. With this PR the same run reports `definitely lost: 0 bytes in 0 blocks`.

## Fix

Freeing the buffers by comparing them against the current defaults, the way `oj_free_call_options()` does for per-call copies, is not safe for an object that outlives the call that created it: `Oj.default_options=` can replace the defaults while the object is alive. After that, a member that still aliases an old default-owned buffer looks like a private one (the pointers differ) and would be freed a second time, or an address reused by the allocator makes a private buffer look like the default and it is never freed.

Instead, the object takes ownership when it is created: `oj_options_take_ownership()` gives it private copies of the members it still shares with the defaults, so it owns all four. `oj_options_release()` can then free them unconditionally from the GC free function, with no reference to the defaults at all. This also removes the object's dependency on the defaults staying alive.

`ignore` is an array of classes that is now private to the object and no longer reachable from anywhere else, so `oj_options_mark()` marks it from the writers' and the encoder's mark functions to keep those classes alive.

The per-call paths and `oj_free_call_options()` are unchanged, and there is no change to any output or to the public API.

## Tests

The valgrind suite already ran `test_writer.rb` and `test_rails.rb`, but neither created a writer or an encoder with `:only`, `:except`, `:create_id`, or `:ignore`, so the C code that allocates those buffers was never reached and memcheck saw nothing. This PR adds tests that exercise each option, plus a test that replaces the default options after a writer is created and checks that the writer still dumps what it was created with and that nothing is double freed.

With the tests applied but the C fix reverted, `rake test:valgrind` exits 1 with 8 leak reports attributed to `str_writer_new`, `stream_writer_new`, and `encoder_new`. With the fix it exits 0:

```
458 runs, 1031 assertions, 0 failures, 0 errors, 0 skips
```

The valgrind workflow added in #1030 will catch a regression of this from now on.
