### PR TITLE
Rename the documented :skip_null_byte option to :omit_null_byte

### DIFF
--- a/docs/mode_table.html
+++ b/docs/mode_table.html
@@ -33,10 +33,10 @@
   <tr><td>:object_class</td><td>Class</td><td></td><td></td><td>x</td><td></td><td></td><td>x</td><td></td></tr>
   <tr><td>:object_nl</td><td>String</td><td></td><td></td><td>x</td><td>x</td><td></td><td>x</td><td></td></tr>
   <tr><td>:omit_nil</td><td>Boolean</td><td>x</td><td>x</td><td>x</td><td>x</td><td>x</td><td>x</td><td></td></tr>
+  <tr><td>:omit_null_byte</td><td>Boolean</td><td>x</td><td>x</td><td>x</td><td>x</td><td>x</td><td>x</td><td></td></tr>
   <tr><td>:quirks_mode</td><td>Boolean</td><td></td><td></td><td>6</td><td></td><td></td><td>x</td><td></td></tr>
   <tr><td>:safe</td><td>String</td><td></td><td></td><td>x</td><td></td><td></td><td></td><td></td></tr>
   <tr><td>:second_precision</td><td>Fixnum</td><td></td><td></td><td></td><td></td><td>x</td><td>x</td><td></td></tr>
-  <tr><td>:skip_null_byte</td><td>Boolean</td><td>x</td><td>x</td><td>x</td><td>x</td><td>x</td><td>x</td><td></td></tr>
   <tr><td>:space</td><td>String</td><td></td><td></td><td>x</td><td>x</td><td></td><td>x</td><td></td></tr>
   <tr><td>:space_before</td><td>String</td><td></td><td></td><td>x</td><td>x</td><td></td><td>x</td><td></td></tr>
   <tr><td>:symbol_keys</td><td>Boolean</td><td>x</td><td>x</td><td>x</td><td>x</td><td>x</td><td>x</td><td></td></tr>

--- a/ext/oj/oj.h
+++ b/ext/oj/oj.h
@@ -326,7 +326,6 @@ extern VALUE oj_max_nesting_sym;
 extern VALUE oj_object_class_sym;
 extern VALUE oj_object_nl_sym;
 extern VALUE oj_quirks_mode_sym;
-extern VALUE oj_skip_null_byte_sym;
 extern VALUE oj_space_before_sym;
 extern VALUE oj_space_sym;
 extern VALUE oj_symbolize_names_sym;

--- a/pages/Options.md
+++ b/pages/Options.md
@@ -249,6 +249,10 @@ integer gives better performance.
 
 If true, Hash and Object attributes with nil values are omitted.
 
+### :omit_null_byte [Boolean]
+
+If true, null bytes in strings will be omitted when dumping.
+
 ### :quirks_mode [Boolean]
 
 Allow single JSON values instead of documents, default is true (allow). This
@@ -264,10 +268,6 @@ to true.
 ### :second_precision [Fixnum]
 
 The number of digits after the decimal when dumping the seconds of time.
-
-### :skip_null_byte [Boolean]
-
-If true, null bytes in strings will be omitted when dumping.
 
 ### :space
 


### PR DESCRIPTION
## Summary

The docs referred to a `:skip_null_byte` option, but the option that actually works is `:omit_null_byte` (`ext/oj/oj.c`, `dump.c`). This renames the doc references and removes a leftover symbol declaration.

- `pages/Options.md` / `docs/mode_table.html`: rename `:skip_null_byte` → `:omit_null_byte` and move the entry to its correct alphabetical position.
- `ext/oj/oj.h`: drop the dangling `oj_skip_null_byte_sym` extern declaration.

## Background

The option was first introduced as `:skip_null_byte` in #883 (b50f308). The next day, #884 (56a05e2, "Fix rubocop") renamed it to `:omit_null_byte`, removing the symbol's definition and all of its uses but missing the `extern` declaration in `oj.h`, which has been dangling ever since. The user-facing docs also kept referring to the old name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)