### PR TITLE
Fix the SEGV dumping an exception that was never raised

### DIFF
--- a/ext/oj/dump_compat.c
+++ b/ext/oj/dump_compat.c
@@ -299,9 +299,10 @@ static ID message_id   = 0;
 static ID backtrace_id = 0;
 
 static void exception_alt(VALUE obj, int depth, Out out) {
-    int    d3      = depth + 2;
-    size_t size    = d3 * out->indent + 2;
-    size_t sep_len = out->opts->dump_opts.before_size + out->opts->dump_opts.after_size + 2;
+    int            d3      = depth + 2;
+    size_t         size    = d3 * out->indent + 2;
+    size_t         sep_len = out->opts->dump_opts.before_size + out->opts->dump_opts.after_size + 2;
+    volatile VALUE bt;
 
     if (0 == message_id) {
         message_id   = rb_intern("message");
@@ -332,7 +333,12 @@ static void exception_alt(VALUE obj, int depth, Out out) {
     if (0 < out->opts->dump_opts.after_size) {
         APPEND_CHARS(out->cur, out->opts->dump_opts.after_sep, out->opts->dump_opts.after_size);
     }
-    dump_array(rb_funcall(obj, backtrace_id, 0), depth, out, false);
+    bt = rb_funcall(obj, backtrace_id, 0);
+    if (T_ARRAY == rb_type(bt)) {
+        dump_array(bt, depth, out, false);
+    } else {
+        oj_dump_nil(Qnil, depth, out, false);
+    }
     fill_indent(out, depth);
     *out->cur++ = '}';
     *out->cur   = '\0';

--- a/test/test_compat.rb
+++ b/test/test_compat.rb
@@ -642,6 +642,26 @@ class CompatJuice < Minitest::Test
     assert_raises(TypeError) { Oj.dump(obj, mode: :compat) }
   end
 
+  # An exception that was never raised has a nil backtrace, and exception_alt()
+  # handed that straight to dump_array().
+  def test_exception_without_a_backtrace
+    Oj.add_to_json(Exception)
+
+    assert_equal('{"json_class":"RuntimeError","m":"boom","b":null}',
+                 Oj.dump(RuntimeError.new('boom'), :mode => :compat))
+
+    raised = begin
+      raise 'raised'
+    rescue StandardError => e
+      e
+    end
+    json = Oj.dump(raised, :mode => :compat)
+    assert_match(/"m":"raised"/, json)
+    assert_match(/"b":\["/, json)
+  ensure
+    Oj.remove_to_json(Exception)
+  end
+
   def dump_and_load(obj, trace=false)
     json = Oj.dump(obj)
     puts json if trace


### PR DESCRIPTION
Found while building a reproduction for #1058. Not part of #1059.

## Problem

`exception_alt()` passes the result of `backtrace` straight to `dump_array()`:

```c
dump_array(rb_funcall(obj, backtrace_id, 0), depth, out, false);
```

An exception that has not been raised has no backtrace, so `dump_array()` reads `Qnil` as an `RArray`:

```ruby
Oj.add_to_json(Exception)
Oj.dump(RuntimeError.new('boom'), mode: :compat)
```

```
-e:1: [BUG] Segmentation fault at 0x0000000000000004
$ echo $?
139
```

`0x4` is `Qnil` itself used as an address. It takes only `Oj.add_to_json(Exception)` and an exception built in place — the shape a rescue-free error path or a log line produces.

## Fix

The backtrace is written as `null` when it is not an Array, which is what the json gem does with the same object:

```ruby
require 'json/add/exception'
RuntimeError.new('boom').to_json
# => {"json_class":"RuntimeError","m":"boom","b":null}
```

Oj now returns the same bytes.

| | before | after | json gem |
|---|---|---|---|
| `RuntimeError.new('boom')` | SIGSEGV | `{"json_class":"RuntimeError","m":"boom","b":null}` | same |
| raised exception | `"b":["…"]` | unchanged | same |
| `set_backtrace([])` | `"b":[]` | unchanged | same |

## Tests

`test_exception_without_a_backtrace` in `test/test_compat.rb`. It takes the interpreter down with SIGSEGV on the unpatched build. `Oj.add_to_json` is process wide, so the test removes it again in an `ensure`.

- `bundle exec ruby test/tests.rb` — 551 runs, 1359 assertions, 0 failures, 0 errors.
- `test/json_gem/json_addition_test.rb` with `REAL_JSON_GEM=1` — 11 tests, 42 assertions, 0 failures, 0 errors.
- `clang-format --dry-run --Werror ext/oj/*.c ext/oj/*.h` — clean.

## Noted while testing, not fixed here

`:custom` mode produces invalid JSON for the same object, with a different cause — the separator, not the backtrace:

```ruby
Oj.dump(RuntimeError.new('boom'), mode: :custom)
# => {,"~mesg":"boom","~bt":null}
```

`dump_obj_attrs()` in `custom.c` writes the exception attributes after `if (',' != *(out->cur - 1)) { *out->cur++ = ','; }`, and for an exception with no instance variables and no class name written the previous character is `{`, so it emits a comma with nothing in front of it. A raised exception has an ivar and comes out fine. Happy to send that separately.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
