### PR TITLE
Fix the documented type of the :safe option (String -> Boolean)

### DIFF
--- a/docs/mode_table.html
+++ b/docs/mode_table.html
@@ -35,7 +35,7 @@
   <tr><td>:omit_nil</td><td>Boolean</td><td>x</td><td>x</td><td>x</td><td>x</td><td>x</td><td>x</td><td></td></tr>
   <tr><td>:omit_null_byte</td><td>Boolean</td><td>x</td><td>x</td><td>x</td><td>x</td><td>x</td><td>x</td><td></td></tr>
   <tr><td>:quirks_mode</td><td>Boolean</td><td></td><td></td><td>6</td><td></td><td></td><td>x</td><td></td></tr>
-  <tr><td>:safe</td><td>String</td><td></td><td></td><td>x</td><td></td><td></td><td></td><td></td></tr>
+  <tr><td>:safe</td><td>Boolean</td><td></td><td></td><td>x</td><td></td><td></td><td></td><td></td></tr>
   <tr><td>:second_precision</td><td>Fixnum</td><td></td><td></td><td></td><td></td><td>x</td><td>x</td><td></td></tr>
   <tr><td>:space</td><td>String</td><td></td><td></td><td>x</td><td>x</td><td></td><td>x</td><td></td></tr>
   <tr><td>:space_before</td><td>String</td><td></td><td></td><td>x</td><td>x</td><td></td><td>x</td><td></td></tr>

--- a/pages/Modes.md
+++ b/pages/Modes.md
@@ -121,7 +121,7 @@ information.
 | :object_nl             | String  |         |         |       x |       x |         |       x |         |
 | :omit_nil              | Boolean |       x |       x |       x |       x |       x |       x |         |
 | :quirks_mode           | Boolean |         |         |       6 |         |         |       x |         |
-| :safe                  | String  |         |         |       x |         |         |         |         |
+| :safe                  | Boolean |         |         |       x |         |         |         |         |
 | :second_precision      | Fixnum  |         |         |         |         |       x |       x |         |
 | :space                 | String  |         |         |       x |       x |         |       x |         |
 | :space_before          | String  |         |         |       x |       x |         |       x |         |


### PR DESCRIPTION
## Summary

The options matrix in `pages/Modes.md` and `docs/mode_table.html` listed `:safe` with a type of **String**, but it is a boolean.

It is registered in the `YesNoOpt` table in `ext/oj/oj.c` alongside `:trace` and `:allow_gc`, and stored as `char safe; // YesNo` in `ext/oj/oj.h`.

Confirmed at runtime:

```ruby
Oj.default_options[:safe]           #=> false
Oj.default_options = {safe: true}   #=> ok
Oj.default_options = {safe: "yes"}  # ArgumentError: ... must be true, false, or nil.
```

`pages/Options.md` already describes it as something you "set to `true`", so only the two matrices needed correcting.

Checked the other boolean options in the matrix as well — `:safe` was the only one with a wrong type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)