### PR TITLE
Fix a one byte buffer over-read on a trailing backslash

### DIFF
--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -414,6 +414,11 @@ static void read_escaped_str(ParseInfo pi, const char *start) {
 
         if ('\\' == *s) {
             s++;
+            if (pi->end <= s) {
+                oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "quoted string not terminated");
+                buf_cleanup(&buf);
+                return;
+            }
             switch (*s) {
             case 'n': buf_append(&buf, '\n'); break;
             case 'r': buf_append(&buf, '\r'); break;

--- a/test/test_compat.rb
+++ b/test/test_compat.rb
@@ -336,6 +336,14 @@ class CompatJuice < Minitest::Test
     assert_equal({'subtext' => '"404er” w k 3 a'}, obj)
   end
 
+  def test_unterminated_string_ending_in_backslash
+    # unpack1 returns a string whose capacity equals its length, so the byte
+    # after the terminator is outside the allocation and valgrind sees the read.
+    json = ('{"a":"' + ('b' * 700) + '\\').unpack1('a*')
+    err = assert_raises(EncodingError) { Oj.load(json, mode: :compat) }
+    assert_match(/quoted string not terminated/, err.message)
+  end
+
   def test_hash_escaping
     json = Oj.to_json({'<>' => '<>'}, mode: :compat)
     assert_equal('{"<>":"<>"}', json)


### PR DESCRIPTION
## Problem

`read_escaped_str()` has one bounds check, at `ext/oj/parse.c:406`, on what the string scanner returned. Everything after that walks `s` forward on the assumption that an escape has a character behind it:

```c
if ('\\' == *s) {
    s++;
    switch (*s) {
    ...
    default:
        // The json gem claims this is not an error despite the
        // ECMA-404 indicating it is not valid.
        if (CompatMode == pi->options.mode) {
            buf_append(&buf, *s);
            break;
        }
```

When the document's last byte is a backslash inside an unterminated string, the scanner stops on it legitimately, `s++` lands on the NUL at `pi->end`, and in CompatMode the default branch treats that NUL as the escaped character and consumes it. The `s++` that closes the block then leaves `s` at `pi->end + 1`, and the loop condition at `ext/oj/parse.c:404` reads it.

For a document held in a Ruby String whose capacity equals its length, or read through the `File` path where the parser allocates exactly `len + 1` bytes, that byte is outside the allocation, so this is a one byte buffer over-read. Under valgrind:

```
Invalid read of size 1
   at 0x237CAE14: read_escaped_str (parse.c:476)
   by 0x237CCAE4: read_str (parse.c:542)
   by 0x237CCAE4: oj_parse2 (parse.c:882)
   by 0x237CCB18: protect_parse (parse.c:1139)
   by 0x237CCC1D: oj_pi_parse (parse.c:1256)
 Address 0x2362d9e4 is 0 bytes after a block of size 708 alloc'd
```

Nothing is returned to the caller: the next iteration scans from a cursor already past the end and raises. The reachable paths are the ones that put the parser in CompatMode with an attacker supplied document, so `Oj.load(doc, mode: :compat)` and `JSON.parse` under `Oj.mimic_JSON`, which sets CompatMode at `ext/oj/mimic_json.c:566`. `Oj.compat_load` does not reach it, since it installs the compat callbacks without setting `pi.options.mode`, so the default branch takes the error path instead.

## Fix

Check for the end of the document right after stepping over the backslash, and raise the same "quoted string not terminated" the loop raises one iteration later. The NUL at `pi->end` is a sentinel, not content, so no escape branch should consume it.

The other branches that advance `s` were checked and stay inside the buffer: `read_hex()` stops at the first non hex character, which is that same NUL, and the surrogate pair check reads `*(s + 1)` only after `'\\' == *s` has already passed, which the NUL cannot satisfy.

## Behaviour

Unchanged. The document was already rejected; it is now rejected without the read. Both before and after, `Oj.load('{"a":"bbb...\\', mode: :compat)` raises `EncodingError: quoted string not terminated (after a) at line 1, column 706`.

## Tests

`test_unterminated_string_ending_in_backslash` is added to `test/test_compat.rb`, which is in the `rake test:valgrind` set. The document is built with `unpack1('a*')` because the read is only detectable when the string's capacity equals its length, and it is 700 bytes so that it is heap allocated rather than embedded in the object.

The assertion passes with or without the fix. What the test guards is the valgrind job: on the unpatched build it reports the `read_escaped_str` invalid read shown above, and on the patched build that context is gone.

- `bundle exec ruby test/tests.rb` — 525 runs, 1283 assertions, 0 failures, 0 errors.
- `test/json_gem/*_test.rb` with `REAL_JSON_GEM=1` — 86 tests across the 8 files, 0 failures, 0 errors.
- `valgrind ruby -Ilib -Itest test/test_compat.rb -n test_unterminated_string_ending_in_backslash` — no oj context, against one before the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
