### PR TITLE
Fix Parser.md benchmark conclusions to reference :usual, not :saj

### DIFF
--- a/pages/Parser.md
+++ b/pages/Parser.md
@@ -280,7 +280,7 @@ Oj::Parser.usual       0.452      110544.876
        JSON::Ext       1.009       49555.094
 ```
 
-The `Oj::Parser.new(:saj)` is **1.55** times faster than `Oj.load` and
+The `Oj::Parser.new(:usual)` is **1.55** times faster than `Oj.load` and
 **2.23** times faster than the JSON gem.
 
 ### Object
@@ -298,7 +298,7 @@ Oj::Parser.usual       0.071      703502.033
        JSON::Ext       0.401      124638.859
 ```
 
-The `Oj::Parser.new(:saj)` is **3.17** times faster than
+The `Oj::Parser.new(:usual)` is **3.17** times faster than
 `Oj.compat_load` and **5.64** times faster than the JSON gem.
 
 ## Summary


### PR DESCRIPTION
## Summary

In `pages/Parser.md`, the "Parse to Ruby primitives" and "Object" sections both benchmark `Oj::Parser.new(:usual)`, but their concluding sentences mistakenly said `Oj::Parser.new(:saj)`.

The quoted rates confirm `:usual` is meant:

- Parse to Ruby primitives: 110544 / 71490 = **1.55**, 110544 / 49555 = **2.23**
- Object: 703502 / 221762 = **3.17**, 703502 / 124638 = **5.64**

This corrects the two sentences (lines 283 and 301). The `:saj` references in the Callback section are correct and are left unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)