### PR TITLE
Fix the exponent bound being checked after it is narrowed

### DIFF
--- a/ext/oj/parser.c
+++ b/ext/oj/parser.c
@@ -892,10 +892,10 @@ static void parse(ojParser p, const byte *json, size_t len, bool more) {
         case EXP_DIGIT:
             p->map = exp_map;
             for (; NUM_DIGIT == digit_map[*b]; b++) {
-                int16_t x = p->num.exp * 10 + (int16_t)(*b - '0');
+                int x = p->num.exp * 10 + (*b - '0');
 
                 if (x <= MAX_EXP) {
-                    p->num.exp = x;
+                    p->num.exp = (int16_t)x;
                 } else {
                     big_change(p);
                     p->map = big_exp_map;

--- a/test/test_parser_usual.rb
+++ b/test/test_parser_usual.rb
@@ -83,6 +83,24 @@ class UsualTest < Minitest::Test
     assert_equal(BigDecimal, doc.class)
   end
 
+  # The exponent is an int16_t, and it used to be narrowed before it was
+  # compared against MAX_EXP, so a wrapped value passed the bound and the
+  # digits after the wrap chose the result.
+  def test_exponent_past_the_limit
+    p = Oj::Parser.new(:usual)
+    [
+      ['1e327683', BigDecimal('1e327683')],
+      ['1e32768', BigDecimal('1e32768')],
+      ['1e-327683', BigDecimal('1e-327683')],
+      ['1e-32768', BigDecimal('1e-32768')],
+      ['1e4933', BigDecimal('1e4933')],
+    ].each do |json, expected|
+      doc = p.parse(json)
+      assert_equal(BigDecimal, doc.class, json)
+      assert_equal(expected, doc, json)
+    end
+  end
+
   def test_array
     p = Oj::Parser.new(:usual)
     [


### PR DESCRIPTION
Item 6 of #1059.

## Problem

```c
for (; NUM_DIGIT == digit_map[*b]; b++) {
    int16_t x = p->num.exp * 10 + (int16_t)(*b - '0');

    if (x <= MAX_EXP) {
        p->num.exp = x;
```

The accumulation is narrowed to `int16_t` before the bound is tested, so the wrap happens first and a wrapped value is under `MAX_EXP` and is accepted. The digits after the wrap then decide what is left, which makes the resulting value something the document gets a choice about.

```ruby
Oj::Parser.usual.parse("[1e327683]")   # => [1000.0]
Oj::Parser.usual.parse("[1e32768]")    # => [1.0]
Oj::Parser.usual.parse("[1e-327683]")  # => [0.001]
Oj::Parser.usual.parse("[1e-32768]")   # => [1.0]
```

`1e327683` comes back as `1000.0` because the accumulator wraps at the fifth digit — 32768 becomes -32768, which is under the bound — and the sixth digit, a 3, is all that survives.

## Fix

The accumulator is an `int` and only a value that passed the bound is stored back. `p->num.exp` is at most `MAX_EXP`, 4932, so the next round is at most 49329 and cannot overflow. An exponent over the bound goes to `big_change()`, which is what one over the bound already did.

## Behaviour

| document | before | after | `JSON.parse` |
|---|---|---|---|
| `[1e327683]` | `[1000.0]` | `[0.1e327684]` | `[Infinity]` |
| `[1e32768]` | `[1.0]` | `[0.1e32769]` | `[Infinity]` |
| `[1e-327683]` | `[0.001]` | `[0.1e-327682]` | `[0.0]` |
| `[1e-32768]` | `[1.0]` | `[0.1e-32767]` | `[0.0]` |
| `[1e4932]` | `[Infinity]` | `[Infinity]` | `[Infinity]` |
| `[1e4933]` | `[0.1e4934]` | `[0.1e4934]` | `[Infinity]` |
| `[1e309]` | `[Infinity]` | `[Infinity]` | `[Infinity]` |
| `[1.5e10]`, `[1e0]`, `[123]`, `[1e-5]`, `[2e-308]` | unchanged | unchanged | same |

Only the exponents that used to wrap change. Everything that was already accepted parses to the same value.

## Tests

`test_exponent_past_the_limit` in `test/test_parser_usual.rb`. It fails on the unpatched build.

Note that `test/test_parser*.rb` is not run by CI at the moment — the `Rake::TestTask` for `test/test_*.rb` is commented out and the `Rake::Task['test'].invoke` in `test_all` resolves to the `test` directory as a file task and does nothing. #1065 wires `test_parser_safe.rb` into `test/tests.rb` for the same reason; I have left `tests.rb` alone here so the two do not collide, and this test will need the same treatment.

- `bundle exec ruby test/tests.rb` — 533 runs, 1309 assertions, 0 failures, 0 errors.
- `bundle exec ruby -Itest test/test_parser_usual.rb` — 27 runs, 88 assertions, 0 failures, 0 errors.
- `clang-format --dry-run --Werror ext/oj/*.c ext/oj/*.h` — clean.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
