### PR TITLE
Fix the read error in Oj::Parser#file being taken as a huge read

### DIFF
--- a/ext/oj/parser.c
+++ b/ext/oj/parser.c
@@ -1556,21 +1556,19 @@ static VALUE parser_file(VALUE self, VALUE filename) {
         return p->result(p);
     }
 #endif
-    byte   buf[16385];
-    size_t size = sizeof(buf) - 1;
-    size_t rsize;
+    byte    buf[16385];
+    size_t  size = sizeof(buf) - 1;
+    ssize_t rsize;
 
     while (true) {
-        if (0 < (rsize = read(fd, buf, size))) {
-            buf[rsize] = '\0';
-            parse(p, buf, rsize, true);
+        if (0 > (rsize = read(fd, buf, size))) {
+            rb_raise(rb_eIOError, "error reading from %s", path);
         }
-        if (rsize <= 0) {
-            if (0 != rsize) {
-                rb_raise(rb_eIOError, "error reading from %s", path);
-            }
+        if (0 == rsize) {
             break;
         }
+        buf[rsize] = '\0';
+        parse(p, buf, rsize, true);
     }
     return p->result(p);
 }

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -281,6 +281,13 @@ class FileJuice < Minitest::Test
     end
   end
 
+  # read() returning -1 was stored in a size_t, so the error looked like a
+  # successful read of SIZE_MAX bytes and the uninitialized stack buffer was
+  # parsed over and over.
+  def test_parser_file_on_a_directory
+    assert_raises(IOError) { Oj::Parser.new(:usual).file(__dir__) }
+  end
+
   def dump_and_load(obj, trace=false)
     filename = File.join(__dir__, 'file_test.json')
     File.open(filename, 'w') { |f|


### PR DESCRIPTION
`parser_file()` stores the result of `read()` in a `size_t`:

```c
byte   buf[16385];
size_t size = sizeof(buf) - 1;
size_t rsize;

while (true) {
    if (0 < (rsize = read(fd, buf, size))) {
        buf[rsize] = '\0';
        parse(p, buf, rsize, true);
    }
    if (rsize <= 0) {
        if (0 != rsize) {
            rb_raise(rb_eIOError, "error reading from %s", path);
        }
        break;
    }
}
```

`read()` returns `-1` on error, and `-1` in a `size_t` is `SIZE_MAX`, so the error is taken as a successful read of `SIZE_MAX` bytes. Four things follow from that:

* `buf[rsize]` is `buf[SIZE_MAX]`, which is `buf - 1`, so the terminator is written one byte in front of the buffer.
* `buf` was never written to, so `parse()` is handed 16 KB of untouched stack. It stops at the first `\0` it finds, and whatever is in front of that is decoded and handed to the delegate.
* `rsize <= 0` is `rsize == 0` for an unsigned value, so the `0 != rsize` arm that was meant to raise `IOError` is unreachable. Read errors are never reported.
* Because nothing breaks out of the loop, `read()` is called again, fails again, and the same stack bytes are parsed again, forever. The loop never calls back into Ruby, so the thread does not respond to interrupts.

## Reaching it

`open(path, O_RDONLY)` succeeds on a directory and `read()` then fails with `EISDIR`, so any application that passes an attacker-influenced path to `Oj::Parser#file` can be sent down this path with a directory name. Any other read error (`EIO`, a revoked file, a stale NFS handle) does the same.

## Before

The stack slot `buf` occupies is reused between calls, so a second call on a directory returns what the previous call read:

```ruby
require 'oj'

Dir.mkdir('/tmp/f10dir')
File.write('/tmp/f10secret.json', '{"password":"hunter2","token":"s3cr3t-abcdef"}')

class Peek < Oj::Saj
  def initialize = @seen = []
  def add_value(v, k) = record(k, v)
  def hash_set(h, k, v) = record(k, v)
  def record(k, v)
    @seen << [k, v]
    raise "saw a value for a directory: #{@seen.inspect}" if @seen.size >= 2
  end
end

Oj::Parser.new(:saj, handler: Peek.new).file('/tmp/f10secret.json') rescue puts "1: #{$!.message}"
Oj::Parser.new(:saj, handler: Peek.new).file('/tmp/f10dir')         rescue puts "2: #{$!.message}"
```

```
1: saw a value for a directory: [["password", "hunter2"], ["token", "s3cr3t-abcdef"]]
2: saw a value for a directory: [["password", "hunter2"], ["token", "s3cr3t-abcdef"]]
```

The second call was given a directory and returned the first file's contents.

With the `:usual` delegate the result is only produced after the loop ends, so the same script hangs instead:

```ruby
Oj::Parser.new(:usual).file('/tmp/f10secret.json')
Oj::Parser.new(:usual).file('/tmp/f10dir')          # spins at 100% CPU
```

`SIGINT` and `SIGTERM` are both ignored while it spins, because the loop never reaches a Ruby interrupt check; the process has to be killed with `SIGKILL`.

When the stale bytes are not valid JSON the loop exits through the parse error instead, which is what a first call on a directory usually does:

```
in 'Oj::Parser#file': unexpected character '(' in 'v' mode at 1:-1 (EncodingError)
```

The character reported there comes from uninitialized stack.

## After

```
many reads (317781 bytes): 20000 elements, first={"k0" => 0}, last={"k19999" => 19999}
empty file: nil
directory: IOError: error reading from /tmp/f10dir (0.02 ms)
```

Every case above now raises `IOError` immediately, and normal parsing is unchanged: a 317,781 byte document spanning many reads still loads its 20,000 elements, and an empty file still gives `nil`.

## The change

`rsize` becomes an `ssize_t`, a negative result raises, and a zero result breaks. The write and the parse only happen for a result that is actually a byte count.

## Note

`parser_file()` never calls `close(fd)`, so every `Oj::Parser#file` call leaks a descriptor (500 calls take the process from 6 open descriptors to 506). That is a separate bug and is left alone here; fixing it properly needs an `rb_ensure` so the descriptor is also closed when `parse()` raises. I will send it as its own PR.

## Tests

`test/test_file.rb` gets `test_parser_file_on_a_directory`, which asserts the `IOError`. Before the change it either hung or raised `EncodingError` depending on what the stack held. Full `test/tests.rb` passes: 557 runs, 1456 assertions, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
