### PR TITLE
Fix the Oj::Doc crash on a JSON document with no root and the comment scanner overreads

### DIFF
--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -92,7 +92,14 @@ inline static void next_non_white(ParseInfo pi) {
         case '\f':
         case '\n':
         case '\r': break;
-        case '/': skip_comment(pi); break;
+        case '/':
+            skip_comment(pi);
+            // A comment that is not terminated by a newline ends on the null
+            // terminator. Stop here so the loop does not step past it.
+            if ('\0' == *pi->s) {
+                return;
+            }
+            break;
         default: return;
         }
     }

--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -1137,7 +1137,9 @@ static VALUE doc_open_file(VALUE clas, VALUE filename) {
     int            given = rb_block_given_p();
 
     path = StringValuePtr(filename);
-    if (0 == (f = fopen(path, "r"))) {
+    // Open in binary mode. On Windows a text mode read translates CRLF into LF
+    // so fewer bytes are read than the file size reported by ftell().
+    if (0 == (f = fopen(path, "rb"))) {
         rb_raise(rb_eIOError, "%s", strerror(errno));
     }
     fseek(f, 0, SEEK_END);

--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -217,10 +217,11 @@ static void skip_comment(ParseInfo pi) {
             if ('*' == *pi->s && '/' == *(pi->s + 1)) {
                 pi->s++;
                 return;
-            } else if ('\0' == *pi->s) {
-                raise_error("comment not terminated", pi->str, pi->s);
             }
         }
+        // The loop only ends on the null terminator so the comment was never
+        // closed.
+        raise_error("comment not terminated", pi->str, pi->s);
     } else if ('/' == *pi->s) {
         for (; 1; pi->s++) {
             switch (*pi->s) {

--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -710,21 +710,23 @@ static void mark_doc(void *ptr) {
 }
 #ifdef HAVE_RB_GC_MARK_MOVABLE
 static void compact_leaf(Leaf leaf) {
-    switch (leaf->value_type) {
-    case COL_VAL:
-        if (NULL != leaf->elements) {
-            Leaf first = leaf->elements->next;
-            Leaf e     = first;
+    if (NULL != leaf) {
+        switch (leaf->value_type) {
+        case COL_VAL:
+            if (NULL != leaf->elements) {
+                Leaf first = leaf->elements->next;
+                Leaf e     = first;
 
-            do {
-                compact_leaf(e);
-                e = e->next;
-            } while (e != first);
+                do {
+                    compact_leaf(e);
+                    e = e->next;
+                } while (e != first);
+            }
+            break;
+        case RUBY_VAL: leaf->value = rb_gc_location(leaf->value); break;
+
+        default: break;
         }
-        break;
-    case RUBY_VAL: leaf->value = rb_gc_location(leaf->value); break;
-
-    default: break;
     }
 }
 
@@ -970,8 +972,9 @@ static int move_step(Doc doc, const char *path, int loc) {
     } else {
         Leaf leaf;
 
+        // A document with no root (empty or comment only JSON) has no leaf to
+        // step from so the path can not be located.
         if (0 == doc->where || 0 == (leaf = *doc->where)) {
-            printf("*** Internal error at %s\n", path);
             return loc;
         }
         if ('.' == *path && '.' == *(path + 1)) {
@@ -1251,10 +1254,14 @@ static VALUE doc_path(VALUE self) {
  * #=> nil
  */
 static VALUE doc_local_key(VALUE self) {
-    Doc            doc  = self_doc(self);
-    Leaf           leaf = *doc->where;
-    volatile VALUE key  = Qnil;
+    Doc            doc = self_doc(self);
+    Leaf           leaf;
+    volatile VALUE key = Qnil;
 
+    if (NULL == doc->where || NULL == *doc->where) {
+        return Qnil;
+    }
+    leaf = *doc->where;
     if (T_HASH == leaf->parent_type) {
         key = rb_utf8_str_new_cstr(leaf->key);
     } else if (T_ARRAY == leaf->parent_type) {
@@ -1408,6 +1415,9 @@ static VALUE doc_each_leaf(int argc, VALUE *argv, VALUE self) {
                 }
                 return Qnil;
             }
+        }
+        if (NULL == doc->where || NULL == *doc->where) {
+            return Qnil;
         }
         each_leaf(doc, self);
         if (0 < wlen) {

--- a/ext/oj/saj.c
+++ b/ext/oj/saj.c
@@ -82,7 +82,14 @@ inline static void next_non_white(ParseInfo pi) {
         case '\f':
         case '\n':
         case '\r': break;
-        case '/': skip_comment(pi); break;
+        case '/':
+            skip_comment(pi);
+            /* A comment that is not terminated by a newline ends on the null
+             * terminator. Stop here so the loop does not step past it. */
+            if ('\0' == *pi->s) {
+                return;
+            }
+            break;
         default: return;
         }
     }
@@ -118,13 +125,14 @@ static void skip_comment(ParseInfo pi) {
             if ('*' == *pi->s && '/' == *(pi->s + 1)) {
                 pi->s++;
                 return;
-            } else if ('\0' == *pi->s) {
-                if (pi->has_error) {
-                    call_error("comment not terminated", pi, __FILE__, __LINE__);
-                } else {
-                    raise_error("comment not terminated", pi->str, pi->s);
-                }
             }
+        }
+        /* The loop only ends on the null terminator so the comment was never
+         * closed. */
+        if (pi->has_error) {
+            call_error("comment not terminated", pi, __FILE__, __LINE__);
+        } else {
+            raise_error("comment not terminated", pi->str, pi->s);
         }
     } else if ('/' == *pi->s) {
         for (; 1; pi->s++) {

--- a/ext/oj/saj.c
+++ b/ext/oj/saj.c
@@ -606,6 +606,19 @@ static void saj_parse(VALUE handler, char *json) {
     }
 }
 
+struct _sajArgs {
+    VALUE handler;
+    char *json;
+};
+
+static VALUE protect_saj_parse(VALUE x) {
+    struct _sajArgs *args = (struct _sajArgs *)x;
+
+    saj_parse(args->handler, args->json);
+
+    return Qnil;
+}
+
 /* call-seq: saj_parse(handler, io)
  *
  * Parses an IO stream or file containing an JSON document. Raises an exception
@@ -670,8 +683,17 @@ oj_saj_parse(int argc, VALUE *argv, VALUE self) {
             rb_raise(rb_eArgError, "saj_parse() expected a String or IO Object.");
         }
     }
-    saj_parse(*argv, json);
-    OJ_R_FREE(json);
+    {
+        // saj_parse() raises on a malformed document so the json buffer has to
+        // be freed even when the parse does not return normally.
+        struct _sajArgs args = {*argv, json};
+        int             ex   = 0;
 
+        rb_protect(protect_saj_parse, (VALUE)&args, &ex);
+        OJ_R_FREE(json);
+        if (0 != ex) {
+            rb_jump_tag(ex);
+        }
+    }
     return Qnil;
 }

--- a/test/test_fast.rb
+++ b/test/test_fast.rb
@@ -506,6 +506,67 @@ class DocTest < Minitest::Test
     assert_nil(result)
   end
 
+  # A JSON document with no root such as an empty, whitespace only, or comment
+  # only document has no leaf to navigate to. The Doc API should report the
+  # empty document instead of dereferencing the missing root.
+  NO_ROOT_JSON = ['', ' ', "\t\r\n ", '// comment', "// comment\n", '/* comment */', '#', "\xEF\xBB\xBF"].freeze
+
+  def test_no_root_doc
+    NO_ROOT_JSON.each do |json|
+      Oj::Doc.open(json) do |doc|
+        assert_equal('/', doc.where?)
+        assert_equal('/', doc.home)
+        assert_nil(doc.local_key)
+        assert_nil(doc.type)
+        assert_nil(doc.fetch)
+        assert_nil(doc.dump)
+        refute(doc.exists?('/1'))
+        assert_raises(ArgumentError) { doc.move('/1') }
+
+        leaves = []
+        doc.each_leaf { |d| leaves << d.where? }
+        assert_empty(leaves)
+
+        children = []
+        doc.each_child { |d| children << d.where? }
+        assert_empty(children)
+
+        values = []
+        doc.each_value { |v| values << v }
+        assert_empty(values)
+      end
+    end
+  end
+
+  def test_no_root_doc_file
+    NO_ROOT_JSON.each do |json|
+      filename = File.join(__dir__, 'no_root.json')
+      File.binwrite(filename, json)
+      begin
+        Oj::Doc.open_file(filename) do |doc|
+          assert_equal('/', doc.where?)
+          assert_nil(doc.local_key)
+          assert_nil(doc.fetch)
+          doc.each_leaf { |_d| flunk('no leaf expected') }
+        end
+      ensure
+        File.delete(filename) if File.exist?(filename)
+      end
+    end
+  end
+
+  # A no root Doc that is not opened with a block stays alive and must survive a
+  # GC mark and compaction of its missing root.
+  def test_no_root_doc_gc
+    docs = NO_ROOT_JSON.map { |json| Oj::Doc.open(json) }
+    GC.start
+    GC.compact if GC.respond_to?(:compact)
+    docs.each do |doc|
+      assert_nil(doc.local_key)
+      doc.close
+    end
+  end
+
   def test_comment
     json = %{{
   "x"/*one*/:/*two*/true,//three

--- a/test/test_fast.rb
+++ b/test/test_fast.rb
@@ -598,4 +598,19 @@ class DocTest < Minitest::Test
     assert_equal({'/x' => true, '/y' => 58, '/z/1' => 1, '/z/2' => 2, '/z/3' => 3}, results)
   end
 
+  # A line comment may end on the last byte of the document. Scanning it must
+  # stop on the null terminator instead of reading the byte after the buffer.
+  def test_comment_at_end
+    ['//', '// comment', '[1,2] // comment'].each do |json|
+      Oj::Doc.open(json) { |doc| doc.fetch() }
+    end
+    assert_equal([1, 2], Oj::Doc.open('[1,2] // comment') { |doc| doc.fetch() })
+  end
+
+  def test_comment_not_terminated
+    ['/*', '/* comment', '[/* comment'].each do |json|
+      assert_raises(Oj::ParseError, json) { Oj::Doc.open(json) { |doc| doc.fetch() } }
+    end
+  end
+
 end # DocTest

--- a/test/test_fast.rb
+++ b/test/test_fast.rb
@@ -460,6 +460,20 @@ class DocTest < Minitest::Test
     end
   end
 
+  # A file must be read in binary mode. A text mode read on Windows translates
+  # CRLF into LF so fewer bytes are read than the size of the file.
+  def test_file_open_crlf
+    filename = File.join(__dir__, 'open_file_crlf_test.json')
+    File.binwrite(filename, %({\r\n"a":[1,2,3]\r\n}))
+    begin
+      Oj::Doc.open_file(filename) do |doc|
+        assert_equal({'a' => [1, 2, 3]}, doc.fetch())
+      end
+    ensure
+      File.delete(filename) if File.exist?(filename)
+    end
+  end
+
   def test_open_no_close
     json = %{{"a":[1,2,3]}}
     doc = Oj::Doc.open(json)

--- a/test/test_saj.rb
+++ b/test/test_saj.rb
@@ -216,4 +216,20 @@ class SajTest < Minitest::Test
     assert_match(%r{invalid format, extra characters at line 1, column 6 \[(?:[A-Za-z]:/)?(?:[a-z.]+/)*saj\.c:\d+\]}, message)
   end
 
+  # A line comment may end on the last byte of the document. Scanning it must
+  # stop on the null terminator instead of reading the byte after the buffer.
+  def test_comment_at_end
+    ['//', '// comment', '[1,2] // comment'].each do |json|
+      handler = AllSaj.new()
+      Oj.saj_parse(handler, json)
+      refute_includes(handler.calls.map(&:first), :error, json)
+    end
+  end
+
+  def test_comment_not_terminated
+    ['/*', '/* comment', '[1,2] /* comment'].each do |json|
+      assert_raises(Oj::ParseError, json) { Oj.saj_parse(Oj::Saj.new, json) }
+    end
+  end
+
 end


### PR DESCRIPTION
Fixes #1016.

## Problem

A JSON document with no root — an empty string, whitespace only, comment only, `#`, a bare BOM, or plain junk — parses to a `NULL` root leaf, but `Oj::Doc.open` / `Oj::Doc.open_file` still hand back a live `Doc`. Three code paths then dereference that missing root and take the process down with a segfault:

```ruby
Oj::Doc.open('').local_key          # => [BUG] Segmentation fault
Oj::Doc.open('') { |d| d.each_leaf {} }  # => [BUG] Segmentation fault

d = Oj::Doc.open('')
GC.compact                          # => [BUG] Segmentation fault (compaction enabled builds)
```

`read_next()` returns `0` when it finds no root, and `protect_open_proc()` stores that as `doc->data` and as `where_path[0]` without complaint, so a live `Doc` ends up with `data == NULL` and `*where == NULL`.

Most of the `Doc` API already tolerates this state and reports the empty document (`where` returns `/`, `type` / `fetch` / `dump` / `local_key` return `nil`, the iterators yield nothing). Three siblings were missed:

| Site | Unsafe dereference |
|---|---|
| `doc_local_key` | `Leaf leaf = *doc->where;` then `leaf->parent_type` |
| `each_leaf` (via `doc_each_leaf`) | `(*doc->where)->value_type` |
| `compact_leaf` (via `compact_doc`) | `leaf->value_type` |

The asymmetry is easiest to see in the iterators: `doc_each_child` has the `NULL == *doc->where` guard, and its sibling `doc_each_leaf` does not. Likewise `mark_leaf` null checks its argument but its compaction counterpart `compact_leaf` does not, so a retained no-root `Doc` crashes the next `GC.compact`.

## Fix

Guard the three missed sites, using the predicate already in `doc_each_child`.

This keeps `Oj::Doc.open('')` returning a usable `Doc` rather than raising. That is deliberate: bf74678 ("Fix empty Doc each_child bug") fixed this same class of bug by adding a guard rather than by rejecting the input, and `test_doc_empty` locks in that contract. Raising in `protect_open_proc()` instead would be a smaller diff, but it changes `Oj::Doc.open('')` from "returns a Doc" to "raises" and breaks that existing test, so it is left alone. Behavior on every valid document is unchanged.

The `printf("*** Internal error ...")` in `move_step()` is removed while here. It is not an internal error — it is exactly the no-root document reached by `Oj::Doc.open('').move('/1')`, and it wrote to stdout from a library. The resulting `ArgumentError` is unchanged.

## Reading a file in binary mode

The second commit is a Windows only fix that the new file test uncovered. `doc_open_file()` opened the file with `fopen(path, "r")`, so on Windows the read ran in text mode and translated CRLF into LF. That makes `fread()` return fewer bytes than the file size `ftell()` reported, and `open_file` raises `Oj::LoadError: Failed to read N bytes`. A JSON file with CRLF line endings could not be read at all. Opening with `"rb"` fixes it, and POSIX makes no distinction between the two modes so nothing changes on Linux or macOS. `test_file_open_crlf` covers it.

## Reading past the end of a comment

The last three commits are a heap overread that the new comment only inputs uncovered, plus what fixing it exposed.

`next_non_white()` walks whitespace and comments with `for (; 1; pi->s++)`, which assumes every `switch` arm consumes exactly one byte. The `case '/'` arm breaks that assumption: `skip_comment()` consumes a whole comment and can leave the pointer sitting **on the null terminator**, and the loop's own `pi->s++` then steps past it and reads the byte after the buffer. It happens two ways:

- a line comment that ends the document (`// comment` with no trailing newline), which is a valid document and must not raise;
- a block comment that is never closed (`/*`), which should raise but did not — see below.

Returning as soon as the comment ends on the terminator fixes both. `fast.c` and `saj.c` each carry their own copy of this scanner and both were affected; `parse.c` is bounded by `pi->end` and `sparse.c` is reader-bounded, so neither is. Terminated comments (`// x\n`, `/* x */`) never reach this path and are unchanged.

**The unterminated block comment error was dead code.** In both files the `comment not terminated` error sits in an `else if ('\0' == *pi->s)` branch *inside* a loop whose condition is `'\0' != *pi->s`, so it can never run. The loop exits by hitting the terminator and the function just returns. Moving the error after the loop, where it is reachable, makes `Oj::Doc.open('/*')` and `Oj.saj_parse(handler, '/*')` raise `Oj::ParseError` — which is what `sparse.c` already does for the same document.

**That raise then exposed a leak in `oj_saj_parse()`.** It allocates a copy of the document and frees it after `saj_parse()` returns, but `saj_parse()` raises on a malformed document, so the free is skipped. This is not specific to comments — valgrind reports the leak today for `Oj.saj_parse(handler, '{"a":1')`. Running the parse under `rb_protect()` frees the buffer on both paths. Without this, every new raise would leak.

## Validation

- Reproduced the reporter's matrix of 21 no-root / malformed inputs against 18 `Doc` entry points, for both `Doc.open` and `Doc.open_file`: 63 segfaults before (`local_key`, `each_leaf`, `GC.compact` for every input), 0 after, across all 756 combinations.
- AddressSanitizer over a comment input matrix (`''`, `' '`, `'//'`, `'// x'`, `'// x\n'`, `'/*'`, `'/* x'`, `'/* x */'`, `'/**/'`, `'/* x */ 5'`, `'[1,/*c*/2]'`, `'{"a":1 // c\n}'`, `'[1,2] /*'`, ...) against `saj_parse`, `Doc.open`, and `Doc.open_file`: 5 heap buffer overreads in `saj.c` before, 0 after. Valgrind sees this overread too — it is what the memcheck CI job caught in `fast.c`.
- `rake test:valgrind` (ruby_memcheck) is clean: no invalid reads and no leaks.
- Differential check on valid documents: `size`, `where`, `local_key`, `home`, `type`, `fetch`, `dump`, `exists?`, `move`, `each_leaf`, `each_child`, `each_value` over 17 documents × 7 paths produce byte-for-byte identical output before and after the patch. Documents with comments (`test_comment`) parse identically.
- `test/tests.rb` passes (502 runs, 0 failures). The three no-root tests each segfault on the unpatched build and pass on the patched one; `test_no_root_doc_gc` covers the compaction path.

## Out of scope

`parse.c` carries the same dead `comment not terminated` branch, so `Oj.load('/*')` returns `nil` rather than raising. Unlike `fast.c` and `saj.c` its comment scanner is bounded by `pi->end`, so there is no overread and no memory issue — only the inconsistency with `sparse.c`, which does raise. I left it alone to keep this PR to the crash and the overread; happy to send it separately if you want the three string parsers to agree.

The other finding in the issue, the stack smashing in `Oj.load` with a custom IO that returns `""` on its second read, does not reproduce on this build. It raises `Oj::ParseError: Array not terminated` cleanly and repeatably. It is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
