### PR TITLE
Fix the double free of the default create_id when a call passes nil

### DIFF
--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -953,9 +953,13 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
             rb_raise(rb_eArgError, ":decimal_class must be BigDecimal or Float.");
         }
     } else if (create_id_sym == k) {
+        // A per call copy of the options aliases the buffer the default
+        // options own, so only the defaults may free it.
+        bool owned = (&oj_default_options == copts && NULL != copts->create_id && oj_json_class != copts->create_id);
+
         if (Qnil == v) {
-            if (oj_json_class != oj_default_options.create_id && NULL != copts->create_id) {
-                OJ_R_FREE((char *)oj_default_options.create_id);
+            if (owned) {
+                OJ_R_FREE((char *)copts->create_id);
             }
             copts->create_id     = NULL;
             copts->create_id_len = 0;
@@ -963,8 +967,8 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
             const char *str = StringValuePtr(v);
 
             len = RSTRING_LEN(v);
-            if (len != copts->create_id_len || 0 != strcmp(copts->create_id, str)) {
-                if (&oj_default_options == copts && oj_json_class != copts->create_id) {
+            if (NULL == copts->create_id || len != copts->create_id_len || 0 != strcmp(copts->create_id, str)) {
+                if (owned) {
                     OJ_R_FREE((char *)copts->create_id);
                 }
                 copts->create_id = OJ_R_ALLOC_N(char, len + 1);

--- a/test/test_compat.rb
+++ b/test/test_compat.rb
@@ -662,6 +662,29 @@ class CompatJuice < Minitest::Test
     Oj.remove_to_json(Exception)
   end
 
+  # A per call :create_id => nil freed the buffer the default options own, so
+  # the default was left pointing at freed memory and the second call freed it
+  # again.
+  def test_create_id_nil_per_call_leaves_the_default_alone
+    Oj.default_options = {:create_id => 'my_class'}
+
+    2.times { Oj.dump({'a' => 1}, :create_id => nil) }
+    assert_equal('my_class', Oj.default_options[:create_id])
+  end
+
+  # Clearing the create_id leaves it NULL, and a replacement of the same length
+  # as the cleared one reached a strcmp() against that NULL.
+  def test_create_id_set_after_being_cleared
+    Oj.default_options = {:create_id => nil}
+    assert_nil(Oj.default_options[:create_id])
+
+    Oj.default_options = {:create_id => ''}
+    assert_equal('', Oj.default_options[:create_id])
+
+    Oj.default_options = {:create_id => 'back'}
+    assert_equal('back', Oj.default_options[:create_id])
+  end
+
   def dump_and_load(obj, trace=false)
     json = Oj.dump(obj)
     puts json if trace


### PR DESCRIPTION
Every entry point copies `oj_default_options` into a per call struct before `parse_options_cb()` walks the option Hash:

```c
static VALUE to_file(int argc, VALUE *argv, VALUE self) {
    struct _options copts = oj_default_options;

    if (3 == argc) {
        oj_parse_options(argv[2], &copts);
    }
```

The copy aliases the `create_id` buffer the defaults own, which is why the branch that assigns a String only frees when it was handed the defaults themselves:

```c
if (&oj_default_options == copts && oj_json_class != copts->create_id) {
    OJ_R_FREE((char *)copts->create_id);
}
```

The `nil` branch a few lines above it has no such guard, and frees through `oj_default_options` rather than through the struct it was given:

```c
if (Qnil == v) {
    if (oj_json_class != oj_default_options.create_id && NULL != copts->create_id) {
        OJ_R_FREE((char *)oj_default_options.create_id);
    }
    copts->create_id     = NULL;
    copts->create_id_len = 0;
```

So a per call `create_id: nil` frees the buffer the whole process shares and sets only its own copy to `NULL`. `oj_default_options.create_id` is left pointing at the freed block.

Reaching it needs a heap allocated default, so `Oj.default_options=` or `JSON.create_id=` has to have been called first. The compiled in default is the static `oj_json_class`, which the guard already excludes.

## Before

```ruby
require 'oj'

Oj.default_options = {create_id: 'my_class'}
Oj.dump({'a' => 1}, create_id: nil)   # frees the default's buffer
Oj.default_options[:create_id]        # use-after-free read
Oj.dump({'a' => 1}, create_id: nil)   # frees it a second time
```

```
free(): double free detected in tcache 2
[BUG] Aborted at 0x000003e800024b2b
```

The read on the third line is what ASAN reports first:

```
==150832==ERROR: AddressSanitizer: heap-use-after-free on address 0x7b2a25074950
READ of size 3 at 0x7b2a25074950 thread T0
    #1 rb_str_new_cstr string.c:1139:28
    #2 get_def_opts ext/oj/oj.c:487:66
freed by thread T0 here:
    #2 ruby_sized_xfree gc.c:5261:13
```

Anything that reads the default reaches it, not just `Oj.default_options`: `custom.c:394` and `dump_compat.c:33` copy it into every dump.

## A second problem in the same block

Clearing the `create_id` leaves it `NULL`, and the String branch only reaches its `strcmp()` when the lengths match, so a replacement whose length equals the cleared one dereferences that `NULL`:

```ruby
Oj.default_options = {create_id: nil}
Oj.default_options = {create_id: ''}
```

```
oj.c:966 in parse_options_cb   # SIGSEGV
```

Both are fixed here because they are the same four lines.

## After

```ruby
Oj.default_options = {mode: :object, create_id: 'my_class'}
3.times { Oj.dump({'a' => 1}, create_id: nil) }
3.times { Oj.dump({'a' => 1}, create_id: 'z') }
Oj.default_options[:create_id]   # => "my_class"

Oj.default_options = {create_id: nil}    # => nil
Oj.default_options = {create_id: ''}     # => ""
Oj.default_options = {create_id: 'back'} # => "back"
```

ASAN reports nothing for that script, and valgrind shows no leak reaching `parse_options_cb`. The per call buffer is still freed by `oj_free_call_options()`, which every dump path already calls.

## The change

The ownership test the String branch was already using is hoisted into an `owned` local and used by both branches, so `nil` frees only when it was given the defaults, and frees through the struct rather than through the global. The String branch's change test gets a `NULL` check ahead of the `strcmp()`.

## Tests

`test/test_compat.rb` gets `test_create_id_nil_per_call_leaves_the_default_alone` and `test_create_id_set_after_being_cleared`. Before the change they exit 134 (`SIGABRT`, the double free) and 139 (`SIGSEGV`) rather than reporting a failure. Full `test/tests.rb` passes: 558 runs, 1459 assertions, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
