### PR TITLE
Hand as_json a copy of the options instead of the encoder's own hash

### DIFF
--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -1080,7 +1080,18 @@ static VALUE encoder_encode(VALUE self, VALUE obj) {
     TypedData_Get_Struct(self, struct _encoder, &oj_encoder_type, e);
 
     if (Qnil != e->arg) {
-        VALUE argv[1] = {e->arg};
+        // as_json is allowed to write into the options hash it is handed, and
+        // the ActiveSupport suite has a test that does exactly that. Handing
+        // out the encoder's own hash lets one such call poison every later
+        // encode by the same encoder, which on ActiveSupport 8.1 is every
+        // option-less to_json in the process because json_encoder= caches one
+        // encoder and keeps it. Rails never exposes a hash it will reuse:
+        // JSONGemEncoder#encode passes options.dup, and only when there are
+        // options at all, so with none as_json writes into its own default.
+        // The copy is not frozen the way Rails 8.0 and later freeze theirs,
+        // because Oj hands as_json the hash even when it is empty and that is
+        // exactly the case Rails leaves writable.
+        VALUE argv[1] = {T_HASH == rb_type(e->arg) ? rb_hash_dup(e->arg) : e->arg};
 
         return encode(obj, encoder_ropts(e), encoder_opts(e), 1, argv);
     }

--- a/test/test_rails.rb
+++ b/test/test_rails.rb
@@ -48,6 +48,16 @@ class OjNestedOptsProbe
   end
 end
 
+# Writes into the options hash it was handed, the way CustomWithOptions does in
+# the ActiveSupport suite. Rails allows this - its own encoder hands as_json a
+# copy for exactly this reason - so it must not reach the encoder's own hash.
+class OjOptionMutatingProbe
+  def as_json(options = nil)
+    options[:only] = ['foo', 'bar'] unless options.nil?
+    {'foo' => 'hello', 'bar' => 'world'}
+  end
+end
+
 class RailsJuice < Minitest::Test
 
   def test_bigdecimal_dump
@@ -101,6 +111,31 @@ class RailsJuice < Minitest::Test
       json = Oj::Rails::Encoder.new(match_string: {/^x/ => String}).encode({id: 1})
       assert_equal('{"id":1}', json)
     end
+  end
+
+  # An as_json that writes into the options hash it was given must not change
+  # what the encoder hands the next one. ActiveSupport 8.1 keeps a single
+  # option-less encoder for the life of the process, so without a copy one such
+  # call leaves :only set on it and every later plain to_json in the process
+  # comes out filtered - usually as {}.
+  def test_as_json_cannot_write_into_the_encoder_options
+    encoder = Oj::Rails::Encoder.new
+
+    assert_equal('{"foo":"hello","bar":"world"}', encoder.encode(OjOptionMutatingProbe.new))
+    # An encoder built with no options hands as_json an empty hash, so "" here
+    # means nothing leaked. Before the fix this was "only".
+    assert_equal('{"n":1,"opts":""}', encoder.encode(OjOptsProbe.new(1)))
+  end
+
+  # The same for an encoder that was given options: the caller's hash is theirs,
+  # and the mutation must not accumulate on it either.
+  def test_as_json_cannot_write_into_the_callers_options
+    opts = {only: ['foo', 'bar', 'n', 'opts']}
+    encoder = Oj::Rails::Encoder.new(opts)
+
+    encoder.encode(OjOptionMutatingProbe.new)
+    assert_equal({only: ['foo', 'bar', 'n', 'opts']}, opts)
+    assert_equal('{"n":1,"opts":"only"}', encoder.encode(OjOptsProbe.new(1)))
   end
 
   # #1020: to_json(only:) on a record with include_root_in_json wraps each row


### PR DESCRIPTION
Fixes a bug where one `as_json` can silently break every later encode in the process on ActiveSupport 8.1.

Found while working on #985. Verifying that #1049 fixed the ActiveSupport 8.1 half of that issue meant running the vendored ActiveSupport suite against 8.1, and it turned out `test/activesupport8` was vendored from Rails v8.0.5 and had never been run against 8.1 at all. Doing so produced a failure that moved between `test_struct`, `test_object`, `test_hashlike` and `test_data_encoding` depending on run order, always as `{}`, and only on 8.1 - the 8.0 suite is clean ten runs out of ten. That is this bug. The 8.1 suite itself is a separate follow-up PR, which needs this one to be green.

## Problem

ActiveSupport lets `as_json` write into the options hash it is given.
Its own suite has a class that does exactly that, in `activesupport/test/json/encoding_test.rb`:

```ruby
class CustomWithOptions
  attr_accessor :foo, :bar

  def as_json(options = {})
    options[:only] = %w(foo bar)
    super(options)
  end
end
```

Rails is fine with this because it never exposes a hash it will reuse:

```ruby
def encode(value)
  unless options.empty?
    value = value.as_json(options.dup.freeze)   # options.dup on 7.2, frozen since 8.0
  end
  ...
```

The copy covers the case where there are options, and when there are none `as_json` is called with no arguments at all, so a mutating `as_json` writes into its own default hash and nobody else ever sees it.

`encoder_encode` passed `e->arg` straight through, and Oj passes it even when it is empty, so the mutation landed on the encoder's own hash and stayed there for the life of that encoder.
Up to ActiveSupport 8.0 that was survivable: `ActiveSupport::JSON.encode` built a new encoder for every call, so the poisoned hash was thrown away with it.
ActiveSupport 8.1 caches one encoder inside `json_encoder=` and uses it for every option-less encode in the process, so a single such `as_json` leaves `:only` set on the encoder that serves **every plain `to_json` from then on**.

Everything whose keys are not in that `:only` list then encodes as `{}`:

```ruby
require "active_support/all"
require "oj"
Oj.optimize_rails

class CustomWithOptions
  attr_accessor :foo, :bar
  def as_json(options = {})
    options[:only] = %w(foo bar)
    super(options)
  end
end

Point = Struct.new(:name, :value)

ActiveSupport::JSON.encode(Point.new("foo", "bar"))
# => "{\"name\":\"foo\",\"value\":\"bar\"}"

f = CustomWithOptions.new
f.foo = "hello"
f.bar = "world"
ActiveSupport::JSON.encode({ "foo" => f })     # the one call that mutates

ActiveSupport::JSON.encode(Point.new("foo", "bar"))
# => "{}"                                       <- and it stays that way
```

ruby 3.4.9 (x86_64-linux):

| activesupport | before | after |
|---|---|---|
| 8.1.3 | `{}` | `{"name":"foo","value":"bar"}` |
| 8.0.5 | `{"name":"foo","value":"bar"}` | `{"name":"foo","value":"bar"}` |

This is not a regression from #1049 - it reproduces the same way on 866f8b7, the commit before it.
#1049 only made it easier to notice, because it is what made the vendored ActiveSupport suite worth running against 8.1.

## Change

`encoder_encode` now hands `as_json` a copy, the way Rails does.
The copy is per encode call, not per `as_json` call, so an object graph still sees one shared hash within a single encode - the same thing `Array#as_json` and `Hash#as_json` do upstream when they pass their options down to every element.

`e->arg` is only a Hash when the encoder was built from one, so the copy is guarded on the type and anything else is passed through untouched.

## Performance

This costs one hash copy per encode. That is measurable on the small payloads #1049 benchmarked, because there the fixed per-encode cost is most of the work - the benchmark payload never calls `as_json` at all, so the copy is pure overhead for it.

The same script as #1049:

```ruby
# bench_1048.rb - the three measurements in this PR. One per process so that
# the RSS numbers are not disturbed by the other runs.
#
#   rake compile
#   B=gemfiles/rails_7.2.gemfile
#   BUNDLE_GEMFILE=$B bundle exec ruby -Ilib bench_1048.rb rss enc_new
#   BUNDLE_GEMFILE=$B bundle exec ruby -Ilib bench_1048.rb rss to_json
#   BUNDLE_GEMFILE=$B bundle exec ruby -Ilib bench_1048.rb tput
#   BUNDLE_GEMFILE=$B bundle exec ruby -Ilib bench_1048.rb size
#
# Run it once on develop and once on the branch, recompiling in between.

require "active_support/all"
require "benchmark"
require "oj"

Oj.optimize_rails
Oj.default_options = {mode: :rails}

PLAIN = {"id" => 1, "name" => "x", "vals" => [1, 2, 3], "ok" => true}.freeze

def rss_mb = `ps -o rss= -p #{Process.pid}`.to_i / 1024.0

def tag = format("oj=%-8s as=%-8s", Oj::VERSION, ActiveSupport::VERSION::STRING)

# RSS while encoding, sampled right after a GC.start. bench.rb from the issue.
def rss(scenario, iters)
  shared = Oj::Rails::Encoder.new
  run = case scenario
        when "enc_new"    then -> { Oj::Rails::Encoder.new.encode(PLAIN) } # what Rails does per to_json
        when "enc_shared" then -> { shared.encode(PLAIN) }
        when "to_json"    then -> { PLAIN.to_json }
        else abort("unknown scenario #{scenario}")
        end

  step = iters / 10
  samples = []
  iters.times do |i|
    run.call
    if (i % step).zero?
      GC.start
      samples << rss_mb.round(1)
    end
  end
  GC.start
  puts format("%s rss %-10s samples=%s final=%.1f", tag, scenario, samples.join(","), rss_mb)
end

# Encodes per second on the two paths that build an encoder per call.
def tput(iters)
  10_000.times { Oj::Rails::Encoder.new.encode(PLAIN) } # warm up

  {"enc_new" => -> { Oj::Rails::Encoder.new.encode(PLAIN) },
   "to_json" => -> { PLAIN.to_json }}.each do |name, run|
    t = Benchmark.realtime { iters.times { run.call } }
    puts format("%s tput %-10s %6.2f s %10.0f enc/s", tag, name, t, iters / t)
  end
end

# Bytes of process memory per live encoder. Encoders are kept in an array so
# that nothing is collected while the delta is taken.
def size(count)
  GC.start
  before = rss_mb
  keep = Array.new(count) { Oj::Rails::Encoder.new }
  GC.start
  after = rss_mb
  puts format("%s size %d encoders %.1f -> %.1f MB  %d bytes/encoder",
              tag, keep.size, before, after, (after - before) * 1024 * 1024 / keep.size)
end

case ARGV[0]
when "rss"  then rss(ARGV[1] || "enc_new", Integer(ARGV[2] || 500_000))
when "tput" then tput(Integer(ARGV[1] || 500_000))
when "size" then size(Integer(ARGV[1] || 50_000))
else abort("usage: ruby -Ilib bench_1048.rb rss [enc_new|enc_shared|to_json] [iters] | tput [iters] | size [count]")
end
```

ruby 4.0.6 (x86_64-linux), activesupport 7.2.3.1, 500k iterations, median of 3 runs:

| | 866f8b7 (before #1049) | c1c48b2 (#1049) | this branch | vs #1049 | vs before #1049 |
|---|---|---|---|---|---|
| encodes/s, a new encoder per encode | 1,102,567 | 3,883,404 | 3,417,005 | -12.0% | **3.10x** |
| encodes/s, `Hash#to_json` | 1,064,267 | 3,353,477 | 3,004,473 | -10.4% | **2.82x** |

Memory is unaffected. The copy is one small short lived hash per encode, which the same GC pass that was already collecting the encoder takes with it.

Raw output:

```
c1c48b2 (#1049)
  oj=3.17.4   as=7.2.3.1  rss enc_new    samples=46.7,49.4,49.4,49.4,49.4,49.4,49.4,49.4,49.4,49.4 final=49.4
  oj=3.17.4   as=7.2.3.1  rss to_json    samples=46.6,49.1,49.2,47.6,47.4,47.6,47.6,47.6,47.6,47.2 final=47.5
  oj=3.17.4   as=7.2.3.1  size 50000 encoders 46.6 -> 74.9 MB  593 bytes/encoder
  oj=3.17.4   as=7.2.3.1  tput enc_new      0.13 s    3980926 enc/s
  oj=3.17.4   as=7.2.3.1  tput to_json      0.15 s    3381939 enc/s
  oj=3.17.4   as=7.2.3.1  tput enc_new      0.13 s    3883404 enc/s
  oj=3.17.4   as=7.2.3.1  tput to_json      0.15 s    3353477 enc/s
  oj=3.17.4   as=7.2.3.1  tput enc_new      0.14 s    3700117 enc/s
  oj=3.17.4   as=7.2.3.1  tput to_json      0.16 s    3144997 enc/s

this branch
  oj=3.17.4   as=7.2.3.1  rss enc_new    samples=46.6,47.9,47.9,47.9,47.9,47.9,47.9,47.9,47.9,47.9 final=47.9
  oj=3.17.4   as=7.2.3.1  rss to_json    samples=46.6,47.8,47.0,47.0,47.0,47.0,47.0,47.0,47.0,47.0 final=47.0
  oj=3.17.4   as=7.2.3.1  size 50000 encoders 46.6 -> 74.9 MB  593 bytes/encoder
  oj=3.17.4   as=7.2.3.1  tput enc_new      0.15 s    3393203 enc/s
  oj=3.17.4   as=7.2.3.1  tput to_json      0.17 s    2956016 enc/s
  oj=3.17.4   as=7.2.3.1  tput enc_new      0.15 s    3417005 enc/s
  oj=3.17.4   as=7.2.3.1  tput to_json      0.17 s    3004473 enc/s
  oj=3.17.4   as=7.2.3.1  tput enc_new      0.14 s    3506811 enc/s
  oj=3.17.4   as=7.2.3.1  tput to_json      0.16 s    3068172 enc/s

866f8b7 (before #1049), for the last column of the table
  oj=3.17.4   as=7.2.3.1  tput enc_new      0.48 s    1035703 enc/s
  oj=3.17.4   as=7.2.3.1  tput to_json      0.47 s    1057575 enc/s
  oj=3.17.4   as=7.2.3.1  tput enc_new      0.45 s    1107443 enc/s
  oj=3.17.4   as=7.2.3.1  tput to_json      0.47 s    1064267 enc/s
  oj=3.17.4   as=7.2.3.1  tput enc_new      0.45 s    1102567 enc/s
  oj=3.17.4   as=7.2.3.1  tput to_json      0.46 s    1093561 enc/s
```

So this gives back about a tenth of what #1049 won and keeps the rest.
I would rather pay that than keep a mode where one `as_json` in an application quietly turns every subsequent `to_json` into `{}`, and the alternative - deferring the copy to the first `as_json` call that actually receives the options - needs per-encode state threaded through `struct _out` and is not worth that risk for the difference.

## Tests

`test/test_rails.rb` gains two tests, both red without the change:

- `test_as_json_cannot_write_into_the_encoder_options` - a mutating `as_json` must not change what the next encode by the same encoder is handed. Fails with `opts` reading `only` instead of empty.
- `test_as_json_cannot_write_into_the_callers_options` - an encoder built from a caller's hash must not accumulate into it either. Fails with the caller's hash coming back as `{only: ["foo", "bar"]}`.

They use a plain probe class rather than ActiveSupport, so they run in every CI job including `no_rails`.

Full runs, all green:

- `test/tests.rb`: 524 runs, 0 failures
- `rails_7.2`: 124 runs, 0 failures
- `rails_8`: 128 runs, 0 failures, 2 skips
- `rails_8.1`: 136 runs, 0 failures, 6 skips (with the suite from the follow-up PR)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
