### PR TITLE
Fix hash flooding by seeding the key hash per process

### DIFF
--- a/ext/oj/cache.c
+++ b/ext/oj/cache.c
@@ -28,6 +28,22 @@
 // almost the Murmur hash algorithm
 #define M 0x5bd1e995
 
+uint64_t oj_hash_seed = 0;
+
+void oj_hash_seed_init(void) {
+    static bool seeded = false;
+
+    if (seeded) {
+        return;
+    }
+    seeded = true;
+#if HAVE_RB_HASH_START
+    oj_hash_seed = (uint64_t)rb_hash_start(0);
+#else
+    oj_hash_seed = (uint64_t)NUM2LL(rb_funcall(rb_str_new_cstr("oj"), rb_intern("hash"), 0));
+#endif
+}
+
 typedef struct _slot {
     struct _slot     *next;
     VALUE             val;
@@ -62,7 +78,7 @@ void cache_set_form(Cache c, VALUE (*form)(const char *str, size_t len)) {
 static uint64_t hash_calc(const uint8_t *key, size_t len) {
     const uint8_t *end     = key + len;
     const uint8_t *endless = key + (len & 0xFFFFFFFC);
-    uint64_t       h       = (uint64_t)len;
+    uint64_t       h       = (uint64_t)len ^ oj_hash_seed;
     uint64_t       k;
 
     while (key < endless) {

--- a/ext/oj/cache.h
+++ b/ext/oj/cache.h
@@ -6,8 +6,13 @@
 
 #include <ruby.h>
 #include <stdbool.h>
+#include <stdint.h>
 
 #define CACHE_MAX_KEY 35
+
+extern uint64_t oj_hash_seed;
+
+extern void oj_hash_seed_init(void);
 
 struct _cache;
 typedef struct _cache *Cache;

--- a/ext/oj/extconf.rb
+++ b/ext/oj/extconf.rb
@@ -32,6 +32,7 @@ have_func('pthread_mutex_init')
 have_func('getrlimit', 'sys/resource.h')
 have_func('rb_enc_interned_str')
 have_func('rb_ext_ractor_safe', 'ruby.h')
+have_func('rb_hash_start', 'ruby.h')
 
 dflags['OJ_DEBUG'] = true unless ENV['OJ_DEBUG'].nil?
 

--- a/ext/oj/intern.c
+++ b/ext/oj/intern.c
@@ -97,6 +97,8 @@ static const rb_data_type_t oj_cache_type = {
 };
 
 void oj_hash_init(void) {
+    oj_hash_seed_init();
+
     VALUE cache_class = rb_define_class_under(Oj, "Cache", rb_cObject);
     rb_undef_alloc_func(cache_class);
 
@@ -151,7 +153,7 @@ ID oj_attr_intern(const char *key, size_t len) {
 static uint64_t hash_calc(const uint8_t *key, size_t len) {
     const uint8_t *end     = key + len;
     const uint8_t *endless = key + (len & 0xFFFFFFFC);
-    uint64_t       h       = (uint64_t)len;
+    uint64_t       h       = (uint64_t)len ^ oj_hash_seed;
     uint64_t       k;
 
     while (key < endless) {


### PR DESCRIPTION
## Problem

Every JSON object key shorter than `CACHE_MAX_KEY` (35) is interned through `cache_intern()`, and the bucket it lands in is decided by `hash_calc()` in `ext/oj/cache.c`. That function is an almost-Murmur hash whose only input is the key bytes and its length, with a compile time constant `M = 0x5bd1e995` and no per process seed:

```c
uint64_t h = (uint64_t)len;
```

`ext/oj/intern.c` carries a second copy of the same function for the class cache.

Because the hash is fully determined at compile time, a caller can precompute keys that all land in the same bucket. `cache.c` resolves collisions with an unbounded singly linked list that is walked on every insert and every lookup (`ext/oj/cache.c:187-194`), so a document made of such keys turns interning from `O(n)` into `O(n^2)`. The locking variant walks that chain while holding the cache mutex, so other threads are blocked as well, and the entries live in a process wide cache that survives many GC cycles, so later unrelated parses stay slow too.

This affects every entry point that interns keys with the default options: `Oj.load`, `Oj::Parser`, and `JSON.parse` under `Oj.mimic_JSON` (which forces `cache_keys => Yes` at `ext/oj/mimic_json.c:710`).

## Fix

Mix a per process random value into the initial state of both copies of `hash_calc()`, which is the standard Murmur seeding position:

```c
uint64_t h = (uint64_t)len ^ oj_hash_seed;
```

`oj_hash_seed` is set once by `oj_hash_seed_init()`, called at the top of `oj_hash_init()` so that it is in place before the first `cache_create()`. The seed comes from `rb_hash_start(0)`, which folds in the random seed Ruby itself uses to defend against the same attack on `Hash`. `rb_hash_start` is behind a `have_func` check with a `String#hash` fallback, since TruffleRuby is in the CI matrix.

The seed is written once during `Init_oj` and only read afterwards, so this does not change the Ractor safety of the caches.

## Measurements

The script at the end of this section reproduces the numbers. Save it as `bench_hash_flooding.rb` at the root of an oj checkout and run it from there:

```
rake compile
ruby bench_hash_flooding.rb
```

It reimplements the pre-patch `hash_calc()` in Ruby and brute forces 5,000 distinct 16 byte keys that share the low 10 bits of the hash. At that entry count the cache settles at 1,024 slots, so all 5,000 keys land in one bucket. It writes that 105 KB document, plus a control document of the same size, key count and key length with sequential keys, then parses each 20 times with `Oj.load(doc)` under `mode: :compat`, each in a process of its own since the intern cache is process wide. The first run spends about 8 seconds precomputing the keys and caches both documents in the temp directory, so later runs start measuring immediately. `KEYS` and `ITER` override the key count and the parses per document.

For the before column, stash the patch and rebuild:

```
git stash push -- ext/oj/cache.c ext/oj/cache.h ext/oj/intern.c ext/oj/extconf.rb
rake compile && ruby bench_hash_flooding.rb
git stash pop && rake compile
```

| build | colliding keys | control keys | ratio |
| --- | --- | --- | --- |
| before | 24.6 ms/parse | 0.54 ms/parse | 46x |
| after | 0.53 ms/parse | 0.54 ms/parse | 1.0x |

The colliding document costs about 46x the control document before the change, and is indistinguishable from it after. Throughput on ordinary documents is unchanged. The cost grows quadratically with the number of colliding keys, so a larger precomputed set scales the gap further.

`Oj::Parser.new(:usual)` shows the same behaviour, since `ext/oj/usual.c:161` interns through the same `cache.c`.

`bench_hash_flooding.rb`:

```ruby
#!/usr/bin/env ruby
# frozen_string_literal: true
#
# Run from the root of an oj checkout, after `rake compile`:
#
#   ruby bench_hash_flooding.rb
#
# KEYS and ITER override the key count and the parses per document. The keys
# are precomputed against hash_calc() with a seed of 0, so the colliding
# document is what an unseeded build is vulnerable to.

require 'rbconfig'
require 'tmpdir'

LIB    = File.join(Dir.pwd, 'lib')
LOCAL  = File.directory?(File.join(LIB, 'oj'))
M      = 0x5bd1e995
MASK64 = 0xFFFFFFFFFFFFFFFF
KEYFMT = '%016x'
COUNT  = Integer(ENV['KEYS'] || 5_000)
ITER   = Integer(ENV['ITER'] || 20)

$LOAD_PATH.unshift(LIB) if LOCAL

def hash_calc(key) # ext/oj/cache.c hash_calc() with a seed of 0
  len = key.bytesize
  h   = len
  n   = len >> 2
  key.unpack("V#{n}").each do |w|
    k = (w * M) & MASK64
    k ^= k >> 24
    h = (h * M) & MASK64
    h ^= (k * M) & MASK64
  end
  i = n << 2
  if len - i > 1
    h ^= ((key.getbyte(i) | (key.getbyte(i + 1) << 8)) << 8)
    i += 2
  end
  h ^= key.getbyte(i) if i < len
  h = (h * M) & MASK64
  h ^= h >> 13
  h = (h * M) & MASK64
  h ^= h >> 15
  h
end

if ARGV[0] == '--parse' # one document, in a process of its own
  require 'oj'
  Oj.default_options = {mode: :compat}
  doc = File.read(ARGV[1])
  t   = Process.clock_gettime(Process::CLOCK_MONOTONIC)
  Integer(ARGV[2]).times { Oj.load(doc) }
  print Process.clock_gettime(Process::CLOCK_MONOTONIC) - t
  exit
end

size = 256 # the cache starts here and quadruples once cnt / size > 4
size *= 4 while COUNT / size > 4
mask = size - 1

def write_doc(path, keys)
  File.write(path, "{#{keys.map { |k| %("#{k}":1) }.join(',')}}")
end

collide = File.join(Dir.tmpdir, "oj_flood_collide_#{COUNT}.json")
control = File.join(Dir.tmpdir, "oj_flood_control_#{COUNT}.json")

unless File.exist?(collide) && File.exist?(control)
  puts "precomputing #{COUNT} keys that share the low #{mask.bit_length} bits of the hash"
  buckets = Hash.new { |h, k| h[k] = [] }
  found   = nil
  i       = 0
  until found
    b = buckets[hash_calc(format(KEYFMT, i)) & mask]
    b << i
    found = b if b.size >= COUNT
    i += 1
  end
  write_doc(collide, found.map { |n| format(KEYFMT, n) })
  write_doc(control, Array.new(COUNT) { |n| format(KEYFMT, 0xdeadbeef00000000 + n) })
  puts "scanned #{i} keys, wrote #{collide} and #{control}"
end

def measure(path)
  cmd = [RbConfig.ruby]
  cmd << "-I#{LIB}" if LOCAL
  cmd += [__FILE__, '--parse', path, ITER.to_s]
  Float(IO.popen(cmd, &:read)) / ITER * 1000
end

flood = measure(collide)
plain = measure(control)

puts format("\n%d keys, %d bytes per document, %d parses each", COUNT, File.size(collide), ITER)
puts format('%-16s %7.2f ms/parse', 'colliding keys', flood)
puts format('%-16s %7.2f ms/parse', 'control keys', plain)
puts format('%-16s %7.1fx', 'ratio', flood / plain)
```

## Tests

- `bundle exec ruby test/tests.rb` — 524 runs, 1280 assertions, 0 failures, 0 errors.
- `test/json_gem/*_test.rb` with `REAL_JSON_GEM=1` — 86 tests total across the 8 files, 0 failures, 0 errors.
- `ext/oj/cache.c` also compiles with `HAVE_RB_HASH_START` undefined, so the fallback branch is not dead code.

No test is added for the hash itself. The seed is deliberately unobservable from Ruby, and a timing assertion would be flaky on CI.

## Follow-up not in this change

Seeding stops the bucket for a key from being precomputed, but the chains themselves are still unbounded. Capping the length of a collision chain and falling back to `c->form()` beyond that cap would bound the worst case even if the seeded hash were ever recovered. That is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
