### PR TITLE
Fix the SyntaxError in test_object.rb that fails every CI job

### DIFF
--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -740,6 +740,8 @@ class ObjectJuice < Minitest::Test
     40.times { loaded = loaded.x }
 
     assert_equal('boom', loaded.message)
+  end
+
   # The uncached resolver formatted the raw name pointer with %s. An escaped
   # class name is decoded into read_escaped_str's stack buffer and is not NUL
   # terminated, so the message ran past it into uninitialized stack memory.


### PR DESCRIPTION
# Restore the end that was lost merging #1058

## What happened

`test_deep_graph_with_exception_and_indent` (#1058) and `test_class_name_error_stops_at_the_name` (#1057) were added to the same place in `test/test_object.rb`. Merging the second one on top of the first dropped the `end` of the first test and the blank line after it, so `test/test_object.rb` has not parsed since 4f8b97c:

```
   736 |   def test_deep_graph_with_exception_and_indent
   ...
   742 |     assert_equal('boom', loaded.message)
   743 |   # The uncached resolver formatted the raw name pointer with %s. ...
   746 |   def test_class_name_error_stops_at_the_name
```

## Effect

Every job of the CI workflow fails on develop, on all three platforms and every Ruby:

```
bundle exec ruby test/tests.rb -v && bundle exec ruby test/tests_mimic.rb -v && ...
/home/runner/work/oj/oj/test/test_object.rb:888: syntax errors found (SyntaxError)
>  888 |   class SubX < StandardError
       |   ^~~~~ unexpected class definition in method body
```

Line 888 is the first `class` body after the unclosed `def`, not where the mistake is. Because `tests.rb` aborted before running, the `test/json_gem/*` files that ran afterwards all reported `0 failures, 0 errors` and the job still exited 1, which is why the log looks like nothing failed.

## Fix

One line, the missing `end`, plus the blank line separating the two tests.

## Nothing else was lost in the merge

Both pull requests are otherwise fully present in develop. Their patches against their merge base reverse apply cleanly to `ext/oj/resolve.c`, `ext/oj/dump.h`, `ext/oj/rails.c` and `test/test_rails.rb`, and every line the two of them added to `test/test_object.rb` is in the file. Only the one `end` went missing.

## Tests

- `ruby -c test/test_object.rb` — Syntax OK.
- `bundle exec ruby test/tests.rb` — 532 runs, 1306 assertions, 0 failures, 0 errors, 0 skips.
- `bundle exec ruby test/tests_mimic.rb` and `test/tests_mimic_addition.rb` — 0 failures, 0 errors.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
