### PR TITLE
Pass the as_json options to every element of a container (#1008)

### DIFF
--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -341,11 +341,16 @@ typedef struct _strLen {
 } *StrLen;
 
 static void dump_actioncontroller_parameters(VALUE obj, int depth, Out out, bool as_ok) {
+    int    saved_argc = out->argc;
+    VALUE *saved_argv = out->argv;
+
     if (0 == parameters_id) {
         parameters_id = rb_intern("@parameters");
     }
     out->argc = 0;
     dump_rails_val(rb_ivar_get(obj, parameters_id), depth, out, true);
+    out->argc = saved_argc;
+    out->argv = saved_argv;
 }
 
 static StrLen columns_array(VALUE rcols, int *ccnt) {
@@ -423,7 +428,9 @@ static ID columns_id = 0;
 static void dump_activerecord_result(VALUE obj, int depth, Out out, bool as_ok) {
     volatile VALUE rows;
     StrLen         cols;
-    int            ccnt = 0;
+    int            ccnt       = 0;
+    int            saved_argc = out->argc;
+    VALUE         *saved_argv = out->argv;
     size_t         i;
     size_t         rcnt;
     size_t         size;
@@ -483,6 +490,8 @@ static void dump_activerecord_result(VALUE obj, int depth, Out out, bool as_ok) 
         fill_indent(out, depth);
     }
     *out->cur++ = ']';
+    out->argc   = saved_argc;
+    out->argv   = saved_argv;
 }
 
 typedef struct _namedFunc {
@@ -491,8 +500,16 @@ typedef struct _namedFunc {
 } *NamedFunc;
 
 static void dump_as_string(VALUE obj, int depth, Out out, bool as_ok) {
+    int    saved_argc = out->argc;
+    VALUE *saved_argv = out->argv;
+
     if (oj_code_dump(oj_compat_codes, obj, depth, out)) {
-        out->argc = 0;
+        // oj_code_dump() writes the whole value and returns, so there is no
+        // subtree here to keep the options away from. Leave them for the next
+        // sibling. Restore instead of leaving them alone in case the encode
+        // consumed them.
+        out->argc = saved_argc;
+        out->argv = saved_argv;
         return;
     }
     oj_dump_obj_to_s(obj, out);
@@ -501,6 +518,8 @@ static void dump_as_string(VALUE obj, int depth, Out out, bool as_ok) {
 static void dump_as_json(VALUE obj, int depth, Out out, bool as_ok) {
     volatile VALUE ja;
     bool           selected;
+    int            saved_argc = out->argc;
+    VALUE         *saved_argv = out->argv;
 
     TRACE(out->opts->trace, "as_json", obj, depth + 1, TraceRubyIn);
     // Some classes elect to not take an options argument so check the arity
@@ -540,6 +559,11 @@ static void dump_as_json(VALUE obj, int depth, Out out, bool as_ok) {
         }
         out->key_filter_off = key_filter_off;
     }
+    // The options were consumed for this value only. Restore them so that the
+    // next sibling in a container is handed them too, the way ActiveSupport's
+    // Array#as_json and Hash#as_json pass them to every element.
+    out->argc = saved_argc;
+    out->argv = saved_argv;
 }
 
 static void dump_regexp(VALUE obj, int depth, Out out, bool as_ok) {
@@ -566,11 +590,16 @@ static VALUE activerecord_base = Qundef;
 static ID    attributes_id     = 0;
 
 static void dump_activerecord(VALUE obj, int depth, Out out, bool as_ok) {
+    int    saved_argc = out->argc;
+    VALUE *saved_argv = out->argv;
+
     if (0 == attributes_id) {
         attributes_id = rb_intern("@attributes");
     }
     out->argc = 0;
     dump_rails_val(rb_ivar_get(obj, attributes_id), depth, out, true);
+    out->argc = saved_argc;
+    out->argv = saved_argv;
 }
 
 static ROpt create_opt(ROptTable rot, VALUE clas) {
@@ -1415,10 +1444,15 @@ static void dump_hash(VALUE obj, int depth, Out out, bool as_ok) {
 }
 
 static void dump_obj(VALUE obj, int depth, Out out, bool as_ok) {
-    VALUE clas;
+    VALUE  clas;
+    int    saved_argc = out->argc;
+    VALUE *saved_argv = out->argv;
 
     if (oj_code_dump(oj_compat_codes, obj, depth, out)) {
-        out->argc = 0;
+        // Same as in dump_as_string(): the value is complete, so the options
+        // stay available for the next sibling.
+        out->argc = saved_argc;
+        out->argv = saved_argv;
         return;
     }
     clas = rb_obj_class(obj);

--- a/test/test_rails.rb
+++ b/test/test_rails.rb
@@ -27,6 +27,27 @@ class OjSecretProbe
   end
 end
 
+# Reports only whether as_json was handed the per-call options. Putting both keys
+# in :only means the dump level key filter drops nothing, so these tests see the
+# option passing and nothing else.
+class OjOptsProbe
+  def initialize(n)
+    @n = n
+  end
+
+  def as_json(options = nil)
+    {'n' => @n, 'opts' => options.nil? ? 'NONE' : options.keys.map(&:to_s).sort.join('+')}
+  end
+end
+
+# as_json returns a value that itself defines as_json. The options were consumed
+# by the outer call, so the inner one must not see them again.
+class OjNestedOptsProbe
+  def as_json(_options = nil)
+    {'inner' => OjOptsProbe.new(9)}
+  end
+end
+
 class RailsJuice < Minitest::Test
 
   def test_bigdecimal_dump
@@ -114,6 +135,48 @@ class RailsJuice < Minitest::Test
     w.push_value({'name' => 1, 'secret' => 2}, 'b')
     w.pop
     assert_equal(%|{"a":{"name":"v-1"},"b":{"name":1}}\n|, w.to_s)
+  end
+
+  # #1008: the options must reach the as_json of every element of a container,
+  # not just the first. ActiveSupport's Array#as_json is
+  # `map { |v| v.as_json(options) }` and the optimized C loop replaces it, so it
+  # owes the elements the same. Before the fix only element one saw them.
+  def test_1008_array_passes_options_to_every_as_json
+    json = Oj::Rails::Encoder.new(only: ['n', 'opts']).encode([OjOptsProbe.new(1), OjOptsProbe.new(2), OjOptsProbe.new(3)])
+    assert_equal('[{"n":1,"opts":"only"},{"n":2,"opts":"only"},{"n":3,"opts":"only"}]', json)
+  end
+
+  # Not limited to a bare Array - a Hash value hits the same path.
+  def test_1008_hash_values_pass_options_to_every_as_json
+    json = Oj::Rails::Encoder.new(only: ['x', 'y', 'n', 'opts']).encode({'x' => OjOptsProbe.new(1), 'y' => OjOptsProbe.new(2)})
+    assert_equal('{"x":{"n":1,"opts":"only"},"y":{"n":2,"opts":"only"}}', json)
+  end
+
+  def test_1008_nested_array_passes_options_to_every_as_json
+    json = Oj::Rails::Encoder.new(only: ['n', 'opts']).encode([[OjOptsProbe.new(1)], [OjOptsProbe.new(2)]])
+    assert_equal('[[{"n":1,"opts":"only"}],[{"n":2,"opts":"only"}]]', json)
+  end
+
+  # The options are restored for siblings but must still be kept away from the
+  # value as_json returned - it already applied the Rails selection, so handing
+  # the options to an as_json inside that value would apply them twice. This pins
+  # the `out->argc = 0` in dump_as_json: remove that line and this goes red.
+  def test_options_are_not_re_applied_inside_an_as_json_value
+    json = Oj::Rails::Encoder.new(only: ['inner', 'n', 'opts']).encode(OjNestedOptsProbe.new)
+    assert_equal('{"inner":{"n":9,"opts":"NONE"}}', json)
+  end
+
+  # Oj.add_to_json makes oj_code_dump() fire for Rational, which is the only way
+  # to reach the `out->argc = 0` in dump_as_string. rails_funcs dispatches
+  # T_RATIONAL there directly, bypassing dump_obj, so that site needs its own
+  # restore. Before the fix the probes after the Rational lost the options.
+  def test_add_to_json_value_does_not_consume_the_options
+    Oj.add_to_json(Rational)
+    json = Oj::Rails::Encoder.new(only: ['n', 'opts']).encode([Rational(1, 2), OjOptsProbe.new(1), OjOptsProbe.new(2)])
+    assert_equal('[{"json_class":"Rational","n":1,"d":2},{"n":1,"opts":"only"},{"n":2,"opts":"only"}]', json)
+  ensure
+    # oj_compat_codes is global and tests.rb runs every file in one process.
+    Oj.remove_to_json(Rational)
   end
 
 end


### PR DESCRIPTION
Fixes #1008.

This is the second half of #1008. #1039 fixed the first half (the `:only`/`:except` key filter being applied a second time to what `as_json` had already produced, dropping `methods:` keys and the `include_root_in_json` wrapper). This fixes what @rlineweaver reported in [his comment](https://github.com/ohler55/oj/issues/1008#issuecomment-4280919695) — "the `opts` are not getting passed along to subsequent collection items" — which you said gave you a place to start.

## Problem

Under `Oj.optimize_rails`, when a container is handed to `to_json` with options, only the **first** element's `as_json` receives them. Every element after it is called as `as_json()` with no arguments. @rlineweaver's example, measured:

```ruby
class Role < ApplicationRecord
  def as_json(opts = {})
    return { got_opts: true } if opts[:got_opts]

    super
  end
end

JSON.parse Role.last(3).to_json(got_opts: true)
```

| build | elements whose `as_json` got the options |
|---|---|
| v3.16.16 | 3/3 — `[{"got_opts"=>true}, {"got_opts"=>true}, {"got_opts"=>true}]` |
| v3.16.17 | 1/3 |
| develop (with #1039) | 1/3 |
| **this PR** | **3/3, same as plain Rails** |

It is not limited to a bare `Array` — a `Hash` value and a nested array hit it too.

## Root cause

`dump_as_json` (ext/oj/rails.c) hands the per-call options to `as_json` and then clears them:

```c
ja = rb_funcall2(obj, oj_as_json_id, out->argc, out->argv);
out->argc = 0;
```

Clearing them is correct and deliberate — it dates to `a5c5b35` (2017) and stops the options being applied a **second** time inside the value `as_json` returned. `as_json` has already resolved the Rails selection and handed back a plain string-keyed hash; re-applying a symbol `:only` to that hash wipes it out:

```ruby
{'name' => 'v', 'company_and_code' => 'v/s'}.as_json(only: [:name])   # => {}
```

That is the same failure mode #1039 dealt with at the `oj_key_skip` level.

The bug is that nothing puts the options **back**. `out->argc` is dump state that outlives the value, and `dump_array` / `dump_hash` read it for every element, so element one's `as_json` consumes the options for the whole container.

## Fix

One invariant:

> `out->argc` / `out->argv` belong to the value being dumped. A dumper that clears them restores them once that value has been written.

This is the same shape #1039 gave `out->key_filter_off` — save, consume, restore:

```c
static void dump_activerecord(VALUE obj, int depth, Out out, bool as_ok) {
    int    saved_argc = out->argc;
    VALUE *saved_argv = out->argv;
    ...
    out->argc = 0;                 // unchanged: no re-apply inside this value
    dump_rails_val(rb_ivar_get(obj, attributes_id), depth, out, true);
    out->argc = saved_argc;        // the next sibling gets them too
    out->argv = saved_argv;
}
```

**The meaning of `out->argc = 0` is unchanged.** It stays 0 for the whole subtree, so the 2017 intent is preserved; only the leak into siblings stops. `test_options_are_not_re_applied_inside_an_as_json_value` pins that — delete the `out->argc = 0` line in `dump_as_json` and it goes red.

`dump_array`, `dump_hash`, `hash_cb` and the delegation conditions are untouched. The element loops already read `out->argc`, so the fix is entirely on the consumer side.

### Why all six sites and not just `dump_obj`

`rails.c` has six `out->argc = 0` sites. Five are reached through `dump_obj` (`dump_actioncontroller_parameters`, `dump_activerecord_result` and `dump_activerecord` via `ro->dump`; `dump_as_json`; `dump_obj`'s own `oj_code_dump` branch), so an outer save/restore in `dump_obj` looks like it would cover everything.

It does not. **`rails_funcs[]` dispatches `T_FILE`, `T_COMPLEX` and `T_RATIONAL` to `dump_as_string` directly**, and `dump_rails_val` calls it without going through `dump_obj`. I built that version first and it left a hole — measured:

```ruby
Oj.add_to_json(Rational)          # makes oj_code_dump() fire for Rational
Oj::Rails::Encoder.new(only: ['n','opts']).encode([Rational(1,2), probe, probe])
# dump_obj-only restore: the probes after the Rational get no options
```

So each site restores its own. That way the invariant is one sentence and can be checked at each site without tracing the dispatch table, and a future entry in `rails_funcs` cannot open the same hole again.

The two sites that return immediately (`dump_as_string` and `dump_obj`'s `oj_code_dump` branch) restore rather than clear: there is no subtree there to keep the options away from, so clearing only ever affected siblings, which was the bug. Restoring rather than deleting the line keeps it correct even if a `c->encode` consumes the options itself.

## What the native json does

Measured on Ruby 4.0 / Rails 8.1: each case is run twice in the same process, once through ActiveSupport's `JSONGemEncoder` before `Oj.optimize_rails` (the oracle) and once through Oj, then compared. Nothing is hard coded.

`probe#as_json(options)` returns `{'n' => n, 'opts' => options.nil? ? 'NONE' : options.keys.join('+')}` — it reports only whether it was handed the options. `vendor-0..2` are AR rows with a `name` and a `code` column and a `company_and_code` method; `code` stands in for a column `:only` is meant to keep out of the response.

**develop diverges from plain Rails on 5 of these 7 shapes. This PR matches the oracle on all 7.**

| shape | plain Rails (oracle) | develop |
|---|---|---|
| `[p1,p2,p3].to_json(only: ['n','opts'])` | `[{"n":1,"opts":"only"},{"n":2,"opts":"only"},{"n":3,"opts":"only"}]` | `[{"n":1,"opts":"only"},{"n":2,"opts":"NONE"},{"n":3,"opts":"NONE"}]` |
| `{'x'=>p1,'y'=>p2}.to_json(only: ['x','y'])` | `{"x":{"n":1,"opts":"only"},"y":{"n":2,"opts":"only"}}` | `{"x":{"n":1,"opts":"only"},"y":{}}` |
| `[[p1],[p2]].to_json(only: ['n','opts'])` | `[[{"n":1,"opts":"only"}],[{"n":2,"opts":"only"}]]` | `[[{"n":1,"opts":"only"}],[{"n":2,"opts":"NONE"}]]` |
| relation `root=true .to_json(only: [:name])` | `[{"vendor":{"name":"vendor-0"}}, …×3]` | matches |
| `Array root=true .to_json(only: [:name])` | `[{"vendor":{"name":"vendor-0"}}, …×3]` | `[{"vendor":{"name":"vendor-0"}},{},{}]` |
| relation `root=false .to_json(only: [:name], methods: [:company_and_code])` | `[{"name":"vendor-0","company_and_code":"vendor-0/secret-0"}, …×3]` | matches |
| `Array root=false .to_json(only: [:name], methods: [:company_and_code])` | `[{"name":"vendor-0","company_and_code":"vendor-0/secret-0"}, …×3]` | `[{"name":"vendor-0","company_and_code":"vendor-0/secret-0"},{"name":"vendor-1"},{"name":"vendor-2"}]` |

(In the `{'x'=>p1,'y'=>p2}` row only `x` and `y` are in `:only`, so on develop the second probe both loses the options **and** has its own keys filtered — the two halves of #1008 stacking on one value.)

The two relation rows are the ones #1039 already fixed; they are here to show this PR does not regress them.

This is also what `pages/Rails.md` promises:

> Options passed into a call to `to_json()` are passed to the `as_json()` methods. (`:60-61`)

> When the optimized encoder it toggled the `as_json()` methods will not be called for that class but instead the optimized version will be called. The optimized version is the same as the ActiveSupport default encoding for a given class. (`:66-71`)

ActiveSupport's default encoding for an `Array` is `map { |v| v.as_json(options) }`. The optimized C loop replaces that Ruby loop, so it owes the elements the same options.

## Performance

`dump_as_string` only serves `T_FILE`/`T_COMPLEX`/`T_RATIONAL` and the rest of the change is two saves and two restores in dumpers that were already calling into Ruby, so nothing lands on the scalar hot path. Six runs each, means:

| | develop | this PR |
|---|---|---|
| 10k ints | 0.02385 s | 0.02378 s |
| 10k strings | 0.03187 s | 0.03030 s |
| 5k nested hashes | 0.11029 s | 0.11120 s |

Indistinguishable. On an `as_json` container **with** `:only` it is about 12% faster (0.269 s → 0.237 s), because #1039's flag now suppresses the key filter for every element instead of just the first, so `oj_key_skip` stops running on rows 2..n.

## Tests

`test/test_rails.rb` gains five tests. They use plain stand-in classes, so no ActiveSupport and no database — they run in every CI cell **and** under `rake test:valgrind` (`test_rails` is in the memcheck list). All four regression tests are red on develop and green here.

- `test_1008_array_passes_options_to_every_as_json` — @rlineweaver's shape
- `test_1008_hash_values_pass_options_to_every_as_json`
- `test_1008_nested_array_passes_options_to_every_as_json`
- `test_add_to_json_value_does_not_consume_the_options` — the `dump_as_string` site. This is the only way to reach it, since `oj_code_dump` only fires after `Oj.add_to_json`. It restores the global in an `ensure` (`tests.rb` runs every file in one process, and I verified `add_to_json`/`remove_to_json` round-trips exactly).
- `test_options_are_not_re_applied_inside_an_as_json_value` — pins the subtree suppression, green before and after, red if `out->argc = 0` is removed.

`bundle exec rake` green on both the `no_rails` and `rails_7.2` gemfiles (`tests.rb` 516/0, `activesupport7` 124/0, `activerecord` 1/0). `rake test:valgrind` green, 493/0, no leaks reported — the change allocates and frees nothing, and all five new tests run under it.

## Two things worth flagging

**#985 is unaffected.** I checked, because this touches the code `85e5b49` changed. `Oj::Rails::Encoder.new.encode(test: BigDecimal("10.0"))` still gives `{"test":10.0}` here. While verifying that I noticed there is no regression test for #985 anywhere — `git show 85e5b49 --stat -- test/` is empty — so a candidate fix that reverts the delegation condition passes the whole suite green while bringing the bug straight back. I can send a characterization test for it as a separate PR if you want one; it needs ActiveSupport (without it `Hash` has no `as_json` and the test has no teeth), so it would go under `test/activesupport7/`. Not mixing it in here.

**A pre-existing difference this makes more visible.** Oj passes `out->argv` — the caller's own options hash — to `as_json`, without duplicating it. ActiveSupport duplicates once and freezes (`options = options.dup.freeze unless options.frozen?`), then shares that one object across all elements, so Oj passing the same object to every element matches AS's semantics apart from the freeze. But an `as_json` that mutates its options argument raises `FrozenError` under plain Rails while Oj silently lets it modify the caller's hash. That happens on develop already, for the first element; after this PR the later elements see the same (possibly mutated) hash instead of seeing nothing. Happy to look at duplicating or freezing in a follow-up if you think it is worth the allocation.
