### PR TITLE
Mark the Ruby objects held by the writers and the Rails encoder

### DIFF
--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -1251,10 +1251,17 @@ void oj_options_release(Options copts) {
     }
 }
 
-// Mark the Ruby objects held by an owned options struct. The ignore member is a
-// private array of classes that is not reachable from anywhere else, so without
-// this the classes could be collected while the owner is still alive.
+// Mark the Ruby objects held by an owned options struct. A long lived object
+// such as a writer or an encoder can be the only reference to the classes in
+// the options so without this they could be collected while the owner is still
+// alive leaving the options with dangling VALUEs.
 void oj_options_mark(Options copts) {
+    if (Qnil != copts->hash_class) {
+        rb_gc_mark(copts->hash_class);
+    }
+    if (Qnil != copts->array_class) {
+        rb_gc_mark(copts->array_class);
+    }
     if (NULL != copts->ignore) {
         VALUE *vp;
 

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -634,10 +634,18 @@ static void encoder_free(void *ptr) {
 static void encoder_mark(void *ptr) {
     if (NULL != ptr) {
         Encoder e = (Encoder)ptr;
+        int     i;
 
         oj_options_mark(&e->opts);
         if (Qnil != e->arg) {
             rb_gc_mark(e->arg);
+        }
+        // The optimized classes in the encoder table are not reachable from
+        // anywhere else once optimize() is called on the encoder itself.
+        for (i = 0; i < e->ropts.len; i++) {
+            if (Qnil != e->ropts.table[i].clas) {
+                rb_gc_mark(e->ropts.table[i].clas);
+            }
         }
     }
 }

--- a/ext/oj/stream_writer.c
+++ b/ext/oj/stream_writer.c
@@ -24,7 +24,14 @@ static void stream_writer_free(void *ptr) {
 
 static void stream_writer_mark(void *ptr) {
     if (NULL != ptr) {
-        oj_options_mark(&((StreamWriter)ptr)->sw.opts);
+        StreamWriter sw = (StreamWriter)ptr;
+
+        oj_options_mark(&sw->sw.opts);
+        // The writer can be the only reference to the stream as in
+        // Oj::StreamWriter.new(StringIO.new) so it must be marked.
+        if (Qnil != sw->stream) {
+            rb_gc_mark(sw->stream);
+        }
     }
 }
 

--- a/test/test_writer.rb
+++ b/test/test_writer.rb
@@ -5,6 +5,7 @@ $LOAD_PATH << __dir__
 
 require 'helper'
 require 'open3'
+require 'weakref'
 
 class OjWriter < Minitest::Test
 
@@ -281,6 +282,64 @@ class OjWriter < Minitest::Test
 
     w = nil
     GC.start
+  end
+
+  # Overwrite the machine stack before collecting. Without this a stale
+  # reference left on the stack can keep an object alive and hide a missing
+  # mark.
+  def scrub_stack(depth = 128)
+    return 0 if 0 == depth
+
+    pad = 'x' * 64
+    scrub_stack(depth - 1) + pad.size
+  end
+
+  def collect_garbage
+    scrub_stack
+    4.times { GC.start(full_mark: true, immediate_sweep: true) }
+  end
+
+  # A writer holds the classes from the options and a stream writer holds the
+  # stream as well. If they are not marked they can be collected while the
+  # writer is still alive which leaves the writer with dangling references.
+  def test_stream_writer_marks_stream
+    # The stream is not kept in a local variable so the writer is the only one
+    # holding a reference to it.
+    w = Oj::StreamWriter.new((output = StringIO.new), :mode => :compat, :indent => 0)
+    ref = WeakRef.new(output)
+    output = nil
+    collect_garbage
+    assert(ref.weakref_alive?, 'the stream was collected while the writer was alive')
+
+    w.push_object()
+    w.push_value(1, 'a')
+    w.pop_all()
+    assert_equal(%|{"a":1}\n|, ref.string())
+  end
+
+  def test_string_writer_marks_hash_class
+    klass = Class.new(Hash)
+    w = Oj::StringWriter.new(:mode => :object, :indent => 0, :hash_class => klass)
+    ref = WeakRef.new(klass)
+    klass = nil
+    collect_garbage
+    assert(ref.weakref_alive?, 'the hash_class was collected while the writer was alive')
+
+    w.push_value({'a' => 1})
+    assert_equal(%|{"a":1}|, w.to_s)
+  end
+
+  def test_stream_writer_marks_array_class
+    klass = Class.new(Array)
+    w = Oj::StreamWriter.new((output = StringIO.new), :mode => :object, :indent => 0, :array_class => klass)
+    ref = WeakRef.new(klass)
+    klass = nil
+    collect_garbage
+    assert(ref.weakref_alive?, 'the array_class was collected while the writer was alive')
+
+    w.push_value([1])
+    w.pop_all()
+    assert_equal(%|[1]|, output.string())
   end
 
   def test_string_writer_reset


### PR DESCRIPTION
## Problem

`Oj::StringWriter`, `Oj::StreamWriter` and `Oj::Rails::Encoder` keep C copies of the options for as long as the object lives, and a stream writer keeps the stream in `sw->stream` as well. Their mark functions only marked the `ignore` option, so several retained VALUEs were never marked and could be collected while the owner was still alive, leaving the C struct with dangling VALUEs.

The one with real teeth is the stream. Passing the stream inline is the natural way to use the writer:

```ruby
w = Oj::StreamWriter.new(StringIO.new, mode: :compat)
# ... the writer is the only reference to the StringIO ...
w.push_object
w.push_value(1, 'a')   # segfault: the StringIO was collected
w.pop_all
```

`stream_writer_write()` does `rb_funcall(sw->stream, oj_write_id, 1, rs)` on a collected object. On develop (`2fb414c`) that reproduces as:

```
repro.rb:11: [BUG] Segmentation fault at 0x0000000000000000
c:0004 p:---- s:0017 e:000016 l:y b:---- CFUNC  :push_object
```

The other unmarked VALUEs are:

* `opts.hash_class` / `opts.array_class` in all three objects. These are dump-side objects so the classes are never dereferenced and this does not crash today, but the options are left holding freed VALUEs.
* The optimized classes in the encoder's own `ropts` table. An encoder gets a private copy of the table and `Oj::Rails::Encoder#optimize(klass)` adds to that copy only, so the encoder can be the only holder of the class. `oj_rails_get_opt()` searches the table by VALUE, so a stale entry can be matched by a later object that happens to reuse the address.

This is a use-after-free rather than a leak, so the Valgrind memcheck run does not see it.

## Fix

* `oj_options_mark()` marks `hash_class` and `array_class` in addition to `ignore`. All three mark functions go through it, so this covers the writers and the encoder.
* `stream_writer_mark()` marks `sw->stream`.
* `encoder_mark()` marks the classes in `e->ropts.table[0 .. len)`.

`rb_gc_mark()` (the pinning variant) is used, matching the existing `e->arg` mark. Nothing else is changed: no option layout change, no behavior or API change.

## Tests

`test/test_writer.rb` gets three tests that hold the writer but not the stream or the option classes, and assert with a `WeakRef` that they survive a collection. The machine stack is scrubbed before collecting, otherwise a stale reference left on the stack keeps the object alive and the test passes even with the mark missing.

Before the fix (3 out of 3 runs):

```
  1) Failure:
OjWriter#test_stream_writer_marks_stream:
the stream was collected while the writer was alive

  2) Failure:
OjWriter#test_string_writer_marks_hash_class:
the hash_class was collected while the writer was alive

  3) Failure:
OjWriter#test_stream_writer_marks_array_class:
the array_class was collected while the writer was alive

37 runs, 38 assertions, 3 failures, 0 errors, 0 skips
```

After the fix:

```
37 runs, 41 assertions, 0 failures, 0 errors, 0 skips
```

The encoder class table has no test. `Oj::Rails::Encoder#optimize(klass)` raises `NameError: uninitialized constant ActiveRecord` for any class that is not in the rails dump map when ActiveRecord is not loaded (pre-existing behavior in `create_opt()`), so the table cannot be filled with a collectable class from the test suite.

Also verified: the full suite (`test/tests.rb`, 484 runs, 0 failures), `rake test:valgrind` (461 runs, 0 failures, exit 0, no new leaks), and a writer used after `GC.verify_compaction_references` + `GC.compact` still writes to its stream.
