### PR TITLE
Fix Rails `to_json(only:/except:)` dropping the include_root wrapper (#1020) and `methods:` keys (#1008)

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -1456,10 +1456,11 @@ void oj_dump_raw(const char *str, size_t cnt, Out out) {
 }
 
 void oj_out_init(Out out) {
-    out->buf       = out->stack_buffer;
-    out->cur       = out->buf;
-    out->end       = out->buf + sizeof(out->stack_buffer) - BUFFER_EXTRA;
-    out->allocated = false;
+    out->buf            = out->stack_buffer;
+    out->cur            = out->buf;
+    out->end            = out->buf + sizeof(out->stack_buffer) - BUFFER_EXTRA;
+    out->allocated      = false;
+    out->key_filter_off = false;
 }
 
 void oj_out_free(Out out) {

--- a/ext/oj/oj.h
+++ b/ext/oj/oj.h
@@ -197,6 +197,7 @@ typedef struct _out {
     bool      allocated;
     bool      omit_nil;
     bool      omit_null_byte;
+    bool      key_filter_off;  // rails: suppress the :only/:except key filter for an as_json result
     int       argc;
     VALUE    *argv;
     ROptTable ropts;

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -500,30 +500,45 @@ static void dump_as_string(VALUE obj, int depth, Out out, bool as_ok) {
 
 static void dump_as_json(VALUE obj, int depth, Out out, bool as_ok) {
     volatile VALUE ja;
+    bool           selected;
 
     TRACE(out->opts->trace, "as_json", obj, depth + 1, TraceRubyIn);
     // Some classes elect to not take an options argument so check the arity
     // of as_json.
     if (0 == rb_obj_method_arity(obj, oj_as_json_id)) {
-        ja = rb_funcall(obj, oj_as_json_id, 0);
+        ja       = rb_funcall(obj, oj_as_json_id, 0);
+        selected = false;  // as_json got no options so it did not do any :only/:except selection
     } else {
-        ja = rb_funcall2(obj, oj_as_json_id, out->argc, out->argv);
+        selected = (0 < out->argc);  // Rails handed the :only/:except options to as_json
+        ja       = rb_funcall2(obj, oj_as_json_id, out->argc, out->argv);
     }
     TRACE(out->opts->trace, "as_json", obj, depth + 1, TraceRubyOut);
 
     out->argc = 0;
-    if (ja == obj || !as_ok) {
-        // Once as_json is called it should never be called again on the same
-        // object with as_ok.
-        dump_rails_val(ja, depth, out, false);
-    } else {
-        int type = rb_type(ja);
+    // When as_json received the options it has already applied the Rails
+    // :only/:except selection at the attribute level (and kept the
+    // include_root_in_json wrapper and any :methods keys), so the Oj dump level
+    // :only/:except key filter must not be applied to the value it returned - a
+    // second pass would drop the wrapper (#1020) and the :methods keys (#1008).
+    // Suppress the filter only for this subtree (save and restore) so sibling
+    // keys outside the as_json result are still filtered. This is a flag on the
+    // dump state, not a change to out->opts: a StringWriter owns its options
+    // struct, so clearing only/except there would leak the buffers and kill the
+    // filter for every later push_value.
+    {
+        bool key_filter_off = out->key_filter_off;
 
-        if (T_HASH == type || T_ARRAY == type) {
-            dump_rails_val(ja, depth, out, true);
+        if (selected) {
+            out->key_filter_off = true;
+        }
+        if (ja == obj || !as_ok) {
+            // Once as_json is called it should never be called again on the same
+            // object with as_ok.
+            dump_rails_val(ja, depth, out, false);
         } else {
             dump_rails_val(ja, depth, out, true);
         }
+        out->key_filter_off = key_filter_off;
     }
 }
 
@@ -1302,7 +1317,7 @@ static int hash_cb(VALUE key, VALUE value, VALUE ov) {
     if (out->omit_nil && Qnil == value) {
         return ST_CONTINUE;
     }
-    if (NULL != out->opts->dump_opts.only || NULL != out->opts->dump_opts.except) {
+    if (!out->key_filter_off && (NULL != out->opts->dump_opts.only || NULL != out->opts->dump_opts.except)) {
         if (oj_key_skip(key, out->opts->dump_opts.only, out->opts->dump_opts.except)) {
             return ST_CONTINUE;
         }

--- a/ext/oj/string_writer.c
+++ b/ext/oj/string_writer.c
@@ -78,6 +78,8 @@ void oj_str_writer_init(StrWriter sw, int buf_size) {
     sw->out.argv       = NULL;
     sw->out.ropts      = NULL;
     sw->out.omit_nil   = oj_default_options.dump_opts.omit_nil;
+    // oj_str_writer_init does not call oj_out_init, so clear this here too.
+    sw->out.key_filter_off = false;
 }
 
 void oj_str_writer_push_key(StrWriter sw, const char *key) {

--- a/test/test_rails.rb
+++ b/test/test_rails.rb
@@ -5,6 +5,28 @@ $LOAD_PATH << __dir__
 
 require 'helper'
 
+# Stand-ins for what ActiveRecord's as_json returns. as_json has already
+# resolved the Rails :only/:except selection at the attribute level, so these
+# return the finished hash (an include_root_in_json wrapper, or :methods keys).
+# No ActiveSupport or database is needed to exercise the #1008 / #1020 paths.
+class OjRootWrappedProbe
+  def as_json(_options = nil)
+    {'vendor' => {'name' => 'v-1'}}
+  end
+end
+
+class OjMethodsProbe
+  def as_json(_options = nil)
+    {'name' => 'v-1', 'company_and_code' => 'v-1/c1'}
+  end
+end
+
+class OjSecretProbe
+  def as_json(_options = nil)
+    {'name' => 'v-1', 'secret' => 's-1'}
+  end
+end
+
 class RailsJuice < Minitest::Test
 
   def test_bigdecimal_dump
@@ -58,6 +80,40 @@ class RailsJuice < Minitest::Test
       json = Oj::Rails::Encoder.new(match_string: {/^x/ => String}).encode({id: 1})
       assert_equal('{"id":1}', json)
     end
+  end
+
+  # #1020: to_json(only:) on a record with include_root_in_json wraps each row
+  # in a root key. as_json already applied :only to the inner attributes, so the
+  # wrapper key must survive - it must not be dropped by the dump level filter.
+  def test_1020_only_keeps_as_json_root_wrapper
+    json = Oj::Rails::Encoder.new(only: [:name]).encode(OjRootWrappedProbe.new)
+    assert_equal('{"vendor":{"name":"v-1"}}', json)
+  end
+
+  # #1008: to_json(only:, methods:) - the key added by :methods is not one of the
+  # :only attributes, but as_json added it on purpose, so it must survive.
+  def test_1008_only_keeps_as_json_methods_key
+    json = Oj::Rails::Encoder.new(only: [:name], methods: [:company_and_code]).encode(OjMethodsProbe.new)
+    assert_equal('{"name":"v-1","company_and_code":"v-1/c1"}', json)
+  end
+
+  # The suppression is scoped to the as_json result: sibling keys of the object
+  # that are not selected are still filtered.
+  def test_only_still_filters_siblings_of_as_json_value
+    json = Oj.dump({'a' => OjMethodsProbe.new, 'b' => 1, 'c' => 2}, mode: :rails, only: ['a', 'b'])
+    assert_equal('{"a":{"name":"v-1","company_and_code":"v-1/c1"},"b":1}', json)
+  end
+
+  # A StringWriter owns its options struct. Suppressing the filter for an
+  # as_json value must not disturb that struct, so :only keeps working for the
+  # value and for every later push_value on the same writer (and nothing leaks).
+  def test_string_writer_rails_only_survives_as_json
+    w = Oj::StringWriter.new(mode: :rails, only: ['name'])
+    w.push_object
+    w.push_value(OjSecretProbe.new, 'a')
+    w.push_value({'name' => 1, 'secret' => 2}, 'b')
+    w.pop
+    assert_equal(%|{"a":{"name":"v-1"},"b":{"name":1}}\n|, w.to_s)
   end
 
 end


### PR DESCRIPTION
Fixes #1020. References #1008 — see Scope: #1008 does not say what its `collection` is, and
whether it is fully fixed depends on that, so I have left it for you to close.

## Problem

When Oj is the ActiveSupport JSON encoder (`Oj.optimize_rails` installs `Oj::Rails::Encoder` as `ActiveSupport.json_encoder`), a Rails `to_json(only:/except:)` on an ActiveRecord relation or model produces the wrong JSON.

#1020 — with `include_root_in_json = true`:

```ruby
Oj.optimize_rails
Oj.default_options = { mode: :compat }
vendors.to_json(only: [:name])
# 3.16.16:  [{"vendor":{"name":"vendor-1"}}, ...]
# 3.16.17+: [{}, {}, {}, ...]                 ← the "vendor" wrapper is gone
```

#1008 — with `methods:`:

```ruby
Oj.optimize_rails
collection.to_json(only: [:id, :code], methods: %i[company_and_code])
# 3.16.16:  [{"id":.., "code":.., "company_and_code":..}, ...]
# 3.16.17+: [{"id":.., "code":..}, ...]        ← company_and_code is gone
```

Plain Rails (the `JSONGemEncoder`, i.e. Oj not installed as the encoder) keeps both the root wrapper and the `methods:` keys, and that is the expected result:

| call | plain Rails (expected) | Oj 3.16.17+ (wrong) |
|---|---|---|
| `root=true  relation.to_json(only: [:name])` | `[{"vendor":{"name":..}}, ...]` | `[{}, ...]` |
| `root=false relation.to_json(only: [:name], methods: [:company_and_code])` | `[{"name":.., "company_and_code":..}, ...]` | `[{"name":..}, ...]` |
| `root=true  model.to_json(only: [:name])` | `{"vendor":{"name":..}}` | `{}` |

## Root cause

The regression was introduced by `e21c538` ("Array hash as json", #1003), which added a general purpose Oj dump option, `:only` / `:except`, that filters output hash keys. `oj_key_skip` (ext/oj/dump.c) drops any key whose name is not listed in `:only` (or is listed in `:except`).

A Rails `to_json` reaches the same option parser, because `to_json` and `Oj::Rails::Encoder.new` are the same path once Oj is the encoder:

```
x.to_json(only: [:name])
  → ActiveSupport::JSON.encode(x, {only: [:name]})
  → Oj::Rails::Encoder.new({only: [:name]}).encode(x)
  → encoder_new() runs oj_parse_options(e->arg, &e->opts)   (ext/oj/rails.c)
  → e->opts.dump_opts.only = ":name:"
```

So the `:only` that Rails means as "select these model attributes" — already resolved by `as_json`, which also keeps the `include_root_in_json` wrapper and the `methods:` keys — is applied a **second** time by Oj, as a literal key filter on the hash `as_json` already produced. The outer `"vendor"` key is not `"name"`, so it is dropped (#1020); `"company_and_code"` is not in `:only`, so it is dropped (#1008).

This is not gated by the `Array`/`Hash` optimization: `oj_key_skip` runs regardless, so `Oj::Rails.deoptimize(Array, Hash)` is **not** a workaround. On released versions the only workaround is to pre-resolve with `as_json` and encode the result without options: `x.as_json(only: [:name]).to_json`.

## Fix

Once `as_json` has been called with the options, it has already applied the Rails `:only`/`:except` selection at the attribute level, so Oj must not re-apply its key filter to the value `as_json` returned. `dump_as_json` (ext/oj/rails.c) now suppresses the key filter for that value:

```c
selected = (0 < out->argc);                 // Rails handed the options to as_json
...
out->argc = 0;
{
    bool key_filter_off = out->key_filter_off;
    if (selected) {
        out->key_filter_off = true;         // don't re-filter what as_json selected
    }
    ... dump the as_json result ...
    out->key_filter_off = key_filter_off;   // restore for sibling keys
}
```

and `hash_cb` honors the flag:

```c
if (!out->key_filter_off && (only || except)) { if (oj_key_skip(key, only, except)) continue; }
```

Three properties of this shape matter:

1. **The suppression lives on the dump state (`struct _out`), not on `out->opts`.** `out->opts` is not always a per-call copy — a `StringWriter`/`StreamWriter` points it at its own owned options struct (`sw->out.opts = &sw->opts`, taken ownership of in `str_writer_new`), so the options must stay read-only during a dump. The flag never touches `out->opts`.

2. **It is scoped to the `as_json` value (save/restore), so sibling keys are still filtered.** `Oj.dump({a: obj_with_as_json, b: 1, c: 2}, mode: :rails, only: ['a', 'b'])` still drops `c`.

3. **It only fires when `as_json` was handed the per-call options (`0 < out->argc`).** If `as_json` ran without them it did not do the selection, so the filter still applies. (The gate is "were any per-call options passed", not specifically `:only`/`:except`; narrowing it to the exact keys would need `only_sym`/`except_sym` exported, which does not seem worth it for the corner case.)

The two identical arms of the old `T_HASH == type || T_ARRAY == type` check in `dump_as_json` are collapsed into one `dump_rails_val` call — it was dead code, and the new block wrapper touches those lines anyway.

Scope of the change: only `ext/oj/rails.c` applies this suppression, so `:only`/`:except` in `:compat`/`:strict`/`:object`/`:custom` modes are unchanged. One `:rails`-mode case changes beyond `to_json`: `Oj.dump(obj_that_defines_as_json, mode: :rails, only: […])` also passes the per-call options into `argv` (existing behavior), so `as_json` receives them and Oj no longer re-applies the key filter to its result (develop did). That is the same rule as `to_json`, applied consistently, and `test_only_still_filters_siblings_of_as_json_value` covers it.

### Preserved (no behavior change)

- `Oj.dump(hash, mode: :custom/:compat/:strict/:object, only: […])` — the #1003 feature. `test_various.rb` / `test_custom.rb` unchanged and green.
- `Oj::Rails::Encoder.new(only: […]).encode(plain_hash)` — still filters, because a plain hash without `as_json` never enters `dump_as_json`. `test_rails.rb` `test_encoder_only` / `test_encoder_except` (the #1031 leak-guard tests) unchanged and green.
- `Oj::StringWriter.new(mode: :rails, only: […])` / `Oj::StreamWriter` — still filter; a writer never sets `out->argc` above `0` (`str_writer_new` uses `argc - 1`, the stream writer leaves it at `0`), so `0 < out->argc` is false and its values never take the suppression path.
- `x.as_json(only: […]).to_json` and `Oj::Rails.encode(x, only: […])` already returned the correct result and still do.

## A note on plain Rails parity

For AR relations/models (what #1008/#1020 are about) the result now matches plain Rails. It is not a universal key-for-key match: for a bare string-keyed Ruby hash, Rails' `as_json` uses a symbol `slice`/`except` (so `{'id'=>1}.to_json(only: [:id])` is `{}` under plain Rails), while Oj's `:only`/`:except` matches the string key. That difference is pre-existing (#1003) and unchanged here; the issues use models whose attribute names resolve correctly.

## Measurements

The numbers below come from a small script (happy to post it on the issues if useful): Ruby 4.0 / Rails 8.1 / sqlite3 in memory, a `Vendor` model with `name` and `code` columns and a `company_and_code` method, three rows with `name` `vendor-0..2` and `code` `secret-0..2` — `code` stands in for a column `:only` is meant to keep out of the response. Each case is measured twice in the same process: once through ActiveSupport's `JSONGemEncoder` before `Oj.optimize_rails` (the oracle — "what does the native json do"), and once through Oj, then compared. No expectations are hard coded.

A relation receiver — the shape #1020 reports — is correct on every case:

| `root=true  relation.to_json(only: [:name])` | output |
|---|---|
| plain Rails (oracle) | `[{"vendor":{"name":"vendor-0"}},{"vendor":{"name":"vendor-1"}},{"vendor":{"name":"vendor-2"}}]` |
| 3.16.16 | same as the oracle |
| 3.16.17 | `[{},{},{}]` |
| this PR | same as the oracle |

Same for `root=false relation.to_json(only: [:name], methods: [:company_and_code])`: `company_and_code` is dropped on 3.16.17 and restored here, matching the oracle.

## Scope — a related issue left for a follow-up PR

There is a second, independent regression from `85e5b49` (#985): `out->argc` is consumed by the first `dump_as_json`, so when a container holds more than one object that defines `as_json`, only the first receives the options. It is not limited to a bare `Array` — a `Hash` value hits it too:

```ruby
Oj.dump({'a' => probe1, 'b' => probe2}, mode: :rails, only: ['a', 'b'])
# → {"a":{"name":..,"company_and_code":..}, "b":{}}
```

A relation is serialized by a single top-level `as_json` (`Relation#as_json` is `to_a.as_json(options)`), so it does not hit this. A bare `Array` of models does:

| `root=true  Array.to_json(only: [:name])` | output |
|---|---|
| plain Rails (oracle) | `[{"vendor":{"name":"vendor-0"}},{"vendor":{"name":"vendor-1"}},{"vendor":{"name":"vendor-2"}}]` |
| 3.16.16 | same as the oracle |
| 3.16.17 | `[{},{},{}]` |
| this PR | `[{"vendor":{"name":"vendor-0"}},{},{}]` |

| `root=false Array.to_json(only: [:name], methods: [:company_and_code])` | output |
|---|---|
| plain Rails (oracle) | `[{"name":"vendor-0","company_and_code":"vendor-0/secret-0"}, …×3]` |
| 3.16.17 | `[{"name":"vendor-0"},{"name":"vendor-1"},{"name":"vendor-2"}]` |
| this PR | `[{"name":"vendor-0","company_and_code":"vendor-0/secret-0"},{"name":"vendor-1"},{"name":"vendor-2"}]` |

So for a bare `Array` this PR fixes the first element and leaves the rest to #985. That is a strict improvement on every shape measured — no case gets worse than 3.16.17, and in particular the trailing elements never expose the `code`/`secret` column that `:only` was hiding: they stay `{}` or `:only`-filtered rather than becoming the full attribute set. The gate on `0 < out->argc` means they become correct automatically once #985 is fixed, with no further change here.

This is also why I have not put `Fixes #1008` on this PR. #1020 says explicitly that it serializes an `ActiveRecord::Relation`, so it is fully fixed. #1008 only says `collection.to_json(only: [:id, :code], methods: %i[company_and_code])` — on 3.16.17 a relation and a bare `Array` both produce exactly the reported symptom (`company_and_code` uniformly absent), so the report does not distinguish them. If that `collection` is a relation it is fixed here; if it is a bare `Array`, the second and later rows still need #985. I would rather leave #1008 open for you to judge once that is known, instead of having a merge shut it automatically.

Happy to fold #985 into this PR if you would prefer to fix both at once.

## Tests

`test/test_rails.rb` gains regression tests that use small stand-ins for `as_json` (an include_root wrapper, a `:methods` key), so no ActiveSupport or database is needed and they run in every CI cell and under `rake test:valgrind`:

- `test_1020_only_keeps_as_json_root_wrapper` — red before (`{}`), green after.
- `test_1008_only_keeps_as_json_methods_key` — red before (`{"name":..}`), green after.
- `test_only_still_filters_siblings_of_as_json_value` — the save/restore scope (also covers the `Oj.dump(…, mode: :rails, only:)` path).
- `test_string_writer_rails_only_survives_as_json` — pins that the options struct stays read-only during a dump, so a writer's `:only` keeps filtering across `push_value` calls.

The bare-`Array` shape is deliberately not pinned, since it is the #985 intermediate state.

`rake test` green; `rake test:valgrind` reports no new leaks (the change allocates and frees nothing).
