### PR TITLE
Add the ActiveSupport 8 test suite so the rails_8 CI job runs it

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
     - 'test/activerecord/**/*'
     - 'test/activesupport6/**/*'
     - 'test/activesupport7/**/*'
+    - 'test/activesupport8/**/*'
 
 # This rule suggests a change that will cause CI tests to fail.
 Gemspec/DevelopmentDependencies:

--- a/gemfiles/rails_8.gemfile
+++ b/gemfiles/rails_8.gemfile
@@ -7,5 +7,12 @@ gem 'sqlite3'
 gem 'mutex_m'
 gem 'base64'
 gem 'drb'
+# Windows has no system zoneinfo, so ActiveSupport::TimeZone cannot resolve a
+# zone without this. The activesupport8 tests need it; rails_7.2 does not
+# because that gemfile is excluded from the Windows jobs. Written as a
+# conditional rather than :platforms so that it works on every bundler: the
+# :windows platform needs bundler 2.5 and the older :mingw/:mswin/:x64_mingw
+# spelling is deprecated.
+gem 'tzinfo-data' if Gem.win_platform?
 
 gemspec :path => '../'

--- a/test/activesupport8/Readme.md
+++ b/test/activesupport8/Readme.md
@@ -1,0 +1,5 @@
+Tests copied from [rails/activesupport/test/json/], [rails/activesupport/lib/active_support], [rails/activesupport/test].
+
+[rails/activesupport/test/json/]: https://github.com/rails/rails/tree/v8.0.5/activesupport/test/json
+[rails/activesupport/lib/active_support]: https://github.com/rails/rails/tree/v8.0.5/activesupport/lib/active_support
+[rails/activesupport/test]: https://github.com/rails/rails/tree/v8.0.5/activesupport/test

--- a/test/activesupport8/abstract_unit.rb
+++ b/test/activesupport8/abstract_unit.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+ORIG_ARGV = ARGV.dup
+
+require "bundler/setup"
+require "active_support/core_ext/kernel/reporting"
+
+silence_warnings do
+  Encoding.default_internal = Encoding::UTF_8
+  Encoding.default_external = Encoding::UTF_8
+end
+
+require "active_support/testing/autorun"
+require "active_support/testing/method_call_assertions"
+require "active_support/testing/error_reporter_assertions"
+
+ENV["NO_RELOAD"] = "1"
+require "active_support"
+
+Thread.abort_on_exception = true
+
+# Show backtraces for deprecated behavior for quicker cleanup.
+ActiveSupport.deprecator.debug = true
+
+# Default to Ruby 2.4+ to_time behavior but allow running tests with old behavior
+ActiveSupport.deprecator.silence do
+  ActiveSupport.to_time_preserves_timezone = ENV.fetch("PRESERVE_TIMEZONES", "1") == "1"
+end
+
+ActiveSupport::Cache.format_version = 7.1
+
+# Disable available locale checks to avoid warnings running the test suite.
+I18n.enforce_available_locales = false
+
+class ActiveSupport::TestCase
+  if Process.respond_to?(:fork) && !Gem.win_platform?
+    parallelize
+  else
+    parallelize(with: :threads)
+  end
+
+  include ActiveSupport::Testing::MethodCallAssertions
+  include ActiveSupport::Testing::ErrorReporterAssertions
+end

--- a/test/activesupport8/abstract_unit.rb
+++ b/test/activesupport8/abstract_unit.rb
@@ -36,7 +36,12 @@ class ActiveSupport::TestCase
   if Process.respond_to?(:fork) && !Gem.win_platform?
     parallelize
   else
-    parallelize(with: :threads)
+    # These tests flip ActiveSupport globals as they run
+    # (use_standard_json_time_format, escape_html_entities_in_json,
+    # JSON::Encoding.time_precision), so forked workers are fine but threaded
+    # ones race on them. Upstream never hits this because it always forks.
+    # workers: 1 keeps the suite serial; it takes well under a second anyway.
+    parallelize(workers: 1)
   end
 
   include ActiveSupport::Testing::MethodCallAssertions

--- a/test/activesupport8/decoding_test.rb
+++ b/test/activesupport8/decoding_test.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require_relative "abstract_unit"
+require "active_support/json"
+require "active_support/time"
+require_relative "time_zone_test_helpers"
+
+class TestJSONDecoding < ActiveSupport::TestCase
+  include TimeZoneTestHelpers
+
+  class Foo
+    def self.json_create(object)
+      "Foo"
+    end
+  end
+
+  TESTS = {
+    %q({"returnTo":{"\/categories":"\/"}})        => { "returnTo" => { "/categories" => "/" } },
+    %q({"return\\"To\\":":{"\/categories":"\/"}}) => { "return\"To\":" => { "/categories" => "/" } },
+    %q({"returnTo":{"\/categories":1}}) => { "returnTo" => { "/categories" => 1 } },
+    %({"returnTo":[1,"a"]})                    => { "returnTo" => [1, "a"] },
+    %({"returnTo":[1,"\\"a\\",", "b"]})        => { "returnTo" => [1, "\"a\",", "b"] },
+    %({"a": "'", "b": "5,000"})                  => { "a" => "'", "b" => "5,000" },
+    %({"a": "a's, b's and c's", "b": "5,000"})   => { "a" => "a's, b's and c's", "b" => "5,000" },
+    # multibyte
+    %({"matzue": "松江", "asakusa": "浅草"}) => { "matzue" => "松江", "asakusa" => "浅草" },
+    %({"a": "2007-01-01"})                       => { "a" => Date.new(2007, 1, 1) },
+    %({"a": "2007-01-01 01:12:34 Z"})            => { "a" => Time.utc(2007, 1, 1, 1, 12, 34) },
+    %(["2007-01-01 01:12:34 Z"])                 => [Time.utc(2007, 1, 1, 1, 12, 34)],
+    %(["2007-01-01 01:12:34 Z", "2007-01-01 01:12:35 Z"]) => [Time.utc(2007, 1, 1, 1, 12, 34), Time.utc(2007, 1, 1, 1, 12, 35)],
+    # no time zone
+    %({"a": "2007-01-01 01:12:34"})              => { "a" => Time.new(2007, 1, 1, 1, 12, 34, "-05:00") },
+    # invalid date
+    %({"a": "1089-10-40"})                       => { "a" => "1089-10-40" },
+    # xmlschema date notation
+    %({"a": "2009-08-10T19:01:02"})              => { "a" => Time.new(2009, 8, 10, 19, 1, 2, "-04:00") },
+    %({"a": "2009-08-10T19:01:02Z"})             => { "a" => Time.utc(2009, 8, 10, 19, 1, 2) },
+    %({"a": "2009-08-10T19:01:02+02:00"})        => { "a" => Time.utc(2009, 8, 10, 17, 1, 2) },
+    %({"a": "2009-08-10T19:01:02-05:00"})        => { "a" => Time.utc(2009, 8, 11, 00, 1, 2) },
+    # needs to be *exact*
+    %({"a": " 2007-01-01 01:12:34 Z "})          => { "a" => " 2007-01-01 01:12:34 Z " },
+    %({"a": "2007-01-01 : it's your birthday"})  => { "a" => "2007-01-01 : it's your birthday" },
+    %({"a": "Today is:\\n2020-05-21"})           => { "a" => "Today is:\n2020-05-21" },
+    %({"a": "2007-01-01 01:12:34 Z\\nwas my birthday"}) => { "a" => "2007-01-01 01:12:34 Z\nwas my birthday" },
+    %([])    => [],
+    %({})    => {},
+    %({"a":1}) => { "a" => 1 },
+    %({"a": ""}) => { "a" => "" },
+    %({"a":"\\""}) => { "a" => "\"" },
+    %({"a": null})  => { "a" => nil },
+    %({"a": true})  => { "a" => true },
+    %({"a": false}) => { "a" => false },
+    '{"bad":"\\\\","trailing":""}' => { "bad" => "\\", "trailing" => "" },
+    %q({"a": "http:\/\/test.host\/posts\/1"}) => { "a" => "http://test.host/posts/1" },
+    %q({"a": "\u003cunicode\u0020escape\u003e"}) => { "a" => "<unicode escape>" },
+    '{"a": "\\\\u0020skip double backslashes"}' => { "a" => "\\u0020skip double backslashes" },
+    %q({"a": "\u003cbr /\u003e"}) => { "a" => "<br />" },
+    %q({"b":["\u003ci\u003e","\u003cb\u003e","\u003cu\u003e"]}) => { "b" => ["<i>", "<b>", "<u>"] },
+    # test combination of dates and escaped or unicode encoded data in arrays
+    %q([{"d":"1970-01-01", "s":"\u0020escape"},{"d":"1970-01-01", "s":"\u0020escape"}]) =>
+      [{ "d" => Date.new(1970, 1, 1), "s" => " escape" }, { "d" => Date.new(1970, 1, 1), "s" => " escape" }],
+    %q([{"d":"1970-01-01","s":"http:\/\/example.com"},{"d":"1970-01-01","s":"http:\/\/example.com"}]) =>
+      [{ "d" => Date.new(1970, 1, 1), "s" => "http://example.com" },
+       { "d" => Date.new(1970, 1, 1), "s" => "http://example.com" }],
+    # tests escaping of "\n" char with Yaml backend
+    %q({"a":"\n"}) => { "a" => "\n" },
+    %q({"a":"\u000a"}) => { "a" => "\n" },
+    %q({"a":"Line1\u000aLine2"}) => { "a" => "Line1\nLine2" },
+    # prevent JSON unmarshalling
+    '{"json_class":"TestJSONDecoding::Foo"}' => { "json_class" => "TestJSONDecoding::Foo" },
+    # JSON "fragments" - these are invalid JSON, but ActionPack relies on this
+    '"a string"' => "a string",
+    "1.1" => 1.1,
+    "1" => 1,
+    "-1" => -1,
+    "true" => true,
+    "false" => false,
+    "null" => nil
+  }
+
+  TESTS.each_with_index do |(json, expected), index|
+    fail_message = "JSON decoding failed for #{json}"
+
+    test "JSON decodes #{index}" do
+      with_tz_default "Eastern Time (US & Canada)" do
+        with_parse_json_times(true) do
+          silence_warnings do
+            if expected.nil?
+              assert_nil ActiveSupport::JSON.decode(json), fail_message
+            else
+              assert_equal expected, ActiveSupport::JSON.decode(json), fail_message
+            end
+          end
+        end
+      end
+    end
+  end
+
+  test "JSON decodes time JSON with time parsing disabled" do
+    with_parse_json_times(false) do
+      expected = { "a" => "2007-01-01 01:12:34 Z" }
+      assert_equal expected, ActiveSupport::JSON.decode(%({"a": "2007-01-01 01:12:34 Z"}))
+    end
+  end
+
+  def test_failed_json_decoding
+    assert_raise(ActiveSupport::JSON.parse_error) { ActiveSupport::JSON.decode(%(undefined)) }
+    assert_raise(ActiveSupport::JSON.parse_error) { ActiveSupport::JSON.decode(%({a: 1})) }
+    assert_raise(ActiveSupport::JSON.parse_error) { ActiveSupport::JSON.decode(%({: 1})) }
+    assert_raise(ActiveSupport::JSON.parse_error) { ActiveSupport::JSON.decode(%()) }
+  end
+
+  def test_cannot_pass_unsupported_options
+    assert_raise(ArgumentError) { ActiveSupport::JSON.decode("", create_additions: true) }
+  end
+
+  private
+    def with_parse_json_times(value)
+      old_value = ActiveSupport.parse_json_times
+      ActiveSupport.parse_json_times = value
+      yield
+    ensure
+      ActiveSupport.parse_json_times = old_value
+    end
+end

--- a/test/activesupport8/encoding_test.rb
+++ b/test/activesupport8/encoding_test.rb
@@ -181,6 +181,10 @@ class TestJSONEncoding < ActiveSupport::TestCase
   end
 
   def test_time_to_json_includes_local_offset
+    # with_env_tz sets ENV["TZ"], which Windows does not use, so Time.local
+    # stays on the machine zone and the offset comes out as +00:00.
+    skip 'Windows ignores the TZ environment variable' if RbConfig::CONFIG['host_os'] =~ /(mingw|mswin)/
+
     with_standard_json_time_format(true) do
       with_env_tz "US/Eastern" do
         assert_equal %("2005-02-01T15:15:10.000-05:00"), ActiveSupport::JSON.encode(Time.local(2005, 2, 1, 15, 15, 10))

--- a/test/activesupport8/encoding_test.rb
+++ b/test/activesupport8/encoding_test.rb
@@ -1,0 +1,571 @@
+# frozen_string_literal: true
+
+require "securerandom"
+require_relative "abstract_unit"
+require "active_support/core_ext/string/inflections"
+require "active_support/json"
+require "active_support/time"
+require_relative "time_zone_test_helpers"
+require_relative "encoding_test_cases"
+
+require 'oj'
+# Sets the ActiveSupport encoder to be Oj and also wraps the setting of globals.
+Oj::Rails.set_encoder()
+Oj::Rails.optimize()
+
+class TestJSONEncoding < ActiveSupport::TestCase
+  include TimeZoneTestHelpers
+
+  def test_is_actually_oj
+    assert_equal Oj::Rails::Encoder, ActiveSupport.json_encoder
+  end
+
+  def sorted_json(json)
+    if json.start_with?("{") && json.end_with?("}")
+      "{" + json[1..-2].split(",").sort.join(",") + "}"
+    else
+      json
+    end
+  end
+
+  JSONTest::EncodingTestCases.constants.each do |class_tests|
+    define_method("test_#{class_tests[0..-6].underscore}") do
+      prev = ActiveSupport.use_standard_json_time_format
+
+      standard_class_tests = /Standard/.match?(class_tests)
+
+      ActiveSupport.escape_html_entities_in_json  = !standard_class_tests
+      ActiveSupport.use_standard_json_time_format = standard_class_tests
+      JSONTest::EncodingTestCases.const_get(class_tests).each do |pair|
+        assert_equal pair.last, sorted_json(ActiveSupport::JSON.encode(pair.first))
+      end
+    ensure
+      ActiveSupport.escape_html_entities_in_json  = false
+      ActiveSupport.use_standard_json_time_format = prev
+    end
+  end
+
+  def test_process_status
+    # There doesn't seem to be a good way to get a handle on a Process::Status object without actually
+    # creating a child process, hence this to populate $?
+    system("not_a_real_program_#{SecureRandom.hex}")
+    assert_equal %({"exitstatus":#{$?.exitstatus},"pid":#{$?.pid}}), ActiveSupport::JSON.encode($?)
+  end
+
+  def test_hash_encoding
+    assert_equal %({\"a\":\"b\"}), ActiveSupport::JSON.encode(a: :b)
+    assert_equal %({\"a\":1}), ActiveSupport::JSON.encode("a" => 1)
+    assert_equal %({\"a\":[1,2]}), ActiveSupport::JSON.encode("a" => [1, 2])
+    assert_equal %({"1":2}), ActiveSupport::JSON.encode(1 => 2)
+
+    assert_equal %({\"a\":\"b\",\"c\":\"d\"}), sorted_json(ActiveSupport::JSON.encode(a: :b, c: :d))
+  end
+
+  def test_hash_keys_encoding
+    ActiveSupport.escape_html_entities_in_json = true
+    assert_equal "{\"\\u003c\\u003e\":\"\\u003c\\u003e\"}", ActiveSupport::JSON.encode("<>" => "<>")
+  ensure
+    ActiveSupport.escape_html_entities_in_json = false
+  end
+
+  def test_hash_keys_encoding_option
+    # Rails 8.0 added a per-call :escape_html_entities option to
+    # ActiveSupport::JSON.encode. Oj::Rails::Encoder ignores it and always
+    # follows the global ActiveSupport.escape_html_entities_in_json, so this
+    # test fails against Oj. Remove the skip once Oj honours the option.
+    skip 'Oj::Rails::Encoder does not support the per-call :escape_html_entities option'
+
+    global_config = ActiveSupport.escape_html_entities_in_json
+
+    ActiveSupport.escape_html_entities_in_json = true
+    assert_equal "{\"<>\":\"<>\"}", ActiveSupport::JSON.encode({ "<>" => "<>" }, escape_html_entities: false)
+
+    ActiveSupport.escape_html_entities_in_json = false
+    assert_equal "{\"\\u003c\\u003e\":\"\\u003c\\u003e\"}", ActiveSupport::JSON.encode({ "<>" => "<>" }, escape_html_entities: true)
+  ensure
+    ActiveSupport.escape_html_entities_in_json = global_config
+  end
+
+  # Pulled out of JSONTest::EncodingTestCases::NumericTests so that the one
+  # unsupported pair does not fail the whole generated test_numeric. Rails
+  # encodes a Numeric subclass through its own to_json; Oj dumps the object
+  # with to_s instead and produces "#<JSONTest::CustomNumeric:0x...>".
+  def test_numeric_subclass_with_custom_to_json
+    skip 'Oj does not call to_json on a Numeric subclass'
+
+    assert_equal %([123]), ActiveSupport::JSON.encode([JSONTest::CustomNumeric.new("123")])
+  end
+
+  def test_hash_keys_encoding_without_escaping
+    assert_equal "{\"<>\":\"<>\"}", ActiveSupport::JSON.encode("<>" => "<>")
+  end
+
+  module UnicodeTests
+    def test_utf8_string_encoded_properly
+      result = ActiveSupport::JSON.encode("€2.99")
+      assert_equal '"€2.99"', result
+      assert_equal(Encoding::UTF_8, result.encoding)
+
+      result = ActiveSupport::JSON.encode("✎☺")
+      assert_equal '"✎☺"', result
+      assert_equal(Encoding::UTF_8, result.encoding)
+    end
+
+    def test_non_utf8_string_transcodes
+      s = "二".encode("Shift_JIS")
+      result = ActiveSupport::JSON.encode(s)
+      assert_equal '"二"', result
+      assert_equal Encoding::UTF_8, result.encoding
+    end
+
+    def test_wide_utf8_chars
+      w = "𠜎"
+      result = ActiveSupport::JSON.encode(w)
+      assert_equal '"𠜎"', result
+    end
+
+    def test_wide_utf8_roundtrip
+      hash = { string: "𐒑" }
+      json = ActiveSupport::JSON.encode(hash)
+      decoded_hash = ActiveSupport::JSON.decode(json)
+      assert_equal "𐒑", decoded_hash["string"]
+    end
+
+    def test_invalid_encoding_raises
+      s = "\xAE\xFF\x9F"
+      refute s.valid_encoding?
+
+      # n.b. this raises EncodingError, because we didn't call Oj.mimic_JSON in the test setup; but,
+      # if you do that (even indirectly through Oj.optimize_rails), then this raises a
+      # JSON::GeneratorError instead of an EncodingError.
+      assert_raises(EncodingError) do
+        ActiveSupport::JSON.encode([s])
+      end
+    end
+  end
+
+  module UnicodeTestsWithEscapingOn
+    def setup
+      ActiveSupport.escape_html_entities_in_json = true
+    end
+
+    def teardown
+      ActiveSupport.escape_html_entities_in_json = false
+    end
+
+    include UnicodeTests
+  end
+
+  module UnicodeTestsWithEscapingOff
+    def setup
+      ActiveSupport.escape_html_entities_in_json = false
+    end
+
+    include UnicodeTests
+  end
+
+  include UnicodeTestsWithEscapingOn
+  include UnicodeTestsWithEscapingOff
+
+  def test_hash_key_identifiers_are_always_quoted
+    values = { 0 => 0, 1 => 1, :_ => :_, "$" => "$", "a" => "a", :A => :A, :A0 => :A0, "A0B" => "A0B" }
+    assert_equal %w( "$" "A" "A0" "A0B" "_" "a" "0" "1" ).sort, object_keys(ActiveSupport::JSON.encode(values))
+  end
+
+  def test_hash_should_allow_key_filtering_with_only
+    assert_equal %({"a":1}), ActiveSupport::JSON.encode({ "a" => 1, :b => 2, :c => 3 }, { only: "a" })
+  end
+
+  def test_hash_should_allow_key_filtering_with_except
+    assert_equal %({"b":2}), ActiveSupport::JSON.encode({ "foo" => "bar", :b => 2, :c => 3 }, { except: ["foo", :c] })
+  end
+
+  def test_time_to_json_includes_local_offset
+    with_standard_json_time_format(true) do
+      with_env_tz "US/Eastern" do
+        assert_equal %("2005-02-01T15:15:10.000-05:00"), ActiveSupport::JSON.encode(Time.local(2005, 2, 1, 15, 15, 10))
+      end
+    end
+  end
+
+  def test_hash_with_time_to_json
+    with_standard_json_time_format(false) do
+      assert_equal '{"time":"2009/01/01 00:00:00 +0000"}', { time: Time.utc(2009) }.to_json
+    end
+  end
+
+  def test_nested_hash_with_float
+    assert_nothing_raised do
+      hash = {
+        "CHI" => {
+          display_name: "chicago",
+          latitude: 123.234
+        }
+      }
+      ActiveSupport::JSON.encode(hash)
+    end
+  end
+
+  def test_hash_like_with_options
+    h = JSONTest::Hashlike.new
+    json = h.to_json only: [:foo]
+
+    assert_equal({ "foo" => "hello" }, JSON.parse(json))
+  end
+
+  def test_object_to_json_with_options
+    obj = Object.new
+    obj.instance_variable_set :@foo, "hello"
+    obj.instance_variable_set :@bar, "world"
+    json = obj.to_json only: ["foo"]
+
+    assert_equal({ "foo" => "hello" }, JSON.parse(json))
+  end
+
+  def test_struct_to_json_with_options
+    struct = Struct.new(:foo, :bar).new
+    struct.foo = "hello"
+    struct.bar = "world"
+    json = struct.to_json only: [:foo]
+
+    assert_equal({ "foo" => "hello" }, JSON.parse(json))
+  end
+
+  def test_struct_to_json_with_options_nested
+    klass = Struct.new(:foo, :bar)
+    struct = klass.new "hello", "world"
+    parent_struct = klass.new struct, "world"
+    json = parent_struct.to_json only: [:foo]
+
+    assert_equal({ "foo" => { "foo" => "hello" } }, JSON.parse(json))
+  end
+
+  def test_hash_should_pass_encoding_options_to_children_in_as_json
+    person = {
+      name: "John",
+      address: {
+        city: "London",
+        country: "UK"
+      }
+    }
+    json = person.as_json only: [:address, :city]
+
+    assert_equal({ "address" => { "city" => "London" } }, json)
+  end
+
+  def test_hash_should_pass_encoding_options_to_children_in_to_json
+    person = {
+      name: "John",
+      address: {
+        city: "London",
+        country: "UK"
+      }
+    }
+    json = person.to_json only: [:address, :city]
+
+    assert_equal(%({"address":{"city":"London"}}), json)
+  end
+
+  def test_array_should_pass_encoding_options_to_children_in_as_json
+    people = [
+      { name: "John", address: { city: "London", country: "UK" } },
+      { name: "Jean", address: { city: "Paris", country: "France" } }
+    ]
+    json = people.as_json only: [:address, :city]
+    expected = [
+      { "address" => { "city" => "London" } },
+      { "address" => { "city" => "Paris" } }
+    ]
+
+    assert_equal(expected, json)
+  end
+
+  def test_array_should_pass_encoding_options_to_children_in_to_json
+    people = [
+      { name: "John", address: { city: "London", country: "UK" } },
+      { name: "Jean", address: { city: "Paris", country: "France" } }
+    ]
+    json = people.to_json only: [:address, :city]
+
+    assert_equal(%([{"address":{"city":"London"}},{"address":{"city":"Paris"}}]), json)
+  end
+
+  People = Class.new(BasicObject) do
+    include Enumerable
+    def initialize
+      @people = [
+        { name: "John", address: { city: "London", country: "UK" } },
+        { name: "Jean", address: { city: "Paris", country: "France" } }
+      ]
+    end
+    def each(*, &blk)
+      @people.each do |p|
+        yield p if blk
+        p
+      end.each
+    end
+  end
+
+  def test_enumerable_should_generate_json_with_as_json
+    json = People.new.as_json only: [:address, :city]
+    expected = [
+      { "address" => { "city" => "London" } },
+      { "address" => { "city" => "Paris" } }
+    ]
+
+    assert_equal(expected, json)
+  end
+
+  def test_enumerable_should_generate_json_with_to_json
+    json = People.new.to_json only: [:address, :city]
+    assert_equal(%([{"address":{"city":"London"}},{"address":{"city":"Paris"}}]), json)
+  end
+
+  def test_enumerable_should_pass_encoding_options_to_children_in_as_json
+    json = People.new.each.as_json only: [:address, :city]
+    expected = [
+      { "address" => { "city" => "London" } },
+      { "address" => { "city" => "Paris" } }
+    ]
+
+    assert_equal(expected, json)
+  end
+
+  def test_enumerable_should_pass_encoding_options_to_children_in_to_json
+    json = People.new.each.to_json only: [:address, :city]
+
+    assert_equal(%([{"address":{"city":"London"}},{"address":{"city":"Paris"}}]), json)
+  end
+
+  class CustomWithOptions
+    attr_accessor :foo, :bar
+
+    def as_json(options = {})
+      options[:only] = %w(foo bar)
+      super(options)
+    end
+  end
+
+  def test_hash_to_json_should_not_keep_options_around
+    f = CustomWithOptions.new
+    f.foo = "hello"
+    f.bar = "world"
+
+    hash = { "foo" => f, "other_hash" => { "foo" => "other_foo", "test" => "other_test" } }
+    assert_equal({ "foo" => { "foo" => "hello", "bar" => "world" },
+                  "other_hash" => { "foo" => "other_foo", "test" => "other_test" } }, ActiveSupport::JSON.decode(hash.to_json))
+  end
+
+  def test_array_to_json_should_not_keep_options_around
+    f = CustomWithOptions.new
+    f.foo = "hello"
+    f.bar = "world"
+
+    array = [f, { "foo" => "other_foo", "test" => "other_test" }]
+    assert_equal([{ "foo" => "hello", "bar" => "world" },
+                  { "foo" => "other_foo", "test" => "other_test" }], ActiveSupport::JSON.decode(array.to_json))
+  end
+
+  class OptionsTest
+    def as_json(options = :default)
+      options
+    end
+  end
+
+  def test_hash_as_json_without_options
+    json = { foo: OptionsTest.new }.as_json
+    assert_equal({ "foo" => :default }, json)
+  end
+
+  def test_array_as_json_without_options
+    json = [ OptionsTest.new ].as_json
+    assert_equal([:default], json)
+  end
+
+  def test_struct_encoding
+    Struct.new("UserNameAndEmail", :name, :email)
+    Struct.new("UserNameAndDate", :name, :date)
+    Struct.new("Custom", :name, :sub)
+    user_email = Struct::UserNameAndEmail.new "David", "sample@example.com"
+    user_birthday = Struct::UserNameAndDate.new "David", Date.new(2010, 01, 01)
+    custom = Struct::Custom.new "David", user_birthday
+
+    json_strings = ""
+    json_string_and_date = ""
+    json_custom = ""
+
+    assert_nothing_raised do
+      json_strings = user_email.to_json
+      json_string_and_date = user_birthday.to_json
+      json_custom = custom.to_json
+    end
+
+    assert_equal({ "name" => "David",
+                  "sub" => {
+                    "name" => "David",
+                    "date" => "2010-01-01" } }, ActiveSupport::JSON.decode(json_custom))
+
+    assert_equal({ "name" => "David", "email" => "sample@example.com" },
+                 ActiveSupport::JSON.decode(json_strings))
+
+    assert_equal({ "name" => "David", "date" => "2010-01-01" },
+                 ActiveSupport::JSON.decode(json_string_and_date))
+  end
+
+  def test_data_encoding
+    data = Data.define(:name, :email).new("test", "test@example.com")
+
+    assert_nothing_raised { data.to_json }
+
+    assert_equal({ "name" => "test", "email" => "test@example.com" },
+      ActiveSupport::JSON.decode(data.to_json))
+  end
+
+  def test_nil_true_and_false_represented_as_themselves
+    assert_nil nil.as_json
+    assert_equal true,  true.as_json
+    assert_equal false, false.as_json
+  end
+
+  class HashWithAsJson < Hash
+    attr_accessor :as_json_called
+
+    def initialize(*)
+      super
+    end
+
+    def as_json(options = {})
+      @as_json_called = true
+      super
+    end
+  end
+
+  def test_json_gem_dump_by_passing_active_support_encoder
+    h = HashWithAsJson.new
+    h[:foo] = "hello"
+    h[:bar] = "world"
+
+    assert_equal %({"foo":"hello","bar":"world"}), JSON.dump(h)
+    assert_nil h.as_json_called
+  end
+
+  def test_json_gem_generate_by_passing_active_support_encoder
+    h = HashWithAsJson.new
+    h[:foo] = "hello"
+    h[:bar] = "world"
+
+    assert_equal %({"foo":"hello","bar":"world"}), JSON.generate(h)
+    assert_nil h.as_json_called
+  end
+
+  def test_json_gem_pretty_generate_by_passing_active_support_encoder
+    h = HashWithAsJson.new
+    h[:foo] = "hello"
+    h[:bar] = "world"
+
+    assert_equal <<EXPECTED.chomp, JSON.pretty_generate(h)
+{
+  "foo": "hello",
+  "bar": "world"
+}
+EXPECTED
+    assert_nil h.as_json_called
+  end
+
+  def test_twz_to_json_with_use_standard_json_time_format_config_set_to_false
+    with_standard_json_time_format(false) do
+      zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
+      time = ActiveSupport::TimeWithZone.new(Time.utc(2000), zone)
+      assert_equal "\"1999/12/31 19:00:00 -0500\"", ActiveSupport::JSON.encode(time)
+    end
+  end
+
+  def test_twz_to_json_with_use_standard_json_time_format_config_set_to_true
+    with_standard_json_time_format(true) do
+      zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
+      time = ActiveSupport::TimeWithZone.new(Time.utc(2000), zone)
+      assert_equal "\"1999-12-31T19:00:00.000-05:00\"", ActiveSupport::JSON.encode(time)
+    end
+  end
+
+  def test_twz_to_json_with_custom_time_precision
+    with_standard_json_time_format(true) do
+      with_time_precision(0) do
+        zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
+        time = ActiveSupport::TimeWithZone.new(Time.utc(2000), zone)
+        assert_equal "\"1999-12-31T19:00:00-05:00\"", ActiveSupport::JSON.encode(time)
+      end
+    end
+  end
+
+  def test_time_to_json_with_custom_time_precision
+    with_standard_json_time_format(true) do
+      with_time_precision(0) do
+        assert_equal "\"2000-01-01T00:00:00Z\"", ActiveSupport::JSON.encode(Time.utc(2000))
+      end
+    end
+  end
+
+  def test_datetime_to_json_with_custom_time_precision
+    with_standard_json_time_format(true) do
+      with_time_precision(0) do
+        assert_equal "\"2000-01-01T00:00:00+00:00\"", ActiveSupport::JSON.encode(DateTime.new(2000))
+      end
+    end
+  end
+
+  def test_twz_to_json_when_wrapping_a_date_time
+    zone = ActiveSupport::TimeZone["Eastern Time (US & Canada)"]
+    time = ActiveSupport::TimeWithZone.new(DateTime.new(2000), zone)
+    assert_equal '"1999-12-31T19:00:00.000-05:00"', ActiveSupport::JSON.encode(time)
+  end
+
+  def test_exception_to_json
+    exception = Exception.new("foo")
+    assert_equal '"foo"', ActiveSupport::JSON.encode(exception)
+  end
+
+  class InfiniteNumber
+    def as_json(options = nil)
+      { "number" => Float::INFINITY }
+    end
+  end
+
+  def test_to_json_works_when_as_json_returns_infinite_number
+    assert_equal '{"number":null}', InfiniteNumber.new.to_json
+  end
+
+  class NaNNumber
+    def as_json(options = nil)
+      { "number" => Float::NAN }
+    end
+  end
+
+  def test_to_json_works_when_as_json_returns_NaN_number
+    assert_equal '{"number":null}', NaNNumber.new.to_json
+  end
+
+  def test_to_json_works_on_io_objects
+    assert_equal STDOUT.to_s.to_json, STDOUT.to_json
+  end
+
+  private
+    def object_keys(json_object)
+      json_object[1..-2].scan(/([^{}:,\s]+):/).flatten.sort
+    end
+
+    def with_standard_json_time_format(boolean = true)
+      old, ActiveSupport.use_standard_json_time_format = ActiveSupport.use_standard_json_time_format, boolean
+      yield
+    ensure
+      ActiveSupport.use_standard_json_time_format = old
+    end
+
+    def with_time_precision(value)
+      old_value = ActiveSupport::JSON::Encoding.time_precision
+      ActiveSupport::JSON::Encoding.time_precision = value
+      yield
+    ensure
+      ActiveSupport::JSON::Encoding.time_precision = old_value
+    end
+end

--- a/test/activesupport8/encoding_test_cases.rb
+++ b/test/activesupport8/encoding_test_cases.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require "bigdecimal"
+require "date"
+require "time"
+require "pathname"
+require "uri"
+
+module JSONTest
+  class Foo
+    def initialize(a, b)
+      @a, @b = a, b
+    end
+  end
+
+  class Hashlike
+    def to_hash
+      { foo: "hello", bar: "world" }
+    end
+  end
+
+  class Custom
+    def initialize(serialized)
+      @serialized = serialized
+    end
+
+    def as_json(options = nil)
+      @serialized
+    end
+  end
+
+  MyStruct = Struct.new(:name, :value) do
+    def initialize(*)
+      @unused = "unused instance variable"
+      super
+    end
+  end
+
+  class RomanNumeral < Numeric
+    def initialize(str)
+      @str = str
+    end
+
+    def as_json(options = nil)
+      @str
+    end
+  end
+
+  class CustomNumeric < Numeric
+    def initialize(str)
+      @str = str
+    end
+
+    def to_json(options = nil)
+      @str
+    end
+  end
+
+  module EncodingTestCases
+    TrueTests     = [[ true,  %(true)  ]]
+    FalseTests    = [[ false, %(false) ]]
+    NilTests      = [[ nil,   %(null)  ]]
+    NumericTests  = [[ 1,     %(1)     ],
+                     [ 2.5,   %(2.5)   ],
+                     [ 0.0 / 0.0,   %(null) ],
+                     [ 1.0 / 0.0,   %(null) ],
+                     [ -1.0 / 0.0,  %(null) ],
+                     [ BigDecimal("0.0") / BigDecimal("0.0"),  %(null) ],
+                     [ BigDecimal("2.5"), %("#{BigDecimal('2.5')}") ],
+                     [ RomanNumeral.new("MCCCXXXVII"), %("MCCCXXXVII") ],
+                     # Oj does not call to_json on a Numeric subclass, so this
+                     # pair is exercised by the skipped
+                     # test_numeric_subclass_with_custom_to_json in
+                     # encoding_test.rb instead of failing every test_numeric
+                     # run. Restore it here once Oj supports it.
+                     # [ [CustomNumeric.new("123")], %([123]) ]
+    ]
+
+    StringTests   = [[ "this is the <string>",     %("this is the \\u003cstring\\u003e")],
+                     [ 'a "string" with quotes & an ampersand', %("a \\"string\\" with quotes \\u0026 an ampersand") ],
+                     [ "http://test.host/posts/1", %("http://test.host/posts/1")],
+                     [ "Control characters: \x00\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f\u2028\u2029",
+                       %("Control characters: \\u0000\\u0001\\u0002\\u0003\\u0004\\u0005\\u0006\\u0007\\b\\t\\n\\u000b\\f\\r\\u000e\\u000f\\u0010\\u0011\\u0012\\u0013\\u0014\\u0015\\u0016\\u0017\\u0018\\u0019\\u001a\\u001b\\u001c\\u001d\\u001e\\u001f\\u2028\\u2029") ]]
+
+    ArrayTests    = [[ ["a", "b", "c"],          %([\"a\",\"b\",\"c\"])        ],
+                     [ [1, "a", :b, nil, false], %([1,\"a\",\"b\",null,false]) ]]
+
+    HashTests     = [[ { foo: "bar" }, %({\"foo\":\"bar\"}) ],
+                     [ { 1 => 1, 2 => "a", 3 => :b, 4 => nil, 5 => false }, %({\"1\":1,\"2\":\"a\",\"3\":\"b\",\"4\":null,\"5\":false}) ]]
+
+    RangeTests    = [[ 1..2,     %("1..2")],
+                     [ 1...2,    %("1...2")],
+                     [ 1.5..2.5, %("1.5..2.5")]]
+
+    SymbolTests   = [[ :a,     %("a")    ],
+                     [ :this,  %("this") ],
+                     [ :"a b", %("a b")  ]]
+
+    ModuleTests   = [[ Module, %("Module") ],
+                     [ Class,  %("Class")  ],
+                     [ ActiveSupport,                   %("ActiveSupport")                   ],
+                     [ ActiveSupport::Testing, %("ActiveSupport::Testing") ]]
+    ObjectTests   = [[ Foo.new(1, 2), %({\"a\":1,\"b\":2}) ]]
+    HashlikeTests = [[ Hashlike.new, %({\"bar\":\"world\",\"foo\":\"hello\"}) ]]
+    StructTests   = [[ MyStruct.new(:foo, "bar"), %({\"name\":\"foo\",\"value\":\"bar\"}) ],
+                     [ MyStruct.new(nil, nil), %({\"name\":null,\"value\":null}) ]]
+    CustomTests   = [[ Custom.new("custom"), '"custom"' ],
+                     [ Custom.new(nil), "null" ],
+                     [ Custom.new(:a), '"a"' ],
+                     [ Custom.new([ :foo, "bar" ]), '["foo","bar"]' ],
+                     [ Custom.new(foo: "hello", bar: "world"), '{"bar":"world","foo":"hello"}' ],
+                     [ Custom.new(Hashlike.new), '{"bar":"world","foo":"hello"}' ],
+                     [ Custom.new(Custom.new(Custom.new(:a))), '"a"' ]]
+
+    RegexpTests   = [[ /^a/, '"(?-mix:^a)"' ], [/^\w{1,2}[a-z]+/ix, '"(?ix-m:^\\\\w{1,2}[a-z]+)"']]
+
+    URITests      = [[ URI.parse("http://example.com"), %("http://example.com") ]]
+
+    PathnameTests = [[ Pathname.new("lib/index.rb"), %("lib/index.rb") ]]
+
+    IPAddrTests   = [[  IPAddr.new("127.0.0.1"), %("127.0.0.1") ]]
+
+    DateTests     = [[ Date.new(2005, 2, 1), %("2005/02/01") ]]
+    TimeTests     = [[ Time.utc(2005, 2, 1, 15, 15, 10), %("2005/02/01 15:15:10 +0000") ]]
+    DateTimeTests = [[ DateTime.civil(2005, 2, 1, 15, 15, 10), %("2005/02/01 15:15:10 +0000") ]]
+
+    StandardDateTests     = [[ Date.new(2005, 2, 1), %("2005-02-01") ]]
+    StandardTimeTests     = [[ Time.utc(2005, 2, 1, 15, 15, 10), %("2005-02-01T15:15:10.000Z") ]]
+    StandardDateTimeTests = [[ DateTime.civil(2005, 2, 1, 15, 15, 10), %("2005-02-01T15:15:10.000+00:00") ]]
+    StandardStringTests   = [[ "this is the <string>", %("this is the <string>")]]
+  end
+end

--- a/test/activesupport8/time_zone_test_helpers.rb
+++ b/test/activesupport8/time_zone_test_helpers.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module TimeZoneTestHelpers
+  def with_tz_default(tz = nil)
+    old_tz = Time.zone
+    Time.zone = tz
+    yield
+  ensure
+    Time.zone = old_tz
+  end
+
+  def with_env_tz(new_tz = "US/Eastern")
+    old_tz, ENV["TZ"] = ENV["TZ"], new_tz
+    yield
+  ensure
+    old_tz ? ENV["TZ"] = old_tz : ENV.delete("TZ")
+  end
+
+  def with_preserve_timezone(value)
+    old_preserve_tz = ActiveSupport.to_time_preserves_timezone
+
+    ActiveSupport.deprecator.silence do
+      ActiveSupport.to_time_preserves_timezone = value
+    end
+
+    yield
+  ensure
+    ActiveSupport.deprecator.silence do
+      ActiveSupport.to_time_preserves_timezone = old_preserve_tz
+    end
+  end
+
+  def with_tz_mappings(mappings)
+    old_mappings = ActiveSupport::TimeZone::MAPPING.dup
+    ActiveSupport::TimeZone.clear
+    ActiveSupport::TimeZone::MAPPING.clear
+    ActiveSupport::TimeZone::MAPPING.merge!(mappings)
+
+    yield
+  ensure
+    ActiveSupport::TimeZone.clear
+    ActiveSupport::TimeZone::MAPPING.clear
+    ActiveSupport::TimeZone::MAPPING.merge!(old_mappings)
+  end
+
+  def with_utc_to_local_returns_utc_offset_times(value)
+    old_tzinfo2_format = ActiveSupport.utc_to_local_returns_utc_offset_times
+    ActiveSupport.utc_to_local_returns_utc_offset_times = value
+    yield
+  ensure
+    ActiveSupport.utc_to_local_returns_utc_offset_times = old_tzinfo2_format
+  end
+end


### PR DESCRIPTION
The `rails_8` CI job currently runs zero ActiveSupport tests, and it does so silently.

The Rakefile picks the test directory by major version (`Rakefile:98-100`):

```ruby
Rake::TestTask.new "activesupport#{Rails::VERSION::MAJOR}" do |t|
  t.libs << 'test'
  t.pattern = "test/activesupport#{Rails::VERSION::MAJOR}/*_test.rb"
```

Only `test/activesupport6/` and `test/activesupport7/` exist. On the `rails_8` job the pattern expands to `test/activesupport8/*_test.rb` and matches nothing. `Rake::TestTask` still builds a command, the loader is handed no files, and the task exits 0:

```
$ BUNDLE_GEMFILE=gemfiles/rails_8.gemfile bundle exec rake activesupport8
ruby -w -I"lib:test" .../rake_test_loader.rb  -v
$ echo $?
0
```

Since `rails_8` is the only Rails 8 job in the matrix, nothing has been checking Oj against ActiveSupport 8.

## What this does

Copies the suite from [rails v8.0.5](https://github.com/rails/rails/tree/v8.0.5/activesupport/test), which is the activesupport version `gemfiles/rails_8.gemfile.lock` resolves to, and applies the same local changes the `activesupport7` copy already carries:

- flatten the `require_relative` paths, since the files sit in one directory here rather than in `test/` and `test/json/`
- drop `require_relative "../../tools/strict_warnings"` and `require_relative "../../tools/test_common"`, which only exist inside the rails repository
- install Oj as the encoder before the tests run, and keep `test_is_actually_oj`, `test_invalid_encoding_raises`, `test_hash_keys_encoding_without_escaping`, and the split of the unicode tests into escaping-on and escaping-off variants

`test/activesupport8/**/*` is added to the rubocop exclude list next to the other two copies.

The `rails_8` job goes from 0 to 127 runs:

```
$ BUNDLE_GEMFILE=gemfiles/rails_8.gemfile bundle exec rake
127 runs, 173 assertions, 0 failures, 0 errors, 2 skips     # activesupport8
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips         # activerecord
511 runs, 1261 assertions, 0 failures, 0 errors, 0 skips    # tests.rb
$ echo $?
0
```

`rails_7.2` is unchanged and still green (activesupport7: 124 runs, 170 assertions, 0 failures).

## Windows

The matrix excludes `windows` + `rails_7.2`, so `rails_8` is the only Windows job that loads Rails at all. It has therefore never run an ActiveSupport test, and turning the suite on found two things specific to that platform. Both are fixed in the second commit.

Windows ships no system zoneinfo, so anything that resolves a zone raised `TZInfo::DataSourceNotFound` — 49 tests in `decoding_test.rb` through `with_tz_default`, plus the four `TimeWithZone` tests in `encoding_test.rb`. `gemfiles/rails_8.gemfile` now pulls in `tzinfo-data` there. It is written as a `Gem.win_platform?` conditional rather than `:platforms` because the `:windows` platform needs bundler 2.5, and the older `:mingw`/`:mswin`/`:x64_mingw` spelling warns as deprecated on current bundler.

`test_time_to_json_includes_local_offset` moves the zone with `with_env_tz`, which sets `ENV["TZ"]`. Windows does not read `TZ`, so `Time.local` stayed on the machine zone and the offset came out as `+00:00` instead of `-05:00`. It is skipped there, in the same style as the existing skips in `test/test_file.rb` and `test/test_writer.rb`.

With the zone data in place the jobs got far enough to turn up a third thing, in the third commit. `abstract_unit.rb` parallelizes with threads when `fork` is unavailable, and these tests flip ActiveSupport globals as they run: `use_standard_json_time_format` and `escape_html_entities_in_json` in the generated encoding tests, `JSON::Encoding.time_precision` in `test_twz_to_json_with_custom_time_precision`. Forked workers each get their own copy, so the upstream arrangement is safe; threads share them and the tests race.

It reproduces on Linux by forcing the threaded branch — five runs of the suite gave 5, 2, 2, 0 and 3 failures, always a wrong `time_precision` or an inverted `use_standard_json_time_format`, which is the same set the Windows job reported. So that job was flaky rather than broken. The Windows branch now uses `parallelize(workers: 1)`; forcing it on Linux gives 0 failures five runs out of five, and the suite finishes in under 0.01s serially, so there was nothing to gain from parallelizing it.

## The two skips

Turning the suite on surfaced two cases where Oj differs from the stock encoder. I have left them as skips with the expected value recorded, so this PR stays a test-infrastructure change and each one can be picked up on its own.

To confirm they are real differences rather than artifacts of the copy, I encoded the same values with the stock encoder and with Oj in one process, on both Rails versions:

| | stock Rails 8.0 | Oj | stock Rails 7.2 |
|---|---|---|---|
| `encode({'<>' => '<>'}, escape_html_entities: false)`, global on | `{"<>":"<>"}` | `{"\u003c\u003e":"\u003c\u003e"}` | `{"\u003c\u003e":"\u003c\u003e"}` |
| `encode({'<>' => '<>'}, escape_html_entities: true)`, global off | `{"\u003c\u003e":"\u003c\u003e"}` | `{"<>":"<>"}` | `{"<>":"<>"}` |
| `encode([CustomNumeric.new('123')])` | `[123]` | `["#<CustomNumeric:0x...>"]` | `[123]` |

Oj matches the stock Rails 7.2 column in both escaping rows, which is the tell: it is reading the global and never looking at the option.

**`test_hash_keys_encoding_option`** — Rails 8.0 added a per-call `:escape_html_entities` option to `ActiveSupport::JSON.encode`. `Oj::Rails::Encoder` ignores it and follows the global `ActiveSupport.escape_html_entities_in_json`, which is why the two rows above come out exactly inverted. Rails 7.2 does not have the option at all, so this is specific to Rails 8.

**`test_numeric_subclass_with_custom_to_json`** — Rails encodes a `Numeric` subclass through its own `to_json`; Oj dumps the object with `to_s` and produces `"#<JSONTest::CustomNumeric:0x...>"`. This one is not new in Rails 8: the stock encoder returns `[123]` on 7.2 as well. The `activesupport7` copy is taken from v7.0.3, which predates the upstream `CustomNumeric` test case, so nothing here covered it.

The second one looks like a plain bug against `pages/Rails.md:66-71` ("The optimized version is the same as the ActiveSupport default encoding for a given class"). I am happy to send a fix for it as a follow-up if you would like. The first one is a feature-support question, so I would rather hear which way you want it to go before writing anything.

To keep the skip visible in the test output, the `CustomNumeric` pair is commented out of `JSONTest::EncodingTestCases::NumericTests` and restated as a skipped test in `encoding_test.rb`; that way the rest of `test_numeric` keeps running instead of the whole generated test failing.
