### PR TITLE
Fix docs that called :custom the default mode

### DIFF
--- a/pages/Custom.md
+++ b/pages/Custom.md
@@ -8,9 +8,8 @@ for object dumping and loading. The `:compat` mode mimic the json gem
 including methods called for encoding and inconsistencies between
 `JSON.dump()`, `JSON.generate()`, and `JSON()`.
 
-The `:custom` mode is the default mode. It can be configured either by passing
-options to the `Oj.dump()` and `Oj.load()` methods or by modifying the default
-options.
+The `:custom` mode can be configured either by passing options to the
+`Oj.dump()` and `Oj.load()` methods or by modifying the default options.
 
 The ability to create objects from JSON object elements is supported and
 considers the `:create_additions` option. Special treatment is given to the

--- a/pages/Options.md
+++ b/pages/Options.md
@@ -213,8 +213,7 @@ for json gem compatibility.
 
 Primary behavior for loading and dumping. The :mode option controls which
 other options are in effect. For more details see the {file:Modes.md} page. By
-default Oj uses the :custom mode which is provides the highest degree of
-customization.
+default Oj uses the :object mode.
 
 ### :nan [Symbol]
 


### PR DESCRIPTION
## Summary

`pages/Custom.md` and `pages/Options.md` both stated that `:custom` is the default mode, but the default is `:object`.

`Init_oj` in `ext/oj/oj.c` sets:

```c
oj_default_options.mode = ObjectMode;
```

and this is confirmed at runtime:

```
$ ruby -Ilib -e 'require "oj"; p Oj.default_options[:mode]'
:object
```

`pages/Modes.md` and `pages/Encoding.md` already document `:object` as the default, so these two files contradicted the rest of the docs.

## Changes

- `pages/Custom.md`: drop the incorrect "The `:custom` mode is the default mode." sentence.
- `pages/Options.md`: the `:mode` entry now says Oj defaults to `:object`.

The trailing `which is provides the highest degree of customization` clause described `:custom`, so it is dropped along with the incorrect claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)