### PR TITLE
Update InstallOptions doc: SIMD is auto-detected, drop --with-sse42

### DIFF
--- a/pages/InstallOptions.md
+++ b/pages/InstallOptions.md
@@ -10,11 +10,13 @@ To enable Oj trace feature, it uses `--enable-trace-log` option when installing 
 Then, the trace logs will be displayed when `:trace` option is set to `true`.
 
 
-### Enable SIMD instructions
+### SIMD instructions
 
-```
-$ gem install oj -- --with-sse42
-```
+SIMD optimizations are enabled automatically, so no install option is
+required. At runtime Oj detects the CPU features that are available and
+selects the best implementation: SSE4.2 or SSE2 on x86 / x86_64, NEON on ARM,
+and a scalar fallback when none is available.
 
-To enable the use of SIMD instructions in Oj, it uses the `--with-sse42` option when installing the gem.
-This will enable the use of the SSE4.2 instructions in the internal.
+Earlier versions required a `--with-sse42` option at install time to turn on
+SSE4.2. That option has been removed (#982); SSE4.2 is now selected
+automatically when the CPU supports it.


### PR DESCRIPTION
## Summary

The `pages/InstallOptions.md` "Enable SIMD instructions" section documented a `--with-sse42` install option:

```
$ gem install oj -- --with-sse42
```

That option no longer exists. It was removed in #982 (`318bf55`) when SIMD was made automatic. Oj now detects CPU features at runtime (`oj_get_simd_implementation()`) and selects the best implementation — SSE4.2 / SSE2 on x86 / x86_64, NEON on ARM, and a scalar fallback otherwise — so no build flag is needed.

This rewrites the section to describe the current behavior. The `--enable-trace-log` section is still valid and is left as-is.

## Background

The doc had not been updated since #832 (`8a1773d`, "Add --enable-trace-log install option") and still referenced the old flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)