### PR TITLE
Fix the buffer over-read when a document ends where a key belongs

### DIFF
--- a/ext/oj/saj.c
+++ b/ext/oj/saj.c
@@ -198,6 +198,12 @@ static void read_hash(ParseInfo pi, const char *key) {
     } else {
         while (1) {
             next_non_white(pi);
+            if ('"' != *pi->s) {
+                if (pi->has_error) {
+                    call_error("invalid format, expected a key", pi, __FILE__, __LINE__);
+                }
+                raise_error("invalid format, expected a key", pi->str, pi->s);
+            }
             ks = read_quoted_value(pi);
             next_non_white(pi);
             if (':' == *pi->s) {

--- a/test/test_saj.rb
+++ b/test/test_saj.rb
@@ -226,6 +226,16 @@ class SajTest < Minitest::Test
     end
   end
 
+  # read_quoted_value() steps over the opening quote before it checks anything,
+  # so a document that ends where a key belongs has to be rejected before the
+  # call rather than inside it.
+  def test_key_expected_at_end
+    ['{', '{ ', '[{"a":[{', '{"a":1,'].each do |json|
+      err = assert_raises(Oj::ParseError, json) { Oj.saj_parse(Oj::Saj.new, json) }
+      assert_match(/\Ainvalid format, expected a key at line 1, column #{json.size + 1} /, err.message, json)
+    end
+  end
+
   def test_comment_not_terminated
     ['/*', '/* comment', '[1,2] /* comment'].each do |json|
       assert_raises(Oj::ParseError, json) { Oj.saj_parse(Oj::Saj.new, json) }


### PR DESCRIPTION
Item 2 of #1059.

## Problem

`read_quoted_value()` is documented as assuming the value starts where it is called, and it acts on that — it steps over the opening quote before it checks anything:

```c
static char *read_quoted_value(ParseInfo pi) {
    char *h = pi->s; /* head */
    ...
    h++; /* skip quote character */
```

`read_hash()` called it without first confirming that a quote is there, so a document that ends where a key belongs stepped over the null terminator instead. The `'\0' == *h` guard inside the loop cannot fire on a terminator that has already been passed, so the scan ran on into whatever followed the buffer until it happened to find a null or a quote.

`read_obj()` in `fast.c` does check, at `ext/oj/fast.c:384`, and is not affected.

The input is copied into a buffer of exactly `RSTRING_LEN + 1` bytes (`ext/oj/saj.c:653`), so this reads past the end of a heap block whatever the input string was:

```
==590213== Invalid read of size 1
==590213==    at 0x237DD34F: read_quoted_value (saj.c:512)
==590213==    by 0x237DDF97: read_hash (saj.c:201)
==590213==    by 0x237DDF97: read_next (saj.c:164)
==590213==    by 0x237DDB3F: read_array (saj.c:241)
==590213==    by 0x237DEC3B: saj_parse (saj.c:606)
==590213==    by 0x237DF03B: oj_saj_parse (saj.c:700)
==590213==  Address 0x2362e4a4 is 0 bytes after a block of size 708 alloc'd
==590213==    at 0x48898A8: malloc (vg_replace_malloc.c:446)
==590213==    by 0x237DEFF7: oj_saj_parse (saj.c:653)
```

How far it ran was visible in the error it did raise. For the one byte document `{`:

```
quoted string not terminated at line 1, column 7
```

five bytes past the end of the document.

## Fix

`read_hash()` checks for the quote before the call, the way `read_obj()` in `fast.c` already does, and reports it the way the other malformed-object cases in the same loop are reported.

```
invalid format, expected a key at line 1, column 2
```

valgrind reports nothing for the same document after the change.

## Tests

`test_key_expected_at_end` in `test/test_saj.rb`, covering `{`, `{ `, `[{"a":[{` and `{"a":1,`. It asserts the position as well as the message, since the position is what showed the over-read. On the unpatched build it fails with `quoted string not terminated at line 1, column 7` for a one byte document.

- `bundle exec ruby test/tests.rb` — 533 runs, 1318 assertions, 0 failures, 0 errors.
- `clang-format --dry-run --Werror ext/oj/*.c ext/oj/*.h` — clean.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
