### PR TITLE
Fix the safe parser limits being dropped when an option is set

### DIFF
--- a/ext/oj/safe.c
+++ b/ext/oj/safe.c
@@ -140,58 +140,72 @@ DEFINE_DELEGATED_OBJECT_FUNCTION(add_float);
 DEFINE_DELEGATED_OBJECT_FUNCTION(add_big);
 DEFINE_DELEGATED_OBJECT_FUNCTION(add_str);
 
+// The counting wrappers live in the parser function table, and the option
+// setters of the usual parser write to the same slots, so an option set after
+// the parser was built puts the unwrapped handler back and the limits stop
+// being applied for that kind of value.
+#define WRAP(funcs, slot, wrapper, saved) \
+    do {                                  \
+        if (wrapper != (funcs)->slot) {   \
+            safe->saved = (funcs)->slot;  \
+        }                                 \
+        (funcs)->slot = wrapper;          \
+    } while (0)
+
+static void wrap_funcs(ojParser p, safe_T safe) {
+    Funcs f = &p->funcs[ARRAY_FUN];
+
+    WRAP(f, open_object, safe_open_object, delegated_open_object_func);
+    WRAP(f, open_array, safe_open_array, delegated_open_array_func);
+    // The following overrides are done for counting objects
+    WRAP(f, add_null, safe_add_null, delegated_add_null_func);
+    WRAP(f, add_true, safe_add_true, delegated_add_true_func);
+    WRAP(f, add_false, safe_add_false, delegated_add_false_func);
+    WRAP(f, add_int, safe_add_int, delegated_add_int_func);
+    WRAP(f, add_float, safe_add_float, delegated_add_float_func);
+    WRAP(f, add_big, safe_add_big, delegated_add_big_func);
+    WRAP(f, add_str, safe_add_str, delegated_add_str_func);
+
+    f = &p->funcs[OBJECT_FUN];
+    WRAP(f, open_object, safe_open_object_key, delegated_open_object_key_func);
+    WRAP(f, open_array, safe_open_array_key, delegated_open_array_key_func);
+    WRAP(f, add_null, safe_add_null_key, delegated_add_null_key_func);
+    WRAP(f, add_true, safe_add_true_key, delegated_add_true_key_func);
+    WRAP(f, add_false, safe_add_false_key, delegated_add_false_key_func);
+    WRAP(f, add_int, safe_add_int_key, delegated_add_int_key_func);
+    WRAP(f, add_float, safe_add_float_key, delegated_add_float_key_func);
+    WRAP(f, add_big, safe_add_big_key, delegated_add_big_key_func);
+    WRAP(f, add_str, safe_add_str_key, delegated_add_str_key_func);
+}
+
+static VALUE safe_option(ojParser p, const char *key, VALUE value) {
+    safe_T safe = (safe_T)p->ctx;
+    VALUE  rv;
+
+    if (0 == strcmp("omit_null", key)) {
+        return safe->omit_null ? Qtrue : Qfalse;
+    }
+    rv = safe->delegated_option_func(p, key, value);
+    if (0 == strcmp("omit_null=", key)) {
+        safe->omit_null = (Qtrue == rv);
+    }
+    wrap_funcs(p, safe);
+
+    return rv;
+}
+
 void oj_init_safe_parser(ojParser p, safe_T safe, VALUE options) {
     // Safe parser inherits all members of usual parser
     oj_init_usual(p, &safe->usual);
 
     safe->delegated_start_func = p->start;
     p->start                   = safe_start;
+    safe->omit_null            = false;
 
-    Funcs f;
+    wrap_funcs(p, safe);
 
-    // Array parser functions
-    f                                = &p->funcs[ARRAY_FUN];
-    safe->delegated_open_object_func = f->open_object;
-    f->open_object                   = safe_open_object;
-    safe->delegated_open_array_func  = f->open_array;
-    f->open_array                    = safe_open_array;
-    // The following overrides are done for counting objects
-    safe->delegated_add_null_func  = f->add_null;
-    f->add_null                    = safe_add_null;
-    safe->delegated_add_true_func  = f->add_true;
-    f->add_true                    = safe_add_true;
-    safe->delegated_add_false_func = f->add_false;
-    f->add_false                   = safe_add_false;
-    safe->delegated_add_int_func   = f->add_int;
-    f->add_int                     = safe_add_int;
-    safe->delegated_add_float_func = f->add_float;
-    f->add_float                   = safe_add_float;
-    safe->delegated_add_big_func   = f->add_big;
-    f->add_big                     = safe_add_big;
-    safe->delegated_add_str_func   = f->add_str;
-    f->add_str                     = safe_add_str;
-
-    // Object parser functions
-    f                                    = &p->funcs[OBJECT_FUN];
-    safe->delegated_open_object_key_func = f->open_object;
-    f->open_object                       = safe_open_object_key;
-    safe->delegated_open_array_key_func  = f->open_array;
-    f->open_array                        = safe_open_array_key;
-    // The following overrides are done for counting objects
-    safe->delegated_add_null_key_func  = f->add_null;
-    f->add_null                        = safe_add_null_key;
-    safe->delegated_add_true_key_func  = f->add_true;
-    f->add_true                        = safe_add_true_key;
-    safe->delegated_add_false_key_func = f->add_false;
-    f->add_false                       = safe_add_false_key;
-    safe->delegated_add_int_key_func   = f->add_int;
-    f->add_int                         = safe_add_int_key;
-    safe->delegated_add_float_key_func = f->add_float;
-    f->add_float                       = safe_add_float_key;
-    safe->delegated_add_big_key_func   = f->add_big;
-    f->add_big                         = safe_add_big_key;
-    safe->delegated_add_str_key_func   = f->add_str;
-    f->add_str                         = safe_add_str_key;
+    safe->delegated_option_func = p->option;
+    p->option                   = safe_option;
 
     SET_CONFIG(max_hash_size);
     SET_CONFIG(max_array_size);

--- a/ext/oj/safe.h
+++ b/ext/oj/safe.h
@@ -60,6 +60,11 @@ typedef struct _safe_S {
     long int current_array_size;
     long int current_elements_count;
 
+    // omit_null is kept here because the usual parser reports it by looking at
+    // the add_null slot, which is one of the slots wrapped below.
+    bool omit_null;
+
+    VALUE (*delegated_option_func)(struct _ojParser *p, const char *key, VALUE value);
     void (*delegated_start_func)(struct _ojParser *p);
 
     // Array functions

--- a/test/test_parser_safe.rb
+++ b/test/test_parser_safe.rb
@@ -111,4 +111,40 @@ class ParserSafeTest < Minitest::Test
 
     assert_equal([1, 2, 3, 4, 5], parser.parse('[1, 2, 3, 4, 5]'))
   end
+
+  # The limits are applied by wrapping the parser function table, and the
+  # option setters of the usual parser write to the same slots, so setting an
+  # option used to take the counting back out for that kind of value.
+  def test_limits_survive_setting_an_option
+    floats = "[#{(['1.5'] * 100).join(',')}]"
+    parser = Oj::Parser.safe(max_array_size: 10)
+    parser.decimal = :float
+    assert_raises(Oj::Parser::ArraySizeError) { parser.parse(floats) }
+    assert_equal(Float, parser.parse('[1.234567890123456789]').first.class)
+
+    strings = "{#{(0...100).map { |i| %("k#{i}":"v") }.join(',')}}"
+    parser = Oj::Parser.safe(max_hash_size: 10)
+    parser.create_id = '^'
+    assert_raises(Oj::Parser::HashSizeError) { parser.parse(strings) }
+
+    nulls = "{#{(0...100).map { |i| %("k#{i}":null) }.join(',')}}"
+    parser = Oj::Parser.safe(max_total_elements: 10)
+    parser.omit_null = true
+    assert_raises(Oj::Parser::TotalElementsError) { parser.parse(nulls) }
+  end
+
+  # omit_null is reported by looking at the add_null slot, which is one of the
+  # slots the limits are applied through.
+  def test_omit_null_reports_itself
+    parser = Oj::Parser.safe(max_hash_size: 10)
+    refute(parser.omit_null)
+
+    parser.omit_null = true
+    assert(parser.omit_null)
+    assert_empty(parser.parse('{"a":null,"b":null}'))
+
+    parser.omit_null = false
+    refute(parser.omit_null)
+    assert_equal({'a' => nil, 'b' => nil}, parser.parse('{"a":null,"b":null}'))
+  end
 end


### PR DESCRIPTION
## Problem

The limits are applied by wrapping the parser function table. `safe.c` replaces the `add_*` and `open_*` slots of `ARRAY_FUN` and `OBJECT_FUN` with counting versions that call what was there before.

The option setters of the usual parser write to those same slots:

| setter | slots it puts back |
|---|---|
| `opt_decimal_set` | `add_float`, `add_big` |
| `opt_omit_null_set` | `add_null` |
| `opt_create_id_set` | `add_str` |

So an option set after the parser was built takes the counting out again for that kind of value, and nothing is reported:

```ruby
parser = Oj::Parser.safe(max_array_size: 10)
parser.decimal = :float
parser.parse('[' + (['1.5'] * 100).join(',') + ']')   # 100 items, accepted
```

Setting these options together with the limits is only possible this way — `parser_safe()` does not forward anything but the four `max_*` keys, so the option has to be assigned afterwards.

(`array_class=` and `hash_class=` also write to the table, but only to `close_array` and `close_object`, which are not wrapped.)

## Fix

The wrapping moves into `wrap_funcs()`, which keeps the delegate it replaces unless the slot already holds the wrapper, so it can be run more than once. Safe owns `p->option` now and runs `wrap_funcs()` again after the usual handler has had the slot.

`omit_null` needs one extra step. The usual parser reports it by asking whether the `add_null` slot holds its `noop`, and that slot now holds the wrapper, so safe keeps the flag itself and answers the getter. Setting it, reading it back, and the omitting itself all still work — there is a test for that.

## Measurement

Every combination of four documents, four setups and the applicable limits, before and after. Seven cells changed, all from accepted to raising:

| document | option set afterwards | limit | before | after |
|---|---|---|---|---|
| float array | `decimal = :float` | `max_array_size` | accepted | ArraySizeError |
| float array | `decimal = :float` | `max_total_elements` | accepted | TotalElementsError |
| bignum array | `decimal = :float` | `max_array_size` | accepted | ArraySizeError |
| bignum array | `decimal = :float` | `max_total_elements` | accepted | TotalElementsError |
| null object | `omit_null = true` | `max_total_elements` | accepted | TotalElementsError |
| string object | `create_id = "^"` | `max_hash_size` | accepted | HashSizeError |
| string object | `create_id = "^"` | `max_total_elements` | accepted | TotalElementsError |

Nothing that already raised changed. One case still passes and should: an object of nothing but nulls parsed with `omit_null` does not hit `max_hash_size`, because the hash it produces is empty.

## Tests

`test_limits_survive_setting_an_option` and `test_omit_null_reports_itself` in `test/test_parser_safe.rb`. The first fails on the unpatched build. Both also assert that the option still does its job after the re-wrap — that `decimal = :float` really returns a Float, and that `omit_null` really omits.

- `bundle exec ruby test/tests.rb` — 552 runs, 1364 assertions, 0 failures, 0 errors.
- `bundle exec ruby -Itest test/test_parser_safe.rb` — 16 runs, 35 assertions, 0 failures, 0 errors.
- `clang-format --dry-run --Werror ext/oj/*.c ext/oj/*.h` — clean.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
