### PR TITLE
Fix a long first token being rejected and the grown reader buffer leaking

### DIFF
--- a/ext/oj/reader.c
+++ b/ext/oj/reader.c
@@ -88,8 +88,8 @@ void oj_reader_init(Reader reader, VALUE io, int fd, bool to_s) {
 }
 
 int oj_reader_read(Reader reader) {
-    int    err;
-    size_t shift = 0;
+    int       err;
+    ptrdiff_t shift = 0;
 
     if (0 == reader->read_func) {
         return -1;

--- a/ext/oj/sparse.c
+++ b/ext/oj/sparse.c
@@ -906,6 +906,7 @@ CLEANUP:
     if (0 != pi->circ_array) {
         oj_circ_array_free(pi->circ_array);
     }
+    reader_cleanup(&pi->rd);
     stack_cleanup(&pi->stack);
     // A :match_string option builds a chain of regexps for this call that has to
     // be freed. Without the option the member aliases the chain owned by the

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -240,6 +240,23 @@ class FileJuice < Minitest::Test
     end
   end
 
+  # A token that is being protected from the head of the reader buffer gave
+  # oj_reader_read() a shift of -1, and the shift is unsigned, so instead of
+  # growing the buffer it pushed tail past end.
+  def test_long_number_at_the_start_of_a_file
+    [4093, 100_000].each do |digits|
+      json = '1' * digits
+
+      Tempfile.create('file_test_bignum.json') do |f|
+        f.write(json)
+        f.close
+
+        assert_equal(json.to_i, Oj.load_file(f.path), digits)
+        assert_equal(json.to_i, File.open(f.path) { |io| Oj.load(io) }, digits)
+      end
+    end
+  end
+
   # A key short enough to be kept in the Val itself points into the value
   # stack, which is moved when stack_push grows it.
   def test_deep_keys_survive_the_value_stack_growing


### PR DESCRIPTION
Two things, both in the path that runs when the reader needs more room. The second was found by the memcheck job once the first made that path reachable in a test.

## Problem 1, the shift underflows

`oj_reader_read()` decides whether to shift the buffer down or grow it:

```c
size_t shift = 0;
...
if (0 == reader->pro) {
    shift = reader->tail - reader->head;
} else {
    shift = reader->pro - reader->head - 1;  // leave one character so we can backup one
}
if (0 >= shift) { /* no space left so allocate more */
```

`shift` is a `size_t`. When the protected token starts at the head of the buffer — which is where the first token of a document sits — `pro` equals `head` and the subtraction wraps to `SIZE_MAX`. The guard is written for a signed value and cannot catch that, so the buffer is never grown. Instead `memmove()` shifts it one byte the wrong way and `tail` lands one past `end`:

```
[probe] shift=18446744073709551615 pro=0x7ffd03941d48 head=0x7ffd03941d48 end=0x7ffd03942d44
[probe] tail=0x7ffd03942d45 end=0x7ffd03942d44
```

`read_from_fd()` then computes `max` as `end - tail`, which wraps as well, and calls `read(fd, tail, SIZE_MAX)`:

```
[probe read] max=18446744073709551615 tail=0x7ffe0620dd95 end=0x7ffe0620dd94
[probe read] cnt=-1 errno=14
```

Linux checks the whole range before it copies anything and returns `EFAULT`, so **nothing is written** and the read is treated as end of input. `read_from_io()` has the matching problem one step earlier: it hands `ULONG2NUM(SIZE_MAX)` to `IO#read` and Ruby raises `RangeError`.

### Effect

The document is cut short either way, so valid JSON is rejected:

```ruby
File.binwrite('n.json', '1' * 100_000)

Oj.load(File.binread('n.json'))          # => 111…1  (Integer, 100,000 digits)
Oj.load_file('n.json')                   # => Oj::ParseError: unexpected characters
                                         #    after the JSON document at line 0, column 4093
File.open('n.json') { |io| Oj.load(io) } # => the same ParseError
r, w = IO.pipe; …                        # => RangeError at line 0, column 4092
```

| input | before | after |
|---|---|---|
| String | Integer | Integer |
| StringIO | Integer | Integer |
| `Oj.load_file` | `Oj::ParseError` | Integer |
| File IO | `Oj::ParseError` | Integer |
| pipe IO | `RangeError` | Integer |

The trigger is narrow. The number has to start at the first byte of the document — a single leading space is enough for `pro` to be ahead of `head` — and it has to be 4093 bytes or longer. 4092 is fine, 4093 is not. It is not reached by a number inside an array or an object, nor by a long string anywhere, nor by a long key:

| document | before |
|---|---|
| `<5000 digits>` | rejected |
| `-<5000 digits>`, `<5000 digits>.5`, `1e<5000 digits>` | rejected |
| `<space><5000 digits>` | fine |
| `[<5000 digits>]`, `{"a":<5000 digits>}` | fine |
| `"<5000 bytes>"`, `{"<5000 bytes>":1}` | fine |

### Fix

`shift` is a `ptrdiff_t`, so `pro == head` gives `-1`, the guard is true, and the buffer grows the way it was meant to. One line.

The `read()` and `IO#read` calls above are consequences of `tail` passing `end`; with the shift fixed that cannot happen and both go back to being handed a sane length.

## Problem 2, the grown buffer is never freed

`reader_cleanup()` has been in `reader.h` since the buffer growing was written and **nothing has ever called it**, so every parse that outgrew the 4 KB buffer in the `ParseInfo` leaked the one it allocated instead.

This is not new and not caused by the change above. On `develop`, a file holding a 20,000 byte string:

```
32,768 bytes in 1 blocks are definitely lost in loss record 10,267 of 10,287
   by 0x237DA82C: oj_reader_read (reader.c:112)
```

Nothing in the `rake test:valgrind` set reached the grow path until the test added here did, which is what turned the memcheck job red on the first version of this PR.

### Fix

`oj_pi_sparse()` calls `reader_cleanup()` in its cleanup block, next to `stack_cleanup()`. It is guarded by `free_head`, so it does nothing for the String and StringIO paths where `head` points into the Ruby string, and `pi->rd` is not touched after that point.

`rake test:valgrind` — 514 runs, 1307 assertions, 0 failures, 0 errors, and no valgrind errors, where before there were five leak records from `reader.c:109` and `reader.c:112`.

## On the severity of the first one

This was originally written up as a stack overwrite — `read(fd, base + 4093, SIZE_MAX)` filling the C stack with the rest of the file. It does not do that here. The kernel validates the whole `count` against the address space before copying, so the call fails with `EFAULT` having written nothing, which I measured rather than assumed. What is left is a correctness bug: a valid document is rejected, and which error you get depends on how you opened it.

## Tests

`test_long_number_at_the_start_of_a_file` in `test/test_file.rb`, covering 4093 and 100,000 digits through both `Oj.load_file` and a `File` IO. On the unpatched build it fails with the `ParseError` above.

- `bundle exec ruby test/tests.rb` — 551 runs, 1358 assertions, 0 failures, 0 errors.
- `bundle exec rake test:valgrind` — 514 runs, 0 failures, 0 errors, no valgrind errors.
- `clang-format --dry-run --Werror ext/oj/*.c ext/oj/*.h` — clean.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
