### PR TITLE
Fix the leak of an escaped hash key in the streaming parser

### DIFF
--- a/ext/oj/sparse.c
+++ b/ext/oj/sparse.c
@@ -290,13 +290,13 @@ static void read_escaped_str(ParseInfo pi) {
         case NEXT_HASH_NEW:
         case NEXT_HASH_KEY:
             if (Qundef == (parent->key_val = pi->hash_key(pi, buf.head, buf_len(&buf)))) {
-                parent->klen = buf_len(&buf);
-                parent->key  = malloc(parent->klen + 1);
-                memcpy((char *)parent->key, buf.head, parent->klen);
-                *(char *)(parent->key + parent->klen) = '\0';
+                parent->klen   = buf_len(&buf);
+                parent->key    = oj_strndup(buf.head, parent->klen);
+                parent->kalloc = 1;
             } else {
-                parent->key  = "";
-                parent->klen = 0;
+                parent->key    = "";
+                parent->klen   = 0;
+                parent->kalloc = 0;
             }
             parent->k1   = *pi->rd.str;
             parent->next = NEXT_HASH_COLON;

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -223,6 +223,23 @@ class FileJuice < Minitest::Test
     end
   end
 
+  # An escaped key is decoded into a buffer of its own rather than being used
+  # in place, so the copy it is kept in has to be freed with the Val.
+  def test_escaped_keys_in_a_file
+    count = 200
+    json = '{' + (0...count).map { |i| %("k\\u0041ey#{i}":#{i}) }.join(',') + '}'
+
+    Tempfile.create('file_test_escaped.json') do |f|
+      f.write(json)
+      f.close
+
+      loaded = Oj.load_file(f.path, :mode => :object)
+      assert_equal(count, loaded.size)
+      assert_equal('kAey0', loaded.keys.first)
+      assert_equal(count - 1, loaded["kAey#{count - 1}"])
+    end
+  end
+
   # A key short enough to be kept in the Val itself points into the value
   # stack, which is moved when stack_push grows it.
   def test_deep_keys_survive_the_value_stack_growing


### PR DESCRIPTION
Item 7 of #1059.

## Problem

An escaped key cannot be used where it sits, so `read_escaped_str()` keeps the decoded copy and points the `Val` at it:

```c
if (Qundef == (parent->key_val = pi->hash_key(pi, buf.head, buf_len(&buf)))) {
    parent->klen = buf_len(&buf);
    parent->key  = malloc(parent->klen + 1);
    memcpy((char *)parent->key, buf.head, parent->klen);
    *(char *)(parent->key + parent->klen) = '\0';
}
```

`kalloc` is left at 0, and the `NEXT_HASH_VALUE` branch only frees the key when it is set, so the copy is never freed. `read_str()` does the same thing one branch over with `oj_strndup()` and `kalloc = 1`.

Parsing 200 escaped keys out of a file:

```
1,490 bytes in 200 blocks are definitely lost in loss record 10,899 of 11,328
   at 0x48898A8: malloc (vg_replace_malloc.c:446)
   by 0x23D268C0: read_escaped_str (sparse.c:294)
   by 0x23D268C0: read_str (sparse.c:341)
```

One block per key. 2,000 keys lose 16,890 bytes in 2,000 blocks.

## Fix

Setting `kalloc` on its own would not have been enough. The key is freed with `OJ_R_FREE`, which is `xfree`, and the copy came from plain `malloc`, so it now goes through `oj_strndup()` like the other branch and the pair matches.

The `else` branch sets `kalloc` to 0 rather than relying on it already being 0, since the key it stores there is a string literal and freeing that would not end well.

After the change valgrind reports nothing from `read_escaped_str` for the same documents, and the definitely-lost block count for the 2,000 key document drops by 1,999 (the remaining difference is Ruby's own run to run variation).

## Tests

`test_escaped_keys_in_a_file` in `test/test_file.rb`. It asserts the keys decode correctly, which is worth having on its own, and `test/test_file.rb` is in the `rake test:valgrind` list, so the leak is caught there rather than only by hand. On the unpatched build that one test produces the 200 block record above; on the patched build it produces none.

- `bundle exec ruby test/tests.rb` — 537 runs, 1332 assertions, 0 failures, 0 errors.
- `clang-format --dry-run --Werror ext/oj/*.c ext/oj/*.h` — clean.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
