### PR TITLE
Free the match_string regexps held by the writers and the Rails encoder

### DIFF
--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -1249,6 +1249,9 @@ void oj_options_release(Options copts) {
         OJ_R_FREE((void *)copts->dump_opts.except);
         copts->dump_opts.except = NULL;
     }
+    // The str_rx chain is detached from the defaults when the owner is created
+    // so the chain, if there is one, was built for this options struct alone.
+    oj_rxclass_cleanup(&copts->str_rx);
 }
 
 // Mark the Ruby objects held by an owned options struct. A long lived object

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -671,6 +671,11 @@ static VALUE encoder_new(int argc, VALUE *argv, VALUE self) {
     Encoder e = OJ_R_ALLOC(struct _encoder);
 
     e->opts = oj_default_options;
+    // Detach from the match_string regexps owned by the defaults before the
+    // options are parsed so that a :match_string option builds a chain of its
+    // own that is freed with the encoder.
+    e->opts.str_rx.head = NULL;
+    e->opts.str_rx.tail = NULL;
     copy_opts(&ropts, &e->ropts);
 
     if (1 <= argc && Qnil != *argv) {

--- a/ext/oj/string_writer.c
+++ b/ext/oj/string_writer.c
@@ -42,12 +42,18 @@ static void maybe_comma(StrWriter sw) {
 
 // Used by stream writer also.
 void oj_str_writer_init(StrWriter sw, int buf_size) {
-    sw->opts       = oj_default_options;
-    sw->depth      = 0;
-    sw->types      = OJ_R_ALLOC_N(char, 256);
-    sw->types_end  = sw->types + 256;
-    *sw->types     = '\0';
-    sw->keyWritten = 0;
+    sw->opts = oj_default_options;
+    // Detach from the match_string regexps owned by the defaults before the
+    // options are parsed. A :match_string option then builds a chain of its own
+    // that is freed with the writer instead of being appended to the chain the
+    // defaults are using.
+    sw->opts.str_rx.head = NULL;
+    sw->opts.str_rx.tail = NULL;
+    sw->depth            = 0;
+    sw->types            = OJ_R_ALLOC_N(char, 256);
+    sw->types_end        = sw->types + 256;
+    *sw->types           = '\0';
+    sw->keyWritten       = 0;
 
     if (0 == buf_size) {
         buf_size = 4096;

--- a/test/test_rails.rb
+++ b/test/test_rails.rb
@@ -51,4 +51,13 @@ class RailsJuice < Minitest::Test
     end
   end
 
+  # A :match_string option builds a chain of compiled regexps in the encoder
+  # that the encoder must free when it is collected.
+  def test_encoder_match_string
+    3.times do
+      json = Oj::Rails::Encoder.new(match_string: {/^x/ => String}).encode({id: 1})
+      assert_equal('{"id":1}', json)
+    end
+  end
+
 end

--- a/test/test_writer.rb
+++ b/test/test_writer.rb
@@ -342,6 +342,23 @@ class OjWriter < Minitest::Test
     assert_equal(%|[1]|, output.string())
   end
 
+  # A :match_string option builds a chain of compiled regexps in the writer that
+  # the writer must free when it is collected. The writers are not kept alive
+  # here so that a leak checker sees the chain as lost.
+
+  def test_string_writer_match_string
+    w = Oj::StringWriter.new(:mode => :custom, :indent => 0, :match_string => {/^x/ => Jeez})
+    w.push_value({'a' => 1})
+    assert_equal(%|{"a":1}|, w.to_s)
+  end
+
+  def test_stream_writer_match_string
+    output = StringIO.open('', 'w+')
+    w = Oj::StreamWriter.new(output, :mode => :custom, :indent => 0, :match_string => {/^x/ => Jeez})
+    w.push_value({'a' => 1})
+    assert_equal(%|{"a":1}|, output.string())
+  end
+
   def test_string_writer_reset
     w = Oj::StringWriter.new(:indent => 0)
     w.push_array()


### PR DESCRIPTION
## Problem

`Oj::StringWriter`, `Oj::StreamWriter` and `Oj::Rails::Encoder` start from a copy of the default options, so their `str_rx` member points at the regexp chain owned by the defaults. When a `:match_string` option is given, `oj_parse_opt_match_string()` starts a fresh chain for that options struct, and the writer or the encoder ends up owning a chain of `RxC` nodes with compiled `regex_t`s. Nothing ever frees it, so every writer or encoder created with `:match_string` leaks its chain.

Measured with `valgrind --leak-check=full` (block counts, not record counts):

| created with `:match_string` | N=50 | N=500 |
| --- | --- | --- |
| `Oj::StringWriter` + `Oj::StreamWriter` | 100 blocks | 1,000 blocks |
| `Oj::Rails::Encoder` | 50 blocks | 500 blocks |

One `RxC` node (344 bytes with the compiled regexp) per object.

Honest note on severity: `:match_string` is a parse-side option and the writers never use it for matching, so passing it to a writer is unusual. The leak is real and grows without bound, but it is not on a path most applications take. It is the last of the option buffers that the writers do not own; the string options were fixed in #1031 and this completes it.

## Fix

The call-scope paths (`mimic_json.c`, the rails dump path) already do `copts.str_rx.head = tail = NULL` before parsing the options. The writers and the encoder did not. So:

* `oj_str_writer_init()` and `encoder_new()` clear `str_rx.head` / `str_rx.tail` right after copying the defaults and *before* `oj_parse_options()` runs. The timing matters: after parsing it would be too late.
* `oj_options_release()` (the GC-side release added in #1031) calls `oj_rxclass_cleanup()`. After the detach, the chain is either empty or owned by that object alone, so the release is unconditional and does not depend on what the defaults hold at collection time.

No option is accepted or rejected differently, and no output changes: the writers never matched against `str_rx` in the first place.

## Tests

`test/test_writer.rb` and `test/test_rails.rb` create a writer / encoder with `:match_string` and do not keep it alive, so the leak checker sees the chain as lost. These files are in the memcheck allowlist.

Before the fix, `rake test:valgrind` exits 1 with the chain reported as definitely lost from `str_writer_new` (string_writer.c:287), `stream_writer_new` (stream_writer.c:120) and `encoder_new` (rails.c:673). After the fix it exits 0 (461 runs, 0 failures, no leaks and no invalid frees).

Also checked that replacing the defaults after a writer is created is still safe: with `Oj.default_options = {match_string: ...}` set before and replaced after the writer is created, the writer dumps the same output, the defaults keep matching their own regexps, the writer's regexps never leak into the defaults, and Valgrind reports no invalid free, read or write.

## Not in this PR

While measuring, two more leaks of the same chain showed up outside the writers. They are separate from the writer lifecycle and are left for a follow-up:

* `Oj.load(json, match_string: {...})` leaks one chain per call. `oj_free_call_options()` does not clean `str_rx`, and the cleanup in `parse.c` looks at `pi->str_rx`, not `pi->options.str_rx`, which is the chain the parsers actually match against.
* `Oj.default_options = {match_string: {...}}` drops the previous default chain without freeing it.
