### PR TITLE
Fix a shared Date or DateTime loading as nil with the circular option

### DIFF
--- a/ext/oj/dump_object.c
+++ b/ext/oj/dump_object.c
@@ -10,6 +10,24 @@ static const char hex_chars[17] = "0123456789abcdef";
 
 static void dump_obj_attrs(VALUE obj, VALUE clas, slot_t id, int depth, Out out);
 
+// An odd class is dumped as {"^O":class,...} and is rebuilt with a create
+// function when loaded so there is no place to put a "^i" circular id on it.
+// Registering it in the circular cache would consume an id that is never
+// written and any later occurrence would then be dumped as a "^r" that refers
+// to nothing. Instead dump odd classes in full each time they are encountered
+// just like Time, Rational, and Complex are.
+static void dump_circular_obj(VALUE obj, VALUE clas, int depth, Out out) {
+    if (NULL != oj_get_odd(clas)) {
+        dump_obj_attrs(obj, clas, 0, depth, out);
+    } else {
+        long id = oj_check_circular(obj, out);
+
+        if (0 <= id) {
+            dump_obj_attrs(obj, clas, id, depth, out);
+        }
+    }
+}
+
 static void dump_time(VALUE obj, Out out) {
     switch (out->opts->time_format) {
     case RubyTime:
@@ -47,11 +65,7 @@ static void dump_data(VALUE obj, int depth, Out out, bool as_ok) {
                 oj_dump_cstr(str, len, 0, 0, out);
             }
         } else {
-            long id = oj_check_circular(obj, out);
-
-            if (0 <= id) {
-                dump_obj_attrs(obj, clas, id, depth, out);
-            }
+            dump_circular_obj(obj, clas, depth, out);
         }
     }
 }
@@ -74,11 +88,7 @@ static void dump_obj(VALUE obj, int depth, Out out, bool as_ok) {
             oj_dump_raw(str, len, out);
         }
     } else {
-        long id = oj_check_circular(obj, out);
-
-        if (0 <= id) {
-            dump_obj_attrs(obj, clas, id, depth, out);
-        }
+        dump_circular_obj(obj, clas, depth, out);
     }
 }
 

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -207,6 +207,24 @@ class ObjectJuice < Minitest::Test
     end # Ni
   end # Ichi
 
+  class Oddball
+
+    attr_reader :h
+
+    def initialize(h)
+      @h = h
+    end
+
+    def self.create(h)
+      new(h)
+    end
+
+    def ==(other)
+      other.is_a?(Oddball) && other.h == @h
+    end
+
+  end # Oddball
+
   def setup
     @default_options = Oj.default_options
   end
@@ -948,6 +966,58 @@ class ObjectJuice < Minitest::Test
     Oj.load(json, :mode => :object, :circular => true)
     assert_equal(obj.x.__id__, h.__id__)
     assert_equal(h['b'].__id__, obj.__id__)
+  end
+
+  # An odd class such as Date is rebuilt with a create function when loaded so
+  # it can not be the target of a circular reference. It must be dumped in full
+  # each time it is encountered instead of leaving a dangling "^r".
+  def test_circular_shared_date
+    date = Date.new(2026, 7, 6)
+    json = Oj.dump({ 'a' => { 'x' => date }, 'b' => { 'x' => date } }, :mode => :object, :circular => true)
+    refute_match(/\^r/, json)
+    h = Oj.load(json, :mode => :object, :circular => true)
+    assert_equal(date, h['a']['x'])
+    assert_equal(date, h['b']['x'])
+  end
+
+  def test_circular_shared_datetime
+    date = DateTime.new(2026, 7, 6, 12, 30, 0)
+    json = Oj.dump({ 'a' => { 'x' => date }, 'b' => { 'x' => date } }, :mode => :object, :circular => true)
+    refute_match(/\^r/, json)
+    h = Oj.load(json, :mode => :object, :circular => true)
+    assert_equal(date, h['a']['x'])
+    assert_equal(date, h['b']['x'])
+  end
+
+  # Issue #961, a Range with the same Date as the begin and the end.
+  def test_circular_shared_date_in_range
+    date = Date.new(2026, 7, 6)
+    range = date..date
+    json = Oj.dump({ 'r' => range }, :mode => :object, :circular => true)
+    refute_match(/\^r/, json)
+    h = Oj.load(json, :mode => :object, :circular => true)
+    assert_equal(range, h['r'])
+  end
+
+  def test_circular_shared_datetime_in_range
+    date = DateTime.new(2026, 7, 6, 12, 30, 0)
+    range = date..date
+    json = Oj.dump({ 'r' => range }, :mode => :object, :circular => true)
+    refute_match(/\^r/, json)
+    h = Oj.load(json, :mode => :object, :circular => true)
+    assert_equal(range, h['r'])
+  end
+
+  def test_circular_shared_odd
+    Oj.register_odd(Oddball, Oddball, :create, :h)
+    odd = Oddball.new({'a' => 1})
+    json = Oj.dump({ 'a' => odd, 'b' => odd }, :mode => :object, :circular => true)
+    # The odd object itself is dumped in full each time. The hash it is built
+    # from is a plain Hash so it can still be shared with a "^r".
+    assert_equal(%|{"^i":1,"a":{"^O":"ObjectJuice::Oddball","h":{"^i":2,"a":1}},"b":{"^O":"ObjectJuice::Oddball","h":"^r2"}}|, json)
+    h = Oj.load(json, :mode => :object, :circular => true)
+    assert_equal(odd, h['a'])
+    assert_equal(odd, h['b'])
   end
 
   def test_omit_nil


### PR DESCRIPTION

Fixes #1036.

## The bug

In the `:object` mode with `circular: true`, a `Date` (or `DateTime`) shared by two sibling hashes loads back as `nil`:

```ruby
date = Date.new(2026, 7, 6)
json = Oj.dump({a: {x: date}, b: {x: date}}, mode: :object, circular: true)
# {"^i":1,":a":{"^i":2,":x":{"^O":"Date","year":2026,"month":7,"day":6,"start":2299161.0}},":b":{"^i":4,":x":"^r3"}}
Oj.load(json, mode: :object, circular: true)
# {:a=>{:x=>#<Date: 2026-07-06 ...>}, :b=>{:x=>nil}}
```

Note the dump itself: the `Date` carries no `^i` id, yet the second occurrence is `"^r3"`, a back reference to an id that appears nowhere in the document. The id counter did advance, the top hash is `^i:1`, hash `a` is `^i:2`, and hash `b` is `^i:4`, so id `3` was consumed by the `Date` and never written. On load the unresolvable `^r3` becomes `nil` and the data is silently corrupted with no error.

## Root cause

`Date` and `DateTime` are registered as odd classes in `ext/oj/odd.c`. An odd class is dumped as `{"^O":class,...}` and is rebuilt with a create function when it is loaded, so there is no place to put a circular `^i` id on it and `dump_odd()` never writes one.

The problem is that the id is consumed before the odd branch is reached. `dump_data()` (`ext/oj/dump_object.c:49`) and `dump_obj()` (`ext/oj/dump_object.c:76`) both call `oj_check_circular()` first, which increments `out->circ_cnt` and registers the object in the circular cache, and only then call `dump_obj_attrs()`. The first thing `dump_obj_attrs()` does (`ext/oj/dump_object.c:470`) is to hand an odd class to `dump_odd()`, dropping the id it was given. The object is now in the circular cache with an id that was never written, so the next occurrence is dumped as a `^r` that refers to nothing.

Why the other types were not affected:

- `Time` is special cased in `dump_data()` before `oj_check_circular()` is called, so it never enters the circular cache and is dumped in full each time.
- `Rational` and `Complex` have their own dump functions that call `dump_obj_attrs()` with the id `0` and never call `oj_check_circular()`, so they too are dumped in full each time. `Rational` is an odd class and round trips correctly today for exactly this reason.
- A plain object dumped as `^o` reaches `dump_obj_attrs()`, does not match an odd class, and writes its `"^i":<id>` there.

So the odd `^O` path was the only path that consumed a circular id without ever materializing it.

## The fix

Keep odd classes out of the circular cache, the same way `Time`, `Rational`, and `Complex` already are. The check is done at the point where the odd class is knowable and before the id is consumed, in a small helper shared by both `dump_data()` and `dump_obj()` so that both the `T_DATA` and the `T_OBJECT` entry points are covered:

```c
static void dump_circular_obj(VALUE obj, VALUE clas, int depth, Out out) {
    if (NULL != oj_get_odd(clas)) {
        dump_obj_attrs(obj, clas, 0, depth, out);
    } else {
        long id = oj_check_circular(obj, out);

        if (0 <= id) {
            dump_obj_attrs(obj, clas, id, depth, out);
        }
    }
}
```

A shared odd object is now dumped in full each time it is encountered and no dangling `^r` is written:

```ruby
Oj.dump({a: {x: date}, b: {x: date}}, mode: :object, circular: true)
# {"^i":1,":a":{"^i":2,":x":{"^O":"Date",...}},":b":{"^i":3,":x":{"^O":"Date",...}}}
Oj.load(json, mode: :object, circular: true)
# {:a=>{:x=>#<Date: 2026-07-06 ...>}, :b=>{:x=>#<Date: 2026-07-06 ...>}}
```

### Trade off

The shared odd object comes back as an equal object rather than as the same object.

Preserving the identity is possible. It would mean writing an `^i` inside the `^O` hash and, on load, re-registering the instance in the circular array in `end_hash()` after the create function has run, since at parse time the value on the stack is still the class and not the instance yet. That needs a new field on the `Val` stack entry to carry the id from the `^i` key to the close of the hash, a new case in `hash_set_num()` for the `^i` key on a `T_CLASS` value, which today is fed to `oj_odd_set_arg()` and raises `^i is not an attribute of Date`, and a change to the dump side. It also changes the `^O` format, so a dump written by this version would raise a parse error on an older Oj.

That is a lot of surface, on both the dump and the load side, for an identity that `Date`, `DateTime`, `Rational`, and `Complex` do not need since they are immutable value types. Given that `Time`, `Rational`, and `Complex` are already dumped in full every time, doing the same for odd classes is both the smaller and the more consistent fix, so the identity preserving version is left aside for now. The `^o` path, where the identity is preserved, is untouched.

The attributes of an odd object are dumped normally, so a plain object or hash shared between two odd objects is still shared through `^i` and `^r` as before.

## Relation to #961

Issue #961, a `Range` with the same `Date` as the begin and the end, was worked around in 3.16.11 by disabling the circular option inside the `Range` struct dump. That is the same underlying problem seen through a different shape. #1036 needs no `Range` at all, only a `Date` shared between two arbitrary values. The `Range` workaround keeps working and is now covered by a test so it cannot regress.

## Tests

Added to `test/test_object.rb`:

- `test_circular_shared_date` and `test_circular_shared_datetime`, a `Date` and a `DateTime` shared by two sibling hashes, assert that no `^r` is written and that both values load back equal to the original.
- `test_circular_shared_date_in_range` and `test_circular_shared_datetime_in_range`, the #961 shape, as a regression guard.
- `test_circular_shared_odd`, a class registered with `Oj.register_odd` and shared, asserts the exact dump and that the hash the odd object is built from is still shared through `^i` and `^r`.

The three new tests for the shared `Date`, `DateTime`, and odd class fail on develop and pass with this change. `test/tests.rb` is green, 507 runs, 1258 assertions, 0 failures, 0 errors.

`rake test:valgrind` (ruby_memcheck) on Linux is clean, 484 runs, 1231 assertions, 0 failures, 0 errors, and no memory errors reported.
