### PR TITLE
Fix the stack buffer overflow writing the error location

### DIFF
--- a/ext/oj/parse.c
+++ b/ext/oj/parse.c
@@ -1101,7 +1101,9 @@ void oj_set_error_at(ParseInfo pi, VALUE err_clas, const char *file, int line, c
     }
     va_end(ap);
     pi->err.clas = err_clas;
-    if (p + 3 < end) {
+    // The eight bytes below, plus the ')' and the terminator that the two bytes
+    // held back from end are for.
+    if (p + 8 <= end) {
         *p++  = ' ';
         *p++  = '(';
         *p++  = 'a';

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -757,6 +757,22 @@ class ObjectJuice < Minitest::Test
     end
   end
 
+  # oj_set_error_at() reserved three bytes for the " (after " it then wrote
+  # eight of, so a class name long enough to put the formatted message in that
+  # window wrote past the end of its 256 byte buffer.
+  def test_long_class_name_error_message
+    (220..232).each do |len|
+      name = 'A' * len
+
+      [%({"^c":"#{name}"}), %({"^u":["#{name}",1]})].each do |json|
+        err = assert_raises(ArgumentError, "#{len} #{json[1, 2]}") do
+          Oj.load(json, :mode => :object)
+        end
+        assert_match(/\Aclass 'A+/, err.message, "#{len} #{json[1, 2]}")
+      end
+    end
+  end
+
   def test_json_anonymous_struct
     s = Struct.new(:x, :y)
     obj = s.new(1, 2)


### PR DESCRIPTION

Reported in #1059 after the first seven were fixed, found by the reporter's fuzzing harness.

## Problem

`oj_set_error_at()` formats into a 256 byte buffer and keeps two bytes back for the `)` and the terminator that come at the end:

```c
char  msg[256];
char *end = p + sizeof(msg) - 2;
...
if (p + 3 < end) {
    *p++ = ' '; *p++ = '('; *p++ = 'a'; *p++ = 'f';
    *p++ = 't'; *p++ = 'e'; *p++ = 'r'; *p++ = ' ';
```

The guard admits `p` up to `end - 4`, and what follows needs ten bytes from `p`: the eight here, then the `)` and the `\0`. A class name long enough to leave the formatted message in that window walks off the end.

```ruby
Oj.load(%({"^c":"#{'A' * 226}"}), mode: :object)
```

Built with `-fsanitize=address`:

```
ERROR: AddressSanitizer: stack-buffer-overflow
WRITE of size 1
  #0 oj_set_error_at   ext/oj/parse.c:1135
  #1 resolve_classpath ext/oj/intern.c:238
  #2 oj_class_intern   ext/oj/intern.c:276
  #3 hat_cstr          ext/oj/object.c:242
  #4 hash_set_cstr     ext/oj/object.c:411
  #5 read_str          ext/oj/parse.c:573
Address 0x7bb50d3f7f60 is located in stack of thread T0 at offset 352 in frame
  This frame has 2 object(s):
    [32, 56) 'ap' (line 1085)
    [96, 352) 'msg' (line 1086) <== Memory access at offset 352 overflows this variable
```

Offset 352 is `msg[256]`, one past the buffer.

Without a sanitizer it is silent — the byte lands in stack padding and the message that reaches Ruby is unchanged — which is why it took a fuzzer to find.

## Fix

The guard is `p + 8 <= end`, which leaves the `)` at `end` and the `\0` at `end + 1`, the two bytes `end` was already holding back.

Reserving the eight in the guard rather than checking each write covers both callers at once. `resolve_classpath` is duplicated — `ext/oj/resolve.c:33` and `ext/oj/intern.c:204` — and `^u` reaches the first while `^c` and `^o` reach the second, so fixing the call sites would have left one of them.

## Behaviour

Unchanged. Every message for class names 200 through 260 bytes is byte identical before and after, and the whole range comes back as the same clean `ArgumentError`.

## Verification

Using the reporter's harness from https://github.com/mschwarzl/oj-fuzz-harness, with `oj.so` built `-fsanitize=address`:

- their `poc_set_error_at.rb`, lengths 220-230 over `^c` and `^u` as both String and StringIO — aborts before, 44 clean lines after;
- a sweep of 3,520 documents: class names 1 to 400 bytes across `^c`, `^o`, `^O` and `^u`, each as String and StringIO, plus nested objects with long keys to fill the `(after a.b.c)` part — 2 ASAN reports before, 0 after.

## Tests

`test_long_class_name_error_message` in `test/test_object.rb`, covering 220 to 232 across `^c` and `^u`.

It does **not** fail on the unpatched build — the overwrite is invisible without a sanitizer. It is there to pin the window as a fixed target and to catch the write turning into something visible. The real check is the ASAN run above.

- `bundle exec ruby test/tests.rb` — 556 runs, 1454 assertions, 0 failures, 0 errors.
- `clang-format --dry-run --Werror ext/oj/*.c ext/oj/*.h` — clean.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
