### PR TITLE
Fix a SEGV from type confusion in class path resolution

### DIFF
--- a/ext/oj/intern.c
+++ b/ext/oj/intern.c
@@ -188,6 +188,9 @@ static VALUE resolve_classname(VALUE mod, const char *classname, int auto_define
 
     if (rb_const_defined_at(mod, ci)) {
         clas = rb_const_get_at(mod, ci);
+        if (!RB_TYPE_P(clas, T_CLASS) && !RB_TYPE_P(clas, T_MODULE)) {
+            clas = Qundef;
+        }
     } else if (auto_define) {
         clas = rb_define_class_under(mod, classname, oj_bag_class);
     } else {

--- a/ext/oj/resolve.c
+++ b/ext/oj/resolve.c
@@ -19,6 +19,9 @@ inline static VALUE resolve_classname(VALUE mod, const char *classname, int auto
 
     if (rb_const_defined_at(mod, ci)) {
         clas = rb_const_get_at(mod, ci);
+        if (!RB_TYPE_P(clas, T_CLASS) && !RB_TYPE_P(clas, T_MODULE)) {
+            clas = Qundef;
+        }
     } else if (auto_define) {
         clas = rb_define_class_under(mod, classname, oj_bag_class);
     } else {

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -350,6 +350,21 @@ class ObjectJuice < Minitest::Test
     assert_equal({"a\nb" => true, "c\td" => false}, obj)
   end
 
+  # A path segment that resolved to something other than a class or module was
+  # passed to rb_const_defined_at() as the scope for the next segment, which
+  # reads whatever it is given as an RClass.
+  def test_non_module_in_class_path
+    [true, false].each do |cache|
+      opts = {:mode => :object, :class_cache => cache}
+      assert_equal({}, Oj.load('{"^o":"Float::DIG::X"}', opts))
+
+      err = assert_raises(ArgumentError) { Oj.load('{"^o":"Float::DIG"}', opts) }
+      assert_match(/is not defined/, err.message)
+
+      assert_equal(Oj, Oj.load('{"^c":"Oj"}', opts))
+    end
+  end
+
   def test_bignum_object
     dump_and_load(7 ** 55, false)
   end


### PR DESCRIPTION
## Problem

`resolve_classpath()` splits a class name from the document on `::` and resolves it a segment at a time, feeding each result back as the scope for the next segment. Nothing checks that the result is a class or a module:

```c
if (rb_const_defined_at(mod, ci)) {
    clas = rb_const_get_at(mod, ci);
}
```

`rb_const_defined_at()` does not check either. It reads what it is given as an `RClass` (`RCLASS_EXT(c)->const_tbl`), so a segment that resolved to something else is dereferenced as a class object.

One document is enough to take the process down with SIGSEGV, not an exception:

```
$ ruby -Ilib -roj -e 'Oj.load(%q({"^o":"Float::DIG::X"}), mode: :object)'
-e:1: [BUG] Segmentation fault at 0x0000000000000021
…/lib/oj/oj.so(resolve_classname+0x16)  ext/oj/intern.c:189
…/lib/oj/oj.so(resolve_classpath)       ext/oj/intern.c:227
…/lib/oj/oj.so(oj_class_intern+0x272)   ext/oj/intern.c:271
$ echo $?
139
```

`Float` resolves to the class, `DIG` to the Integer 15, and 15 is then handed to `rb_const_defined_at()` as the scope to look `X` up in, which reads a struct field off the immediate value 15. The faulting address is the immediate itself. A top level constant holding a heap object rather than an immediate — `ARGV`, `RUBY_DESCRIPTION`, or an application's own `TIMEOUT = 30` — makes it read a field off an unrelated object instead, so what is dereferenced is influenced by the document.

Both resolvers have the flaw and both crash: `ext/oj/intern.c` on the default `class_cache => true` path, and `ext/oj/resolve.c` when the cache is off.

Reaching it needs no options. `:object` is the shipped default mode, so the `^o` and `^c` tags are live for any application calling `Oj.load` on a document it did not write, and `json_class` reaches the same resolver under `JSON.load` or `create_additions`.

## Fix

Both copies of `resolve_classname()` now treat a constant that is not a `T_CLASS` or `T_MODULE` as unresolved, which is what it is: a name that does not name a class cannot be one, and cannot hold the next segment either.

## Behaviour

Classes and modules resolve exactly as before, including nested ones, on both the cached and uncached paths.

Three documents change, none of which Oj can produce, since it only writes `^o` and `^c` for a class or module:

| document | before | after |
| --- | --- | --- |
| `{"^o":"Float::DIG::X"}` | SIGSEGV | `{}` |
| `{"^o":"Float::DIG"}` | `TypeError: wrong argument type Integer (expected Class)` | `ArgumentError: class 'Float::DIG' is not defined` |
| `{"^c":"Float::DIG"}` | `15` | `ArgumentError: class 'Float::DIG' is not defined` |

The first lands on the path an unresolvable middle segment already took: `resolve_classpath()` returns `Qundef` for one without setting an error, so `{"^o":"NoSuchModule::X"}` parses as `{}` today and did before this change too. That silence is worth revisiting, since the final segment does set an error, but it is not this change.

## Tests

`test_non_module_in_class_path` in `test/test_object.rb`, which is in the `rake test:valgrind` set. It covers both resolvers, since `class_cache` picks between them, and pins that a real module still resolves. It crashes the interpreter without the fix rather than failing.

- `bundle exec ruby test/tests.rb` — 525 runs, 1290 assertions, 0 failures, 0 errors.
- `test/json_gem/*_test.rb` with `REAL_JSON_GEM=1` — 8 files, 0 failures, 0 errors.

## Noted while here

Not changed, and reported separately if you want it: the error at `ext/oj/resolve.c:58` formats `name` with `%s`, but `name` points into the document and is not NUL terminated, so the message runs past the class name until it finds a zero byte. The copy in `ext/oj/intern.c` copies it into a bounded buffer first, which is what this one should do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
