### PR TITLE
Fix output buffer overflows when writing indentation

### DIFF
--- a/ext/oj/dump.h
+++ b/ext/oj/dump.h
@@ -70,9 +70,19 @@ inline static void assure_size(Out out, size_t len) {
     }
 }
 
+// Bytes that fill_indent(), or the dump_opts equivalent used when :indent is a
+// String, writes at this depth. nl_size is array_size or hash_size.
+inline static size_t indent_len(Out out, int depth, size_t nl_size) {
+    if (out->opts->dump_opts.use) {
+        return depth * out->opts->dump_opts.indent_size + nl_size;
+    }
+    return depth * out->indent + 1;
+}
+
 inline static void fill_indent(Out out, int cnt) {
     if (0 < out->indent) {
         cnt *= out->indent;
+        assure_size(out, cnt + 1);
         *out->cur++ = '\n';
         memset(out->cur, ' ', cnt);
         out->cur += cnt;

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -410,7 +410,7 @@ static void dump_row(VALUE row, StrLen cols, int ccnt, int depth, Out out) {
 
     assure_size(out, 2);
     *out->cur++ = '{';
-    size        = depth * out->indent + 3;
+    size        = indent_len(out, d2, out->opts->dump_opts.array_size) + 3;
     for (i = 0; i < ccnt; i++, cols++) {
         assure_size(out, size);
         if (out->opts->dump_opts.use) {
@@ -433,7 +433,7 @@ static void dump_row(VALUE row, StrLen cols, int ccnt, int depth, Out out) {
             *out->cur++ = ',';
         }
     }
-    size = depth * out->indent + 1;
+    size = indent_len(out, depth, out->opts->dump_opts.array_size) + 1;
     assure_size(out, size);
     if (out->opts->dump_opts.use) {
         if (0 < out->opts->dump_opts.array_size) {
@@ -476,11 +476,7 @@ static void dump_activerecord_result(VALUE obj, int depth, Out out, bool as_ok) 
     rcnt      = RARRAY_LEN(rows);
     assure_size(out, 2);
     *out->cur++ = '[';
-    if (out->opts->dump_opts.use) {
-        size = d2 * out->opts->dump_opts.indent_size + out->opts->dump_opts.array_size + 1;
-    } else {
-        size = d2 * out->indent + 2;
-    }
+    size        = indent_len(out, d2, out->opts->dump_opts.array_size) + 1;
     assure_size(out, 2);
     for (i = 0; i < rcnt; i++) {
         assure_size(out, size);
@@ -503,7 +499,7 @@ static void dump_activerecord_result(VALUE obj, int depth, Out out, bool as_ok) 
         }
     }
     OJ_R_FREE(cols);
-    size = depth * out->indent + 1;
+    size = indent_len(out, depth, out->opts->dump_opts.array_size) + 1;
     assure_size(out, size);
     if (out->opts->dump_opts.use) {
         if (0 < out->opts->dump_opts.array_size) {
@@ -1359,11 +1355,7 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
     if (0 == cnt) {
         *out->cur++ = ']';
     } else {
-        if (out->opts->dump_opts.use) {
-            size = d2 * out->opts->dump_opts.indent_size + out->opts->dump_opts.array_size + 1;
-        } else {
-            size = d2 * out->indent + 2;
-        }
+        size = indent_len(out, d2, out->opts->dump_opts.array_size) + 1;
         assure_size(out, size * cnt);
         cnt--;
         for (i = 0; i <= cnt; i++) {
@@ -1385,7 +1377,7 @@ static void dump_array(VALUE a, int depth, Out out, bool as_ok) {
                 *out->cur++ = ',';
             }
         }
-        size = depth * out->indent + 1;
+        size = indent_len(out, depth, out->opts->dump_opts.array_size) + 1;
         assure_size(out, size);
         if (out->opts->dump_opts.use) {
             if (0 < out->opts->dump_opts.array_size) {

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -694,6 +694,24 @@ class ObjectJuice < Minitest::Test
     end
   end
 
+  # dump_obj_attrs() wrote the closing indent, and the exception branch wrote
+  # its own with a size that was never assigned, without assuring the buffer
+  # first. A nested graph with a large :indent then ran past the end of it.
+  def test_deep_graph_with_indent
+    obj = 1
+    30.times { obj = Jam.new(obj, 2) }
+    assert_equal(obj, Oj.load(Oj.dump(obj, :mode => :object, :indent => 16), :mode => :object))
+  end
+
+  def test_deep_graph_with_exception_and_indent
+    obj = RuntimeError.new('boom')
+    40.times { obj = Jam.new(obj, 2) }
+    loaded = Oj.load(Oj.dump(obj, :mode => :object, :indent => 16), :mode => :object)
+    40.times { loaded = loaded.x }
+
+    assert_equal('boom', loaded.message)
+  end
+
   def test_json_anonymous_struct
     s = Struct.new(:x, :y)
     obj = s.new(1, 2)

--- a/test/test_rails.rb
+++ b/test/test_rails.rb
@@ -295,4 +295,18 @@ class RailsJuice < Minitest::Test
     Oj.default_options = orig
   end
 
+  # A String :indent forces the numeric one to zero, but dump_array sized the
+  # closing indent from the numeric one, so a deeply nested array wrote past
+  # the end of the output buffer.
+  def test_deep_array_with_string_indent
+    orig = Oj.default_options
+    Oj.default_options = {indent: '        '}
+    obj = [1]
+    200.times { obj = [obj] }
+
+    assert_equal(obj, Oj.load(Oj.dump(obj, mode: :rails), mode: :strict))
+  ensure
+    Oj.default_options = orig
+  end
+
 end


### PR DESCRIPTION
## Problem

`fill_indent()` writes `1 + depth * out->indent` bytes and does no bounds checking of its own, so every caller has to have assured the buffer first. Several do not, and the ones that do are not all sizing it the same way.

Two shapes of the same bug.

**No `assure_size()` at all.** `dump_obj_attrs()` writes the closing indent of an object with nothing but the fixed `BUFFER_EXTRA` slack behind it (`ext/oj/dump_object.c:571`), and its exception branch passes `size` to `assure_size()` at `:552` and `:561` where `size` was set to 0 at `:475` and never assigned since. The same pattern is in `ext/oj/dump_compat.c` at `:336`, `:379` and `:797`. Depth is attacker data in any application that re-serializes a document it was given, and `MAX_DEPTH` is 1000.

```
$ ruby -Ilib -e 'require "oj"; o = 1; 30.times { o = Jam.new(o, 2) }; Oj.dump(o, mode: :object, indent: 16)'
realloc(): invalid next size
-e:1: [BUG] Aborted
$ echo $?
134
```

**The wrong size.** `ext/oj/rails.c` sized the closing indent of an array, a row and an ActiveRecord result from `out->indent`, but `:indent` given as a String forces that to 0 (`ext/oj/oj.c:819-828`) and the bytes actually written are `array_nl` plus `depth` copies of `indent_str`:

```
$ ruby -Ilib -e 'require "oj"; Oj.default_options = {indent: "        "}; o = [1]; 30.times { o = [o] }; Oj.dump(o, mode: :rails)'
-e:1: [BUG] Segmentation fault at 0x0000000000000000
$ echo $?
139
```

## Fix

`fill_indent()` now assures what it writes. That covers every one of its 92 call sites at once, including the ones nobody has audited yet, and it is a comparison on a path that is already about to `memset`. Nothing caches `out->cur` across a call to it, so the reallocation `assure_size()` may do is safe there.

The rails sizes go through one helper rather than being spelled out six times:

```c
inline static size_t indent_len(Out out, int depth, size_t nl_size) {
    if (out->opts->dump_opts.use) {
        return depth * out->opts->dump_opts.indent_size + nl_size;
    }
    return depth * out->indent + 1;
}
```

The asymmetry it hides is why the sizes were easy to get wrong: with a numeric indent the newline is a separate byte that `fill_indent()` writes, and with a String indent it is already inside `array_nl`, so the two branches used to differ by a `+1` that had nothing to do with the character being written after the indent. Callers now add only what they themselves write.

Comparing the six replaced expressions against the old ones, none got smaller. Two got one byte larger: the closing indent of a row and of an array, which had counted the spaces but not the newline.

## Behaviour

Unchanged. Dumping three structures in `:rails`, `:compat`, `:object` and `:strict` mode, with no indent, integer indents and String indents, produces byte identical output before and after (same MD5 over the 18,502 bytes of concatenated results). The change is only in how much room is reserved before writing.

## Tests

- `test_deep_graph_with_indent` and `test_deep_graph_with_exception_and_indent` in `test/test_object.rb`.
- `test_deep_array_with_string_indent` in `test/test_rails.rb`.

All three abort the interpreter with `realloc(): invalid next size` on the unpatched build, so they guard the fix rather than passing either way. All three files are in the `rake test:valgrind` set.

- `bundle exec ruby test/tests.rb` — 527 runs, 1283 assertions, 0 failures, 0 errors.
- `test/json_gem/*_test.rb` with `REAL_JSON_GEM=1` — 8 files, 0 failures, 0 errors.
- The `test/activesupport*` suites were not run here, ActiveSupport is not installed on this machine, so the rails paths rely on CI for that coverage.

## What is not demonstrated

The `dump_compat.c` sites are fixed by the same change, but I could not build a document that overflows through them: after `dump_array()` returns, the room left has been enough in everything I tried, including a sweep of 1,500 buffer offsets, and valgrind reports nothing there. The missing `assure_size()` is real in the code and the guard now covers it; I am not claiming a reproduction.

## Noted while testing

Separate from this change, and reported on its own if you want it: with `Oj.add_to_json(Exception)`, dumping an exception that was never raised takes the process down with SIGSEGV. `exception_alt()` passes `backtrace` to `dump_array()` at `ext/oj/dump_compat.c:333`, and for an unraised exception that is `nil`, which `dump_array()` then reads as an Array.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
