### PR TITLE
Hold onto the Ruby objects in the default options

### DIFF
--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -606,6 +606,40 @@ static VALUE get_def_opts(VALUE self) {
  *   - *:trace* [_Boolean_] turn trace on or off.
  *   - *:safe* [_Boolean_] turn safe mimic on or off.
  */
+static ID oj_default_options_keeper_id = 0;
+
+// The default options are a plain C global so the Ruby objects in them, the
+// classes of the hash_class, array_class, and ignore options and the regexps
+// and the classes of the match_string option, can not be reached by the GC and
+// are collected while the defaults still refer to them. Holding them in an
+// array the GC does know about keeps them alive. The array is rebuilt whenever
+// the defaults change and replaces the previous one so that only the objects
+// the defaults are currently using are held.
+static void keep_default_options(void) {
+    VALUE keep = rb_ary_new();
+
+    if (0 == oj_default_options_keeper_id) {
+        oj_default_options_keeper_id = rb_intern("@default_options_keeper");
+    }
+    if (Qnil != oj_default_options.hash_class) {
+        rb_ary_push(keep, oj_default_options.hash_class);
+    }
+    if (Qnil != oj_default_options.array_class) {
+        rb_ary_push(keep, oj_default_options.array_class);
+    }
+    if (NULL != oj_default_options.ignore) {
+        VALUE *vp;
+
+        for (vp = oj_default_options.ignore; Qnil != *vp; vp++) {
+            rb_ary_push(keep, *vp);
+        }
+    }
+    oj_rxclass_keep(&oj_default_options.str_rx, keep);
+    // An instance variable of the Oj module is a reference the GC can follow on
+    // every engine, unlike a C global.
+    rb_ivar_set(Oj, oj_default_options_keeper_id, keep);
+}
+
 static VALUE set_def_opts(VALUE self, VALUE opts) {
     Check_Type(opts, T_HASH);
     // A :match_string option replaces the regexps instead of adding to them so
@@ -617,6 +651,7 @@ static VALUE set_def_opts(VALUE self, VALUE opts) {
         oj_default_options.str_rx.tail = NULL;
     }
     oj_parse_options(opts, &oj_default_options);
+    keep_default_options();
 
     return Qnil;
 }

--- a/ext/oj/rxclass.c
+++ b/ext/oj/rxclass.c
@@ -142,3 +142,19 @@ void oj_rxclass_copy(RxClass src, RxClass dest) {
         }
     }
 }
+
+// Add the Ruby objects in the chain to an array. The regexps and the classes
+// can be referenced from nowhere else, as with a default match_string option,
+// and are collected unless something holds onto them.
+void oj_rxclass_keep(RxClass rc, VALUE keep) {
+    RxC rxc;
+
+    for (rxc = rc->head; NULL != rxc; rxc = rxc->next) {
+        if (Qnil != rxc->rrx) {
+            rb_ary_push(keep, rxc->rrx);
+        }
+        if (Qnil != rxc->clas) {
+            rb_ary_push(keep, rxc->clas);
+        }
+    }
+}

--- a/ext/oj/rxclass.h
+++ b/ext/oj/rxclass.h
@@ -22,5 +22,6 @@ extern int   oj_rxclass_append(RxClass rc, const char *expr, VALUE clas);
 extern VALUE oj_rxclass_match(RxClass rc, const char *str, size_t len);
 extern void  oj_rxclass_copy(RxClass src, RxClass dest);
 extern void  oj_rxclass_rappend(RxClass rc, VALUE rx, VALUE clas);
+extern void  oj_rxclass_keep(RxClass rc, VALUE keep);
 
 #endif /* OJ_RXCLASS_H */

--- a/test/test_compat.rb
+++ b/test/test_compat.rb
@@ -12,6 +12,7 @@ require 'minitest/autorun'
 require 'stringio'
 require 'date'
 require 'bigdecimal'
+require 'weakref'
 require 'oj'
 
 class CompatJuice < Minitest::Test
@@ -44,6 +45,18 @@ class CompatJuice < Minitest::Test
       %|{"args":"#{a}"}|
     end
   end # Argy
+
+  class Rex
+    attr_accessor :s
+
+    def self.json_create(s)
+      new(s)
+    end
+
+    def initialize(s)
+      @s = s
+    end
+  end # Rex
 
   class Stringy
 
@@ -83,6 +96,72 @@ class CompatJuice < Minitest::Test
 
   def teardown
     Oj.default_options = @default_options
+    # Oj.default_options does not report :match_string so restoring the saved
+    # options leaves any regexps a test set in place. Clear them explicitly.
+    Oj.default_options = {:match_string => {}}
+  end
+
+  # Overwrite the machine stack before collecting. Without this a stale
+  # reference left on the stack can keep an object alive and hide a missing
+  # mark.
+  def scrub_stack(depth = 128)
+    return 0 if 0 == depth
+
+    pad = 'x' * 64
+    scrub_stack(depth - 1) + pad.size
+  end
+
+  def collect_garbage
+    scrub_stack
+    4.times { GC.start(full_mark: true, immediate_sweep: true) }
+  end
+
+  # A WeakRef reports whether the C level mark kept the object alive on CRuby.
+  # Other engines manage the objects a C extension holds differently so the
+  # tests below check that the option still works instead.
+  def assert_marked(ref, msg)
+    assert(ref.weakref_alive?, msg) if 'ruby' == RUBY_ENGINE
+  end
+
+  # The default options hold the classes of the :hash_class, :array_class and
+  # :ignore options and the regexps of the :match_string option. Nothing else
+  # refers to them so they are collected unless the defaults are marked.
+
+  def test_default_options_marks_hash_class
+    klass = Class.new(Hash)
+    Oj.default_options = {:hash_class => klass}
+    ref = WeakRef.new(klass)
+    klass = nil
+    collect_garbage
+
+    assert_marked(ref, 'the hash_class of the defaults was collected')
+    loaded = Oj.load('{"a":1}')
+    assert_equal(Oj.default_options[:hash_class], loaded.class)
+    assert_equal({'a' => 1}, loaded.to_h)
+  end
+
+  def test_default_options_marks_ignore
+    klass = Class.new
+    Oj.default_options = {:ignore => [klass]}
+    ref = WeakRef.new(klass)
+    klass = nil
+    collect_garbage
+
+    assert_marked(ref, 'a class of the ignore option of the defaults was collected')
+    ignore = Oj.default_options[:ignore]
+    assert_equal(1, ignore.size)
+    assert_kind_of(Class, ignore[0])
+  end
+
+  def test_default_options_marks_match_string
+    # The regexp is not kept in a local variable so the regexps of the defaults
+    # are the only reference to it. Matching calls it, so if it is collected the
+    # load below reads a freed object.
+    Oj.default_options = {:create_additions => true, :match_string => {Regexp.new('^z') => Rex}}
+    collect_garbage
+
+    obj = Oj.load('"zzz"')
+    assert_equal(Rex, obj.class, 'the regexp of the match_string option of the defaults was collected')
   end
 
   def test_nil


### PR DESCRIPTION
## Problem

`oj_default_options` is a plain C global, so the Ruby objects it holds are reachable from nowhere the GC can see:

* the classes of the `:hash_class`, `:array_class` and `:ignore` options
* the regexps and the classes in the `:match_string` chain

They are collected while the defaults still point at them, which leaves the defaults with dangling VALUEs.

The regexps are the ones that hurt. Matching calls the regexp (`rb_funcall(rxc->rrx, :match, ...)`), and a regexp given as a `:match_string` key in the defaults is referenced only from the chain, so this is a use-after-free on an ordinary use of the option:

```ruby
Oj.default_options = {mode: :custom, create_additions: true, match_string: {/^z/ => Foo}}
GC.start
Oj.load('"zzz"')   # [BUG] Segmentation fault
```

The classes are narrower: a class bound to a constant is rooted by the constant, so only an anonymous class is exposed. `Oj.default_options = {hash_class: Class.new(Hash)}` followed by a collection makes even reading `Oj.default_options` segfault.

This is a use-after-free, not a leak, so the Valgrind memcheck run does not see it. #1032 marked the same options when a writer or an encoder holds them; this does it for the defaults.

## Fix

Whenever the defaults change, `set_def_opts()` rebuilds an array of the Ruby objects the defaults refer to and keeps it in an instance variable of the `Oj` module. The array replaces the previous one, so only the objects the defaults are currently using are held. `oj_rxclass_keep()` (new) adds the regexps and the classes of the match_string chain to it; keeping only the classes would leave the regexp use-after-free in place.

An instance variable is used rather than a mark function because it works on every engine:

* A mark function on a hidden object wrapped with `rb_gc_register_mark_object()` works on CRuby, but TruffleRuby never runs it and the classes are still collected (`dead handle` when reading `Oj.default_options`).
* A C global registered with `rb_gc_register_address()` does not pick up values assigned to it later on TruffleRuby.

No behavior or API change.

## Tests

`test/test_compat.rb` gets three tests that put an anonymous class or an anonymous regexp in the defaults, keep no other reference to it, and check after a collection that it survived. The machine stack is scrubbed before collecting, otherwise a stale reference on the stack keeps the object alive and the test passes even with the bug present. A `WeakRef` reflects what the C code holds only on CRuby, so the tests also use the option after the collection, which is what catches the bug on the other engines.

Before the fix the tests are red on every run on CRuby (2 failures, and the match_string test segfaults outright in some runs) and on TruffleRuby. After the fix they pass on both.

Verified on CRuby 4.0.5 (full suite 494 runs, 0 failures; `rake test:valgrind` exits 0, no leaks) and on TruffleRuby 34.0.1 (494 runs, 0 failures).

Note for the tests: `Oj.default_options` does not report `:match_string`, so saving and restoring the options does not restore the regexps. The teardown clears them explicitly, as in #1034.
