### PR TITLE
Share the global rails state with an encoder instead of copying it per encoder

### DIFF
--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -16,6 +16,10 @@ typedef struct _encoder {
     struct _rOptTable ropts;
     struct _options   opts;
     VALUE             arg;
+    // Each is false while the matching member is unused and the global it
+    // shadows - ropts or oj_default_options - is read instead.
+    bool own_ropts;
+    bool own_opts;
 } *Encoder;
 
 bool oj_rails_hash_opt  = false;
@@ -81,6 +85,32 @@ static ROptTable copy_opts(ROptTable src, ROptTable dest) {
         memcpy(dest->table, src->table, sizeof(struct _rOpt) * dest->alen);
     }
     return NULL;
+}
+
+// The table an encoder reads from. Until the encoder is asked to optimize or
+// deoptimize a class of its own it has no table and follows the global one.
+// NULL is how oj_rails_get_opt() is told to use the global table, so the NULL
+// has to reach it - handing it &e->ropts with an empty table instead would
+// quietly turn every optimization off for this encoder.
+static ROptTable encoder_ropts(Encoder e) {
+    return e->own_ropts ? &e->ropts : NULL;
+}
+
+// The options an encoder encodes with. See encoder_new() for why an encoder
+// built without options follows the defaults instead of holding a copy.
+static Options encoder_opts(Encoder e) {
+    return e->own_opts ? &e->opts : &oj_default_options;
+}
+
+// The table an encoder writes to. Copying the global table is deferred to here
+// because it is a 6KB allocation and ActiveSupport builds an encoder for every
+// encode call, while almost none of them ever optimize a class of their own.
+static ROptTable encoder_own_ropts(Encoder e) {
+    if (!e->own_ropts) {
+        copy_opts(&ropts, &e->ropts);
+        e->own_ropts = true;
+    }
+    return &e->ropts;
 }
 
 static int dump_attr_cb(ID key, VALUE value, VALUE ov) {
@@ -635,6 +665,12 @@ static ROpt create_opt(ROptTable rot, VALUE clas) {
     ro->clas = clas;
     ro->on   = true;
     ro->dump = dump_obj_attrs;
+    if (&ropts == rot) {
+        // Nothing marks the global table, so a class that lives only in it has
+        // to be a root. Encoders used to hold a copy of the table and mark it,
+        // which covered this by accident for as long as one was alive.
+        rb_gc_register_mark_object(clas);
+    }
     for (nf = dump_map; NULL != nf->name; nf++) {
         if (0 == strcmp(nf->name, classname)) {
             ro->dump = nf->func;
@@ -667,7 +703,9 @@ static void encoder_free(void *ptr) {
     if (NULL != ptr) {
         Encoder e = (Encoder)ptr;
 
-        oj_options_release(&e->opts);
+        if (e->own_opts) {
+            oj_options_release(&e->opts);
+        }
         if (NULL != e->ropts.table) {
             OJ_R_FREE(e->ropts.table);
         }
@@ -680,15 +718,21 @@ static void encoder_mark(void *ptr) {
         Encoder e = (Encoder)ptr;
         int     i;
 
-        oj_options_mark(&e->opts);
+        if (e->own_opts) {
+            oj_options_mark(&e->opts);
+        }
         if (Qnil != e->arg) {
             rb_gc_mark(e->arg);
         }
         // The optimized classes in the encoder table are not reachable from
-        // anywhere else once optimize() is called on the encoder itself.
-        for (i = 0; i < e->ropts.len; i++) {
-            if (Qnil != e->ropts.table[i].clas) {
-                rb_gc_mark(e->ropts.table[i].clas);
+        // anywhere else once optimize() is called on the encoder itself. An
+        // encoder that never optimized anything has no table to walk - the
+        // classes in the global table are roots registered by create_opt().
+        if (NULL != e->ropts.table) {
+            for (i = 0; i < e->ropts.len; i++) {
+                if (Qnil != e->ropts.table[i].clas) {
+                    rb_gc_mark(e->ropts.table[i].clas);
+                }
             }
         }
     }
@@ -714,21 +758,35 @@ static const rb_data_type_t oj_encoder_type = {
 static VALUE encoder_new(int argc, VALUE *argv, VALUE self) {
     Encoder e = OJ_R_ALLOC(struct _encoder);
 
-    e->opts = oj_default_options;
-    // Detach from the match_string regexps owned by the defaults before the
-    // options are parsed so that a :match_string option builds a chain of its
-    // own that is freed with the encoder.
-    e->opts.str_rx.head = NULL;
-    e->opts.str_rx.tail = NULL;
-    copy_opts(&ropts, &e->ropts);
+    e->ropts.len   = 0;
+    e->ropts.alen  = 0;
+    e->ropts.table = NULL;
+    e->own_ropts   = false;
 
     if (1 <= argc && Qnil != *argv) {
         e->arg = *argv;
     } else {
         e->arg = rb_hash_new();
     }
-    oj_parse_options(e->arg, &e->opts);
-    oj_options_take_ownership(&e->opts);
+    // An encoder given no options of its own reads oj_default_options at encode
+    // time rather than copying it here. ActiveSupport keeps one option-less
+    // encoder for the life of the process, so a copy taken now would freeze
+    // every later Oj.default_options and ActiveSupport::JSON::Encoding change
+    // out of it - including the time_precision that set_encoder itself writes
+    // after ActiveSupport has already built and cached that encoder.
+    e->own_opts = T_HASH == rb_type(e->arg) && 0 < RHASH_SIZE(e->arg);
+    if (e->own_opts) {
+        e->opts = oj_default_options;
+        // Detach from the match_string regexps owned by the defaults before the
+        // options are parsed so that a :match_string option builds a chain of
+        // its own that is freed with the encoder.
+        e->opts.str_rx.head = NULL;
+        e->opts.str_rx.tail = NULL;
+        oj_parse_options(e->arg, &e->opts);
+        oj_options_take_ownership(&e->opts);
+    } else {
+        memset(&e->opts, 0, sizeof(e->opts));
+    }
 
     return TypedData_Wrap_Struct(encoder_class, &oj_encoder_type, e);
 }
@@ -825,7 +883,7 @@ static VALUE encoder_optimize(int argc, VALUE *argv, VALUE self) {
     Encoder e;
     TypedData_Get_Struct(self, struct _encoder, &oj_encoder_type, e);
 
-    optimize(argc, argv, &e->ropts, true);
+    optimize(argc, argv, encoder_own_ropts(e), true);
 
     return Qnil;
 }
@@ -882,7 +940,7 @@ static VALUE encoder_deoptimize(int argc, VALUE *argv, VALUE self) {
     Encoder e;
     TypedData_Get_Struct(self, struct _encoder, &oj_encoder_type, e);
 
-    optimize(argc, argv, &e->ropts, false);
+    optimize(argc, argv, encoder_own_ropts(e), false);
 
     return Qnil;
 }
@@ -913,7 +971,7 @@ static VALUE encoder_optimized(VALUE self, VALUE clas) {
     ROpt    ro;
 
     TypedData_Get_Struct(self, struct _encoder, &oj_encoder_type, e);
-    ro = oj_rails_get_opt(&e->ropts, clas);
+    ro = oj_rails_get_opt(encoder_ropts(e), clas);
 
     if (NULL == ro) {
         return Qfalse;
@@ -1024,9 +1082,9 @@ static VALUE encoder_encode(VALUE self, VALUE obj) {
     if (Qnil != e->arg) {
         VALUE argv[1] = {e->arg};
 
-        return encode(obj, &e->ropts, &e->opts, 1, argv);
+        return encode(obj, encoder_ropts(e), encoder_opts(e), 1, argv);
     }
-    return encode(obj, &e->ropts, &e->opts, 0, NULL);
+    return encode(obj, encoder_ropts(e), encoder_opts(e), 0, NULL);
 }
 
 /* Document-method: encode

--- a/pages/Rails.md
+++ b/pages/Rails.md
@@ -89,6 +89,8 @@ The classes that can be put in optimized mode and are optimized when
  * any class inheriting from ActiveRecord::Base
  * any other class where all attributes should be dumped
 
+Both `Oj::Rails` and each `Oj::Rails::Encoder` have `optimize()`, `deoptimize()`, and `optimized?()` methods. The module level methods change the setting for the whole process. An encoder follows those process wide settings until `optimize()` or `deoptimize()` is called on the encoder itself. From then on the encoder keeps a set of its own and later module level changes do not reach it.
+
 The ActiveSupport decoder is the `JSON.parse()` method. Calling the
 `Oj::Rails.set_decoder()` method replaces that method with the Oj equivalent.
 

--- a/test/test_rails.rb
+++ b/test/test_rails.rb
@@ -179,4 +179,85 @@ class RailsJuice < Minitest::Test
     Oj.remove_to_json(Rational)
   end
 
+  # #1048: an encoder no longer copies the optimization table when it is created.
+  # It reads the global table until it optimizes a class of its own, and only
+  # then takes a copy. Range is used because it is one of the classes Oj has a
+  # built-in dump function for, so optimizing it does not need ActiveRecord.
+  #
+  # The ensure blocks put the global table back because Oj::Rails.optimize is
+  # process wide and tests.rb runs every file in one process.
+
+  def test_encoder_optimize_stays_private_to_the_encoder
+    e = Oj::Rails::Encoder.new
+    e.optimize(Range)
+
+    assert(e.optimized?(Range))
+    refute(Oj::Rails.optimized?(Range))
+    refute(Oj::Rails::Encoder.new.optimized?(Range))
+  ensure
+    Oj::Rails.deoptimize(Range)
+  end
+
+  # An encoder that has not optimized anything itself follows the global table,
+  # including changes made after it was created. ActiveSupport caches an encoder
+  # inside json_encoder=, which Oj.optimize_rails calls before Oj::Rails.optimize,
+  # so a table captured at creation left that encoder permanently unoptimized.
+  def test_encoder_follows_a_global_optimize_made_after_it_was_created
+    before = Oj::Rails::Encoder.new
+    Oj::Rails.optimize(Range)
+
+    assert(before.optimized?(Range))
+  ensure
+    Oj::Rails.deoptimize(Range)
+  end
+
+  def test_encoder_with_its_own_table_ignores_later_global_changes
+    e = Oj::Rails::Encoder.new
+    e.optimize(Regexp) # takes the copy
+    Oj::Rails.optimize(Range)
+
+    refute(e.optimized?(Range))
+    assert(Oj::Rails::Encoder.new.optimized?(Range))
+  ensure
+    Oj::Rails.deoptimize(Range)
+  end
+
+  def test_encoder_deoptimize_does_not_touch_the_global_table
+    Oj::Rails.optimize(Range)
+    e = Oj::Rails::Encoder.new
+    e.deoptimize(Range)
+
+    refute(e.optimized?(Range))
+    assert(Oj::Rails.optimized?(Range))
+  ensure
+    Oj::Rails.deoptimize(Range)
+  end
+
+  # The options are shared the same way and for the same reason. The encoder
+  # ActiveSupport caches is built with no options and lives for the life of the
+  # process, so it has to read Oj.default_options when it encodes rather than
+  # copy it when it is created.
+  def test_optionless_encoder_follows_later_default_options
+    orig = Oj.default_options
+    e = Oj::Rails::Encoder.new
+    Oj.default_options = {indent: 2}
+
+    assert_equal(%|{\n  "a":1\n}\n|, e.encode({'a' => 1}))
+  ensure
+    Oj.default_options = orig
+  end
+
+  # An encoder given options of its own keeps the copy it took of the defaults,
+  # which is what ActiveSupport wants for the per-call encoders it builds from
+  # the to_json arguments.
+  def test_encoder_with_options_keeps_its_own_copy
+    orig = Oj.default_options
+    e = Oj::Rails::Encoder.new(only: ['a'])
+    Oj.default_options = {indent: 2}
+
+    assert_equal('{"a":1}', e.encode({'a' => 1, 'b' => 2}))
+  ensure
+    Oj.default_options = orig
+  end
+
 end


### PR DESCRIPTION
Fixes the allocation half of #1048.

## Problem

`Oj::Rails::Encoder.new` copied two pieces of global state into every instance:

- `copy_opts(&ropts, &e->ropts)` duplicated the whole optimized-class table, `256 * sizeof(struct _rOpt)` = 6144 bytes.
- `e->opts = oj_default_options` snapshotted the default options.

ActiveSupport builds a new encoder for every `ActiveSupport::JSON.encode` / `to_json` call, so with `Oj.optimize_rails` active a busy app pays ~6.7 KB of malloc per encode. That is what made the reporter's `enc_new` benchmark in #1048 plateau twice as high as it needed to. Almost none of those encoders ever call `optimize` or `deoptimize`, so almost none of them ever need a table of their own.

The snapshots are also observably wrong for the one encoder that is *not* short lived. `Oj.optimize_rails` calls `rails_set_encoder` before `rails_optimize`, and `rails_set_encoder` calls `ActiveSupport.json_encoder=` before it writes `time_precision` into `oj_default_options`. ActiveSupport 8.1 caches `@encoder_without_options = encoder.new` inside `json_encoder=`, so that cached encoder captured an empty table and a stale set of options and kept both for the life of the process.

## Change

An encoder now starts with no state of its own and reads the globals:

- `e->ropts.table` stays NULL and `encoder_ropts()` hands `oj_rails_get_opt()` a NULL `ROptTable`, which is how it is told to use the global table. The copy is made by `encoder_own_ropts()` on the first `optimize` / `deoptimize` on that instance, so an encoder that customizes its own set still gets one and still keeps it private.
- `e->opts` is only populated when the encoder is given a non-empty options hash. `encoder_opts()` returns `&oj_default_options` otherwise, so an option-less encoder picks up later `Oj.default_options` and `ActiveSupport::JSON::Encoding` changes at encode time.

`encoder_free` and `encoder_mark` now only touch what the encoder owns.

The two halves have to ship together. Making only the table lazy turns the AS 8.1 cached encoder from "silently unoptimized" into "optimized with stale options": it starts using Oj's optimized `Time` dump while still holding the `sec_prec` that was in effect before `set_encoder` wrote `time_precision`. That regresses six tests in `test/activesupport8` under ActiveSupport 8.1. With both halves it is clean.

`create_opt` also registers a class added to the *global* table as a GC root. Nothing marks that table; the per-encoder copies used to mark it by accident for as long as an encoder was alive, and with no copies left a class that lives only in that table would be unreachable. `odd.c` uses `rb_gc_register_mark_object` for the same situation.

## Behavior change

An encoder created before a module level `Oj::Rails.optimize` used to keep the table it captured at creation, so the later `optimize` never reached it. It now follows the global set until it optimizes something itself. Nothing in the repo tested or documented the old snapshot, and it is the mechanism behind the ActiveSupport 8.1 half of #985. `pages/Rails.md` now spells out when an encoder detaches.

## Measurements

Save this next to the checkout as `bench_1048.rb`. It needs nothing but the repo and one of the bundled gemfiles, and it runs the same way on `develop` and on this branch.

```ruby
# bench_1048.rb - the three measurements in this PR. One per process so that
# the RSS numbers are not disturbed by the other runs.
#
#   rake compile
#   B=gemfiles/rails_7.2.gemfile
#   BUNDLE_GEMFILE=$B bundle exec ruby -Ilib bench_1048.rb rss enc_new
#   BUNDLE_GEMFILE=$B bundle exec ruby -Ilib bench_1048.rb rss to_json
#   BUNDLE_GEMFILE=$B bundle exec ruby -Ilib bench_1048.rb tput
#   BUNDLE_GEMFILE=$B bundle exec ruby -Ilib bench_1048.rb size
#
# Run it once on develop and once on the branch, recompiling in between.

require "active_support/all"
require "benchmark"
require "oj"

Oj.optimize_rails
Oj.default_options = {mode: :rails}

PLAIN = {"id" => 1, "name" => "x", "vals" => [1, 2, 3], "ok" => true}.freeze

def rss_mb = `ps -o rss= -p #{Process.pid}`.to_i / 1024.0

def tag = format("oj=%-8s as=%-8s", Oj::VERSION, ActiveSupport::VERSION::STRING)

# RSS while encoding, sampled right after a GC.start. bench.rb from the issue.
def rss(scenario, iters)
  shared = Oj::Rails::Encoder.new
  run = case scenario
        when "enc_new"    then -> { Oj::Rails::Encoder.new.encode(PLAIN) } # what Rails does per to_json
        when "enc_shared" then -> { shared.encode(PLAIN) }
        when "to_json"    then -> { PLAIN.to_json }
        else abort("unknown scenario #{scenario}")
        end

  step = iters / 10
  samples = []
  iters.times do |i|
    run.call
    if (i % step).zero?
      GC.start
      samples << rss_mb.round(1)
    end
  end
  GC.start
  puts format("%s rss %-10s samples=%s final=%.1f", tag, scenario, samples.join(","), rss_mb)
end

# Encodes per second on the two paths that build an encoder per call.
def tput(iters)
  10_000.times { Oj::Rails::Encoder.new.encode(PLAIN) } # warm up

  {"enc_new" => -> { Oj::Rails::Encoder.new.encode(PLAIN) },
   "to_json" => -> { PLAIN.to_json }}.each do |name, run|
    t = Benchmark.realtime { iters.times { run.call } }
    puts format("%s tput %-10s %6.2f s %10.0f enc/s", tag, name, t, iters / t)
  end
end

# Bytes of process memory per live encoder. Encoders are kept in an array so
# that nothing is collected while the delta is taken.
def size(count)
  GC.start
  before = rss_mb
  keep = Array.new(count) { Oj::Rails::Encoder.new }
  GC.start
  after = rss_mb
  puts format("%s size %d encoders %.1f -> %.1f MB  %d bytes/encoder",
              tag, keep.size, before, after, (after - before) * 1024 * 1024 / keep.size)
end

case ARGV[0]
when "rss"  then rss(ARGV[1] || "enc_new", Integer(ARGV[2] || 500_000))
when "tput" then tput(Integer(ARGV[1] || 500_000))
when "size" then size(Integer(ARGV[1] || 50_000))
else abort("usage: ruby -Ilib bench_1048.rb rss [enc_new|enc_shared|to_json] [iters] | tput [iters] | size [count]")
end
```

ruby 4.0.6 (x86_64-linux), activesupport 7.2.3.1, 500k iterations, 50k encoders:

| measurement | command | develop | this branch | change |
|---|---|---|---|---|
| final RSS, a new encoder per encode | `rss enc_new` | 66.2 MB | 47.5 MB | -28% |
| final RSS, `Hash#to_json` | `rss to_json` | 79.6 MB | 47.4 MB | -40% |
| encodes per second, a new encoder per encode | `tput` | 843 K/s | 3.73 M/s | 4.4x |
| encodes per second, `Hash#to_json` | `tput` | 819 K/s | 3.37 M/s | 4.1x |
| memory per live encoder | `size` | 6757 bytes | 594 bytes | -91% |

The throughput multiplier is that large because the 6 KB allocation and copy are a fixed cost per encoder that has nothing to do with what is being encoded, so it dominates on a small payload. It shrinks as the payload grows: 4.8x on the 44 byte object used here, 2.9x on a 323 byte one, and 1.2x on a 5.2 KB list of 50 rows.

Raw output:

```
develop
  oj=3.17.4   as=7.2.3.1  rss enc_new    samples=46.7,76.1,65.0,68.0,66.4,75.8,75.7,60.4,60.9,59.1 final=66.2
  oj=3.17.4   as=7.2.3.1  rss to_json    samples=46.6,76.5,62.7,62.9,56.3,79.6,79.6,79.6,79.6,79.6 final=79.6
  oj=3.17.4   as=7.2.3.1  tput enc_new      0.59 s     843206 enc/s
  oj=3.17.4   as=7.2.3.1  tput to_json      0.61 s     819369 enc/s
  oj=3.17.4   as=7.2.3.1  size 50000 encoders 46.6 -> 368.8 MB  6757 bytes/encoder

this branch
  oj=3.17.4   as=7.2.3.1  rss enc_new    samples=46.6,49.1,49.1,49.1,49.1,49.2,49.2,49.2,47.7,47.7 final=47.5
  oj=3.17.4   as=7.2.3.1  rss to_json    samples=46.5,49.0,49.2,49.2,47.3,47.3,47.4,47.4,47.4,47.4 final=47.4
  oj=3.17.4   as=7.2.3.1  tput enc_new      0.13 s    3731889 enc/s
  oj=3.17.4   as=7.2.3.1  tput to_json      0.15 s    3372597 enc/s
  oj=3.17.4   as=7.2.3.1  size 50000 encoders 46.6 -> 75.0 MB  594 bytes/encoder
```

The `develop` RSS samples move around by 20 MB from sample to sample because that memory is short lived garbage waiting for the next GC, which is the effect described in #1048. The branch samples are flat because there is almost nothing left to collect.

## Tests

`test/test_rails.rb` gains six tests: the instance level `optimize` / `deoptimize` / `optimized?` trio had no coverage at all before. They pin that an instance level set stays private to the instance and detaches from later global changes, that an encoder with no set of its own follows the global one, and the same two directions for the options.

- `test/tests.rb`: 522 runs, 0 failures
- `test/activesupport7` on ActiveSupport 7.2: 124 runs, 0 failures
- `test/activesupport8` on ActiveSupport 8.0: 127 runs, 0 failures, 2 skips
- `test/activesupport8` on ActiveSupport 8.1: unchanged from develop. `test_cannot_pass_unsupported_options` fails on both, and `encoding_test.rb:40` flakes by run order on both (roughly 1 run in 4, under whichever test name the order lands on).
- `rake test:valgrind`: 499 runs, 0 failures, no leak or invalid access reports

## Not in this change

`create_opt` reaches for `ActiveRecord::Base` for any class with no built-in dump function and lets the `NameError` through, so `Oj::Rails.optimize(SomeClass)` raises when ActiveRecord is not loaded. It is a separate bug and the tests here use `Range` to stay clear of it.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
