### PR TITLE
Fix the id from a circular reference being used unchecked

### DIFF
--- a/ext/oj/circarray.c
+++ b/ext/oj/circarray.c
@@ -25,8 +25,12 @@ void oj_circ_array_free(CircArray ca) {
     OJ_R_FREE(ca);
 }
 
+// Objects are numbered in encounter order starting at 1, so the only id that
+// can extend the array is one past the highest already seen. Anything further
+// is not a reference to an object the document can contain and must not be
+// used to size an allocation.
 void oj_circ_array_set(CircArray ca, VALUE obj, unsigned long id) {
-    if (0 < id && 0 != ca) {
+    if (0 != ca && 0 < id && id <= ca->cnt + 1) {
         unsigned long i;
 
         if (ca->size < id) {
@@ -57,7 +61,7 @@ VALUE
 oj_circ_array_get(CircArray ca, unsigned long id) {
     VALUE obj = Qnil;
 
-    if (id <= ca->cnt && 0 != ca) {
+    if (0 != ca && 0 < id && id <= ca->cnt) {
         obj = ca->objs[id - 1];
     }
     return obj;

--- a/ext/oj/object.c
+++ b/ext/oj/object.c
@@ -54,7 +54,7 @@ static VALUE str_to_value(ParseInfo pi, const char *str, size_t len, const char 
     } else if (pi->circ_array && 3 <= len && '^' == *orig && 'r' == orig[1]) {
         long i = read_long(str + 2, len - 2);
 
-        if (0 > i) {
+        if (0 >= i) {
             oj_set_error_at(pi, oj_parse_error_class, __FILE__, __LINE__, "not a valid ID number");
             return Qnil;
         }

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -1034,6 +1034,28 @@ class ObjectJuice < Minitest::Test
   # An odd class such as Date is rebuilt with a create function when loaded so
   # it can not be the target of a circular reference. It must be dumped in full
   # each time it is encountered instead of leaving a dangling "^r".
+  # Ids start at 1, so id 0 is not a reference. The guard let it through and
+  # oj_circ_array_get() read objs[-1].
+  def test_circular_ref_zero
+    [%({"a":"^r0"}), %(["^r0"])].each do |json|
+      err = assert_raises(Oj::ParseError, json) do
+        Oj.load(json, :mode => :object, :circular => true)
+      end
+      assert_match(/\Anot a valid ID number/, err.message, json)
+    end
+  end
+
+  # The array is indexed by the id, so an id far past the objects the document
+  # actually has sized an allocation from a number the document picked.
+  def test_circular_id_out_of_sequence
+    json = %([{"^i":1000000,"a":1},"^r1000000"])
+    assert_equal([{'a' => 1}, nil], Oj.load(json, :mode => :object, :circular => true))
+
+    json = %([{"^i":1,"a":1},"^r1"])
+    loaded = Oj.load(json, :mode => :object, :circular => true)
+    assert_same(loaded[0], loaded[1])
+  end
+
   def test_circular_shared_date
     date = Date.new(2026, 7, 6)
     json = Oj.dump({ 'a' => { 'x' => date }, 'b' => { 'x' => date } }, :mode => :object, :circular => true)


### PR DESCRIPTION
Items 3 and 4 of #1059. Both come from the same place: the id in a `^r` or `^i` tag is document data and neither the lookup nor the allocation checked it.

## Problem

### The lookup accepts id 0

```c
VALUE
oj_circ_array_get(CircArray ca, unsigned long id) {
    VALUE obj = Qnil;

    if (id <= ca->cnt && 0 != ca) {
        obj = ca->objs[id - 1];
```

`id` is an `unsigned long`, so 0 passes the guard and `ca->objs[id - 1]` wraps to `objs[ULONG_MAX]` — the eight bytes in front of the array. `object.c` `str_to_value()` reaches it because it rejects only a negative id (`if (0 > i)`) while the two sibling call sites in `array_append_cstr()` require a positive one.

```ruby
Oj.load(%({"a":"^r0"}), mode: :object, circular: true)
# => {"a" => 4112}
Oj.load(%(["^r0"]), mode: :object, circular: true)
# => [4112]
```

`obj_array` is the first member of `_circArray`, so what comes back is the malloc chunk header of the block holding it, read as a `VALUE`. On this build that block is 8224 bytes with the in-use bit set — 8225, an odd number, which Ruby takes for the Fixnum 4112. That is why it prints as a harmless looking integer. A different allocator or a different struct layout puts a different word there, and an even word is a pointer as far as Ruby is concerned.

(The guard also dereferenced `ca` in `id <= ca->cnt` before testing `0 != ca`.)

### The allocation is sized from the id

```c
if (ca->size < id) {
    unsigned long cnt = id + 512;
```

So a 20 byte document reserves 8 MB:

```ruby
Oj.load(%({"^i":1000000,"a":1}), mode: :object, circular: true)
# VmHWM 19380KB -> 26920KB
```

## Fix

Objects are numbered in encounter order starting at 1 — `out->circ_cnt++` in `oj_check_circular()`, `ext/oj/dump.c:591` — so the only id that can extend the array is one past the highest already seen. `oj_circ_array_set()` now requires that, which leaves the allocation proportional to the objects the document really has. `oj_circ_array_get()` tests the array pointer first and rejects 0 before indexing. `str_to_value()` rejects 0 the way it already rejects a negative id.

| | before | after |
|---|---|---|
| `{"a":"^r0"}` | `{"a" => 4112}` | `Oj::ParseError: not a valid ID number` |
| `["^r0"]` | `[4112]` | `Oj::ParseError: not a valid ID number` |
| `{"^i":1000000,"a":1}` | VmHWM +7540KB | VmHWM +0KB |
| `[1,2,[self]]` round trip | works | works |

## Behaviour change

An id further ahead than the document can justify is ignored rather than accepted, so `["^i1000000",...]` no longer registers and a later `"^r1000000"` resolves to `nil` instead of the object:

```ruby
Oj.load(%([{"^i":1000000,"a":1},"^r1000000"]), mode: :object, circular: true)
# before => [{"a" => 1}, {"a" => 1}]
# after  => [{"a" => 1}, nil]
```

Nothing Oj writes is affected — it never emits an id that is not the next one — and a document that does emit one is asking for an allocation it has not earned.

## Tests

`test_circular_ref_zero` and `test_circular_id_out_of_sequence` in `test/test_object.rb`. Both fail on the unpatched build. The second also asserts that a normal `^i1` / `^r1` pair still resolves to the same object.

- `bundle exec ruby test/tests.rb` — 534 runs, 1314 assertions, 0 failures, 0 errors.
- `clang-format --dry-run --Werror ext/oj/*.c ext/oj/*.h` — clean.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
