### PR TITLE
Fix the truncated float format copying stack bytes into the output

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -1732,6 +1732,11 @@ void oj_dump_float(VALUE obj, int depth, Out out, bool as_ok) {
 size_t oj_dump_float_printf(char *buf, size_t blen, VALUE obj, double d, const char *format) {
     size_t cnt = snprintf(buf, blen, format, d);
 
+    // snprintf() returns the length the output would have needed, which is
+    // more than it wrote when the format asks for more room than buf has.
+    if (blen <= cnt) {
+        cnt = blen - 1;
+    }
     // Round off issues at 16 significant digits so check for obvious ones of
     // 0001 and 9999.
     if (17 <= cnt && (0 == strcmp("0001", buf + cnt - 4) || 0 == strcmp("9999", buf + cnt - 4))) {

--- a/test/test_strict.rb
+++ b/test/test_strict.rb
@@ -12,6 +12,7 @@ require 'minitest/autorun'
 require 'stringio'
 require 'date'
 require 'bigdecimal'
+require 'tempfile'
 require 'oj'
 
 class StrictJuice < Minitest::Test
@@ -445,6 +446,24 @@ class StrictJuice < Minitest::Test
   def test_omit_nil
     json = Oj.dump({'x' => {'a' => 1, 'b' => nil }, 'y' => nil}, :omit_nil => true)
     assert_equal(%|{"x":{"a":1}}|, json)
+  end
+
+  # snprintf() reports the length the output would have needed, and that was
+  # used as the number of bytes to copy out of a 64 byte stack buffer. The
+  # dumped String stops at the NUL the truncation left, but to_file writes the
+  # whole length and so wrote the stack bytes that followed it.
+  def test_float_format_wider_than_the_buffer
+    json = Oj.dump([1.5, 2, 3], :mode => :strict, :float_format => '%.99f')
+    assert_equal([1.5, 2, 3], Oj.load(json))
+
+    Tempfile.create('strict_float_format.json') do |f|
+      f.close
+
+      Oj.to_file(f.path, [1.5, 2, 3], :mode => :strict, :float_format => '%.99f')
+      written = File.binread(f.path)
+      assert_nil(written.index("\0"), 'wrote past the end of the float buffer')
+      assert_equal(json, written)
+    end
   end
 
   def dump_and_load(obj, trace=false)


### PR DESCRIPTION
`oj_dump_float_printf()` returns `snprintf()`'s result to its callers as the number of bytes to copy out of a 64 byte stack buffer:

```c
size_t oj_dump_float_printf(char *buf, size_t blen, VALUE obj, double d, const char *format) {
    size_t cnt = snprintf(buf, blen, format, d);

    // Round off issues at 16 significant digits so check for obvious ones of
    // 0001 and 9999.
    if (17 <= cnt && (0 == strcmp("0001", buf + cnt - 4) || 0 == strcmp("9999", buf + cnt - 4))) {
```

`snprintf()` returns the length the output *would* have needed, not the length it wrote, so a `:float_format` that asks for more room than `buf` has makes `cnt` larger than the buffer. Both the `strcmp()` here and the `APPEND_CHARS()` in every caller then read past the end of it.

`:float_format` is only checked for being 6 bytes or less (`oj.c:1170`), and `"%.99f"` is 5.

## Measured

`snprintf(buf, 64, "%.99f", 1.5)` returns 101 while `strlen(buf)` is 63, so 37 bytes past the buffer get copied.

`Oj.dump()` hides that, because the String is built with `rb_utf8_str_new_cstr()` (`oj.c:1602`) and stops at the NUL `snprintf()` left at `buf[63]`. What it does not hide is that the document is cut off there:

```ruby
json = Oj.dump([1.5, 2, 3], mode: :strict, float_format: '%.99f')
json.bytesize   # => 64
Oj.load(json)   # => Oj::ParseError: Array not terminated (after [1]) at line 1, column 64
```

`Oj.to_file()` writes `out->cur - out->buf` bytes, so it writes the whole thing:

```ruby
Oj.to_file('/tmp/f.json', [1.5, 2, 3], mode: :strict, float_format: '%.99f')
d = File.binread('/tmp/f.json')
d.bytesize   # => 107
d[64..]
# => "\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00C\x14\xADPt\x1F`PL\xF9\xEA\x9A\x7F\x00\x00xB\xF9\xEA\x9A\x7F\x00\x00\x03\x00\x00\x00\x00,2,3]"
```

43 bytes of stack, with the `\x7f\x00\x00` of x86-64 pointers still in them, went into the file. `Oj.to_stream()` and the writers use the same length.

A wider format makes it worse: `"%.9999f"` does not fit the 6 byte limit but `"%9999f"` does, and that asks for a copy of about 10 KB.

## After

```ruby
Oj.dump([1.5, 2, 3], mode: :strict, float_format: '%.99f')
# => "[1.500000000000000000000000000000000000000000000000000000000000,2,3]"
Oj.to_file(...)   # writes exactly the same bytes
```

The float is truncated to what fits, which is what the buffer size already implied, and the document stays valid.

## The change

`cnt` is clamped to `blen - 1` right after the `snprintf()`, before anything uses it. That also covers the platforms whose `snprintf()` returns `-1` on truncation instead of the needed length, since `-1` in the `size_t` is `SIZE_MAX` and gets clamped the same way.

The three call sites that pass a literal `"%0.16g"` (`dump_compat.c:596`, `rails.c:1320`) were never affected; this only ever mattered for a `:float_format` coming from the application.

## Not covered here

`:float_format` is passed to `snprintf()` as the format string with a single `double` argument, so a format containing `%s` or `%n` still reaches `printf`. That is a separate question about what the option should be allowed to hold, and restricting it would be visible to anyone already using the option, so I have left it out of this change and will raise it on its own.

## Tests

`test/test_strict.rb` gets `test_float_format_wider_than_the_buffer`, covering both the `Oj.dump()` round trip and the bytes `Oj.to_file()` writes. Before the change it fails with `Oj::ParseError: Array not terminated`. Full `test/tests.rb` passes: 557 runs, 1458 assertions, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
