### PR TITLE
Fix the documented minimum Ruby version (2.4+ -> 2.7+)

### DIFF
--- a/pages/Compatibility.md
+++ b/pages/Compatibility.md
@@ -2,7 +2,7 @@
 
 **Ruby**
 
-Oj is compatible with Ruby 2.4+ and RBX.
+Oj is compatible with Ruby 2.7+ and RBX.
 Support for JRuby has been removed as JRuby no longer supports C extensions and
 there are bugs in the older versions that are not being fixed.
 


### PR DESCRIPTION
## Summary

`pages/Compatibility.md` states that Oj is compatible with **Ruby 2.4+**, but the gemspec requires `>= 2.7`:

```ruby
# oj.gemspec
s.required_ruby_version = '>= 2.7'
```

This updates the doc to `Ruby 2.7+` so it matches the actual supported version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)