### PR TITLE
Free the match_string regexps allocated for a parse call and the defaults

### DIFF
--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -608,6 +608,14 @@ static VALUE get_def_opts(VALUE self) {
  */
 static VALUE set_def_opts(VALUE self, VALUE opts) {
     Check_Type(opts, T_HASH);
+    // A :match_string option replaces the regexps instead of adding to them so
+    // the ones the defaults are holding have to be freed here, the only place
+    // that owns them. A per call options struct only aliases them.
+    if (Qnil != rb_hash_lookup(opts, match_string_sym)) {
+        oj_rxclass_cleanup(&oj_default_options.str_rx);
+        oj_default_options.str_rx.head = NULL;
+        oj_default_options.str_rx.tail = NULL;
+    }
     oj_parse_options(opts, &oj_default_options);
 
     return Qnil;

--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -1306,8 +1306,14 @@ CLEANUP:
         OJ_R_FREE(json);
     }
     stack_cleanup(&pi->stack);
-    if (pi->str_rx.head != oj_default_options.str_rx.head) {
-        oj_rxclass_cleanup(&pi->str_rx);
+    // The parsers match against pi->options.str_rx. A :match_string option
+    // builds a chain of its own for this call, which has to be freed. Without
+    // the option the member still aliases the chain owned by the defaults and
+    // must be left alone.
+    if (pi->options.str_rx.head != oj_default_options.str_rx.head) {
+        oj_rxclass_cleanup(&pi->options.str_rx);
+        pi->options.str_rx.head = NULL;
+        pi->options.str_rx.tail = NULL;
     }
     oj_free_call_options(&pi->options);
     if (err_has(&pi->err)) {

--- a/ext/oj/parse.h
+++ b/ext/oj/parse.h
@@ -49,7 +49,6 @@ typedef struct _parseInfo {
     VALUE            handler;
     struct _valStack stack;
     CircArray        circ_array;
-    struct _rxClass  str_rx;
     int              expect_value;
     int              max_depth;  // just for the json gem
     VALUE            proc;

--- a/ext/oj/sparse.c
+++ b/ext/oj/sparse.c
@@ -907,6 +907,14 @@ CLEANUP:
         oj_circ_array_free(pi->circ_array);
     }
     stack_cleanup(&pi->stack);
+    // A :match_string option builds a chain of regexps for this call that has to
+    // be freed. Without the option the member aliases the chain owned by the
+    // defaults and must be left alone.
+    if (pi->options.str_rx.head != oj_default_options.str_rx.head) {
+        oj_rxclass_cleanup(&pi->options.str_rx);
+        pi->options.str_rx.head = NULL;
+        pi->options.str_rx.tail = NULL;
+    }
     oj_free_call_options(&pi->options);
     if (0 != fd) {
 #ifdef _WIN32

--- a/test/test_custom.rb
+++ b/test/test_custom.rb
@@ -19,6 +19,18 @@ class CustomJuice < Minitest::Test
   module TestModule
   end
 
+  class Rex
+    attr_accessor :s
+
+    def self.json_create(s)
+      new(s)
+    end
+
+    def initialize(s)
+      @s = s
+    end
+  end # Rex
+
   class Jeez
     attr_accessor :x, :y, :_z
 
@@ -94,6 +106,9 @@ class CustomJuice < Minitest::Test
 
   def teardown
     Oj.default_options = @default_options
+    # Oj.default_options does not report :match_string so restoring the saved
+    # options leaves any regexps a test set in place. Clear them explicitly.
+    Oj.default_options = {:match_string => {}}
   end
 
   def test_nil
@@ -504,6 +519,41 @@ class CustomJuice < Minitest::Test
     dump_load_dump(obj, false, :time_format => :xmlschema, :create_id => '^o', :create_additions => true)
     dump_load_dump(obj, false, :time_format => :xmlschema, :create_id => '^o', :create_additions => true, second_precision: 3)
     dump_load_dump(obj, false, :time_format => :ruby, :create_id => '^o', :create_additions => true)
+  end
+
+  # A :match_string option builds a chain of compiled regexps for the call that
+  # the call must free. Nothing is kept alive here so that a leak checker sees
+  # the chain as lost.
+
+  def test_match_string
+    obj = Oj.load('"zzz"', :create_additions => true, :match_string => {/^z/ => Rex})
+    assert_equal(Rex, obj.class)
+    assert_equal('zzz', obj.s)
+  end
+
+  def test_match_string_io
+    obj = Oj.load(StringIO.new('"zzz"'), :create_additions => true, :match_string => {/^z/ => Rex})
+    assert_equal(Rex, obj.class)
+  end
+
+  # The regexps of a call are its own but the ones the defaults hold are only
+  # aliased by a call, so a call must not free them.
+  def test_match_string_leaves_default
+    Oj.default_options = {:mode => :custom, :create_additions => true, :match_string => {/^a/ => Rex}}
+    Oj.load('"zzz"', :match_string => {/^z/ => Rex})
+
+    assert_equal(Rex, Oj.load('"aaa"').class, 'the default regexps were freed by the call')
+    assert_equal(String, Oj.load('"zzz"').class, 'the regexps of the call leaked into the defaults')
+  end
+
+  # Setting :match_string replaces the regexps of the defaults instead of adding
+  # to them, so the previous ones are freed. Matching must still work after that.
+  def test_match_string_default_replaced
+    Oj.default_options = {:mode => :custom, :create_additions => true, :match_string => {/^a/ => Rex}}
+    Oj.default_options = {:match_string => {/^b/ => Rex}}
+
+    assert_equal(Rex, Oj.load('"bbb"').class)
+    assert_equal(String, Oj.load('"aaa"').class)
   end
 
   def dump_and_load(obj, trace=false, options={})


### PR DESCRIPTION
## Problem

A `:match_string` option builds a chain of `RxC` nodes with compiled regexps (344 bytes each) in the options struct it is parsed into. Two of those chains are never freed.

**Every `Oj.load()` with `:match_string` leaks one.** The cleanup in `parse.c` frees `pi->str_rx`, a member of `ParseInfo` that nothing ever fills — the parsers match against `pi->options.str_rx` (compat.c, custom.c), and that is where `oj_parse_options()` puts the chain. So the cleanup empties an empty chain and the real one is lost. The stream parser (`sparse.c`, used when loading from an IO) has no `str_rx` cleanup at all. `oj_free_call_options()` does not look at `str_rx` either.

**Replacing the defaults leaks the previous chain.** `:match_string` replaces the regexps instead of adding to them (`oj_parse_opt_match_string()` starts a new chain), but the chain being replaced is dropped without being freed.

Measured with `valgrind --leak-check=full` (block counts, not record counts):

| | N=50 | N=500 |
| --- | --- | --- |
| `Oj.load(json, match_string: {...})` | 50 blocks | 500 blocks |
| `Oj.load(io, match_string: {...})` (stream parser) | 50 blocks | 500 blocks |
| `Oj.default_options = {match_string: {...}}` | 49 blocks | 499 blocks |

Severity: leaks only, no crash and no corruption — the chain of a call never mixes into the defaults. But the first two are what using `:match_string` normally looks like, and they grow without bound in a long lived process.

## Fix

* `parse.c` and `sparse.c` clean up `pi->options.str_rx`, the chain the parsers actually match against, and only when its head differs from the head the defaults own. Without a `:match_string` option the member still aliases the chain of the defaults and must be left alone.
* The unused `str_rx` member of `ParseInfo` is removed.
* `set_def_opts()` frees the regexps of the defaults before parsing options that carry a new `:match_string`. The defaults own that chain and a per call options struct only aliases it, so this is the one place allowed to free it.

The matching logic, `oj_parse_opt_match_string()`, `oj_free_call_options()`, and the public API are unchanged.

## Tests

`test/test_custom.rb` (in the memcheck allowlist) gets tests that load with `:match_string` from a string and from an IO without keeping anything alive, so the leak checker sees the chain as lost, plus two tests for the ownership rule: a call must not free the regexps of the defaults, and replacing the regexps of the defaults must keep matching correctly afterwards.

Before the fix `rake test:valgrind` exits 1 with the chains reported as definitely lost from `oj_pi_parse` and `oj_pi_sparse`. After the fix it exits 0 (465 runs, 0 failures, no leaks, no invalid frees or reads). The full suite is green (`test/tests.rb`, 488 runs, 0 failures), and a run that mixes per call regexps with default regexps and reassigns the defaults repeatedly reports no invalid free, read or write and keeps matching the right classes.

Note for the tests: `Oj.default_options` does not report `:match_string`, so saving and restoring the options does not restore the regexps. The teardown clears them explicitly, otherwise regexps set by one test match strings in later ones.
