### PR TITLE
Fix two length underflows that cause an unbounded buffer over-read

### DIFF
--- a/ext/oj/compat.c
+++ b/ext/oj/compat.c
@@ -14,11 +14,11 @@
 
 static void hash_set_cstr(ParseInfo pi, Val kval, const char *str, size_t len, const char *orig) {
     const char *key    = kval->key;
-    int         klen   = kval->klen;
+    size_t      klen   = kval->klen;
     Val         parent = stack_peek(&pi->stack);
 
     if (Qundef == kval->key_val && Yes == pi->options.create_ok && NULL != pi->options.create_id &&
-        *pi->options.create_id == *key && (int)pi->options.create_id_len == klen &&
+        *pi->options.create_id == *key && (size_t)pi->options.create_id_len == klen &&
         0 == strncmp(pi->options.create_id, key, klen)) {
         parent->classname = oj_strndup(str, len);
         parent->clen      = len;

--- a/ext/oj/custom.c
+++ b/ext/oj/custom.c
@@ -896,11 +896,11 @@ void oj_dump_custom_val(VALUE obj, int depth, Out out, bool as_ok) {
 
 static void hash_set_cstr(ParseInfo pi, Val kval, const char *str, size_t len, const char *orig) {
     const char *key    = kval->key;
-    int         klen   = kval->klen;
+    size_t      klen   = kval->klen;
     Val         parent = stack_peek(&pi->stack);
 
     if (Qundef == kval->key_val && Yes == pi->options.create_ok && NULL != pi->options.create_id &&
-        *pi->options.create_id == *key && (int)pi->options.create_id_len == klen &&
+        *pi->options.create_id == *key && (size_t)pi->options.create_id_len == klen &&
         0 == strncmp(pi->options.create_id, key, klen)) {
         parent->clas = oj_name2class(pi, str, len, false, rb_eArgError);
         if (2 == klen && '^' == *key && 'o' == key[1]) {

--- a/ext/oj/object.c
+++ b/ext/oj/object.c
@@ -31,7 +31,7 @@ inline static long read_long(const char *str, size_t len) {
 static VALUE calc_hash_key(ParseInfo pi, Val kval, char k1) {
     volatile VALUE rkey;
 
-    if (':' == k1) {
+    if (':' == k1 && 0 < kval->klen) {
         return ID2SYM(rb_intern3(kval->key + 1, kval->klen - 1, oj_utf8_encoding));
     }
     if (Yes == pi->options.sym_key) {
@@ -207,7 +207,7 @@ oj_parse_xml_time(const char *str, int len) {
 
 static int hat_cstr(ParseInfo pi, Val parent, Val kval, const char *str, size_t len) {
     const char *key  = kval->key;
-    int         klen = kval->klen;
+    size_t      klen = kval->klen;
 
     if (2 == klen) {
         switch (key[1]) {
@@ -230,7 +230,12 @@ static int hat_cstr(ParseInfo pi, Val parent, Val kval, const char *str, size_t 
             parent->odd_args = oj_odd_alloc_args(odd);
             break;
         }
-        case 'm': parent->val = ID2SYM(rb_intern3(str + 1, len - 1, oj_utf8_encoding)); break;
+        case 'm':
+            if (0 == len) {
+                return 0;
+            }
+            parent->val = ID2SYM(rb_intern3(str + 1, len - 1, oj_utf8_encoding));
+            break;
         case 's': parent->val = rb_utf8_str_new(str, len); break;
         case 'c':  // class
         {
@@ -395,7 +400,7 @@ void oj_set_obj_ivar(Val parent, Val kval, VALUE value) {
 
 static void hash_set_cstr(ParseInfo pi, Val kval, const char *str, size_t len, const char *orig) {
     const char    *key    = kval->key;
-    int            klen   = kval->klen;
+    size_t         klen   = kval->klen;
     Val            parent = stack_peek(&pi->stack);
     volatile VALUE rval   = Qnil;
 
@@ -437,7 +442,7 @@ WHICH_TYPE:
             if (0 != oj_odd_set_arg(parent->odd_args, kval->key, kval->klen, rval)) {
                 char buf[256];
 
-                if ((int)sizeof(buf) - 1 <= klen) {
+                if (sizeof(buf) - 1 <= klen) {
                     klen = sizeof(buf) - 2;
                 }
                 memcpy(buf, key, klen);
@@ -466,7 +471,7 @@ WHICH_TYPE:
 
 static void hash_set_num(ParseInfo pi, Val kval, NumInfo ni) {
     const char    *key    = kval->key;
-    int            klen   = kval->klen;
+    size_t         klen   = kval->klen;
     Val            parent = stack_peek(&pi->stack);
     volatile VALUE rval   = Qnil;
 
@@ -506,7 +511,7 @@ WHICH_TYPE:
             if (0 != oj_odd_set_arg(parent->odd_args, key, klen, rval)) {
                 char buf[256];
 
-                if ((int)sizeof(buf) - 1 <= klen) {
+                if (sizeof(buf) - 1 <= klen) {
                     klen = sizeof(buf) - 2;
                 }
                 memcpy(buf, key, klen);
@@ -535,7 +540,7 @@ WHICH_TYPE:
 
 static void hash_set_value(ParseInfo pi, Val kval, VALUE value) {
     const char *key    = kval->key;
-    int         klen   = kval->klen;
+    size_t      klen   = kval->klen;
     Val         parent = stack_peek(&pi->stack);
 
 WHICH_TYPE:
@@ -591,7 +596,7 @@ WHICH_TYPE:
         } else if (0 != oj_odd_set_arg(parent->odd_args, key, klen, value)) {
             char buf[256];
 
-            if ((int)sizeof(buf) - 1 <= klen) {
+            if (sizeof(buf) - 1 <= klen) {
                 klen = sizeof(buf) - 2;
             }
             memcpy(buf, key, klen);

--- a/ext/oj/val_stack.h
+++ b/ext/oj/val_stack.h
@@ -35,8 +35,8 @@ typedef struct _val {
     const char    *classname;
     VALUE          clas;
     OddArgs        odd_args;
-    uint16_t       klen;
-    uint16_t       clen;
+    size_t         klen;
+    size_t         clen;
     char           next;  // ValNext
     char           k1;    // first original character in the key
     char           kalloc;

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -283,6 +283,21 @@ class ObjectJuice < Minitest::Test
     dump_and_load(:":xyz", false)
   end
 
+  # The value of a ^m tag is a colon followed by the symbol name. An empty one
+  # left nothing to strip the colon from and rb_intern3() was handed len - 1.
+  def test_empty_symbol_tag
+    assert_equal(:abc, Oj.load('{"^m":":abc"}', :mode => :object))
+    assert_equal({'^m' => ''}, Oj.load('{"^m":""}', :mode => :object))
+  end
+
+  # Val.klen was a uint16_t, so a key of 65,536 bytes wrapped to zero. The key
+  # came back empty and calc_hash_key() handed rb_intern3() a length of -1.
+  def test_long_key
+    name = 'A' * 65_536
+    assert_equal({name.to_sym => 1}, Oj.load(%({":#{name}":1}), :mode => :object))
+    assert_equal({name => 1}, Oj.load(%({"#{name}":1}), :mode => :object))
+  end
+
   def test_encode
     opts = Oj.default_options
     Oj.default_options = { :ascii_only => false }


### PR DESCRIPTION
## Problem

Two places compute `len - 1` on a length a document can drive to zero and pass the result to `rb_intern3()` as a `long`. The subtraction underflows and the length becomes enormous, while the pointer still points into the document, so each one is an unbounded buffer over-read that walks forward until it leaves mapped memory. Both crash the process: each of the two documents below core dumps a `ruby -roj` one liner on this machine.

**`{"^m":""}`** — `ext/oj/object.c:237`. The value of a `^m` tag is a colon followed by the symbol name, so the handler skips the colon with `rb_intern3(str + 1, len - 1, ...)`. An empty value leaves nothing to skip: `len` is `size_t`, so `len - 1` is `SIZE_MAX`, and the symbol lookup hashes from one byte past the value until it reaches an unmapped page. `str_to_value()` guards the same expression with `0 < len` at `ext/oj/object.c:53`; `hat_cstr()` does not.

This one needs no options at all. `:object` is the shipped default mode (`ext/oj/oj.c:2469`), so any application calling `Oj.load` on a document it did not write can be crashed by nine bytes.

**A key of 65,536 bytes** — `ext/oj/object.c:35`. `Val.klen` was a `uint16_t` while `read_str()` assigns `parent->klen = pi->cur - str`, so a key of exactly 65,536 bytes wrapped to zero and `parent->k1` still held its first character. When that character is a colon, `calc_hash_key()` takes the symbol branch and evaluates `rb_intern3(kval->key + 1, kval->klen - 1, ...)`, where `kval->klen - 1` promotes to `-1`.

The same truncation silently mangled long keys in every mode that goes through `read_str()`. JSON puts no limit on the length of a key, but a 65,536 byte one used to parse as the empty string:

```ruby
Oj.load(%({"#{'A' * 65_536}":1}), mode: :compat)  # => {"" => 1}
```

## Fix

`Val.klen` and `Val.clen` become `size_t`, so the length of a key is whatever the document says it is and there is nothing left to wrap. The locals that copied them into an `int` in `object.c`, `compat.c` and `custom.c` follow, along with two casts that only existed to compare an `int` with the old narrow field.

`struct _val` grows from 88 to 104 bytes. The val stack embeds `STACK_INC` of them, so a `ParseInfo` on the C stack goes from 5,664 to 6,688 bytes.

The two subtractions are guarded as well, since a guard is cheaper than proving no other caller can reach them with zero. `hat_cstr()` returns 0 for an empty `^m` value, which is what it already does for a tag it cannot handle, so `{"^m":""}` parses as the plain hash `{"^m" => ""}`. `calc_hash_key()` takes the symbol branch only when the key is non-empty, mirroring `str_to_value()`.

The alternative was to reject keys that do not fit, the way `Oj::Parser` does at `ext/oj/usual.c:203` for its own `int16_t` length. That keeps the struct small, but 65,535 is not a limit JSON has, and the field is what would be imposing it.

## Behaviour

`{"^m":":abc"}` still parses as `:abc`. Keys of any length now parse as what the document says, in every mode, rather than being truncated: a 65,536 byte key comes back as a 65,536 byte key, and a 200,000 byte one works too. Nothing that parsed correctly before parses differently now.

## Tests

Both added to `test/test_object.rb`, which is in the `rake test:valgrind` set:

- `test_empty_symbol_tag` — `{"^m":""}` parses, and `{"^m":":abc"}` still gives `:abc`.
- `test_long_key` — a 65,536 byte key comes back whole, through both branches of `calc_hash_key()`.

Both crash the interpreter without the fix rather than failing, so they guard against a regression instead of asserting something that passes either way.

- `bundle exec ruby test/tests.rb` — 526 runs, 1284 assertions, 0 failures, 0 errors.
- `test/json_gem/*_test.rb` with `REAL_JSON_GEM=1` — 8 files, 0 failures, 0 errors.
- `valgrind ruby -Ilib -Itest test/test_object.rb -n '/test_empty_symbol_tag|test_long_key/'` — no oj context.

## Noted while checking the other `^` handlers

Not changed here, and reported separately if you want it fixed: `oj_get_oddc()` at `ext/oj/odd.c:169` compares `odd->clen` bytes of the candidate name with `strncmp()` and then indexes `classname[odd->clen]`, neither of which respects the `len` it was given. It is only reachable with odd classes registered, which is why it is not in this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
