### PR TITLE
Fix the buffer over-read of an odd attribute name and the leak of its args

### DIFF
--- a/ext/oj/odd.c
+++ b/ext/oj/odd.c
@@ -195,7 +195,7 @@ int oj_odd_set_arg(OddArgs args, const char *key, size_t klen, VALUE value) {
     int          i;
 
     for (i = args->odd->attr_cnt, np = args->odd->attr_names, vp = args->args; 0 < i; i--, np++, vp++) {
-        if (0 == strncmp(key, *np, klen) && '\0' == *((*np) + klen)) {
+        if (klen == strlen(*np) && 0 == memcmp(key, *np, klen)) {
             *vp = value;
             return 0;
         }

--- a/ext/oj/val_stack.h
+++ b/ext/oj/val_stack.h
@@ -62,6 +62,16 @@ inline static int stack_empty(ValStack stack) {
 }
 
 inline static void stack_cleanup(ValStack stack) {
+    Val v;
+
+    // end_hash() frees the args of a completed odd class. Anything still here
+    // belongs to a parse that was abandoned part way through.
+    for (v = stack->head; v < stack->tail; v++) {
+        if (NULL != v->odd_args) {
+            oj_odd_free(v->odd_args);
+            v->odd_args = NULL;
+        }
+    }
     if (stack->base != stack->head) {
         OJ_R_FREE(stack->head);
         stack->head = NULL;

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -1189,6 +1189,21 @@ class ObjectJuice < Minitest::Test
     assert_equal({'a' => 1}, h)
   end
 
+  # oj_odd_set_arg() compared the key with strncmp(), which stops at the NUL the
+  # key carries, and then looked for the end of the registered name at the key
+  # length. A key that starts with a registered name, a NUL and any amount of
+  # padding read that many bytes past the name, and was taken for the attribute
+  # whenever the byte it landed on happened to be zero.
+  def test_odd_key_with_an_embedded_nul
+    (0..1000).each do |pad|
+      json = %({"^O":"Rational","numerator\\u0000#{'A' * pad}":3,"denominator":1})
+      assert_raises(Oj::ParseError, "a key holding a NUL was taken as numerator with #{pad} bytes of padding") do
+        Oj.load(json, :mode => :object)
+      end
+    end
+    assert_equal(Rational(3, 1), Oj.load(%({"^O":"Rational","numerator":3,"denominator":1}), :mode => :object))
+  end
+
   def test_auto_string
     s = AutoStrung.new('Pete', true)
     dump_and_load(s, false)


### PR DESCRIPTION
`oj_odd_set_arg()` matches a JSON object key against the attribute names registered for an odd class:

```c
for (i = args->odd->attr_cnt, np = args->odd->attr_names, vp = args->args; 0 < i; i--, np++, vp++) {
    if (0 == strncmp(key, *np, klen) && '\0' == *((*np) + klen)) {
        *vp = value;
        return 0;
    }
}
```

`strncmp()` stops at a NUL in either string, so a key made of a registered name, a NUL and any amount of padding compares equal to that name however long the key is. The second test is then supposed to confirm the name ended where the key did, but it reads the name at the key's length, which is as far past the end of the name as the padding is long.

Whatever byte is there decides the outcome. If it is zero the padded key is taken for the attribute; otherwise the loop moves on and the document is rejected. Either way the read is out of bounds and the offset is chosen by the document.

`Rational`, `Date`, `DateTime` and `Range` are registered unconditionally by `oj_odd_init()`, so `:object` mode reaches this with no application setup.

## Measured

Sweeping the padding from 0 to 6000 bytes:

```ruby
require 'oj'

hits = (0..6000).count do |pad|
  json = %({"^O":"Rational","numerator\\u0000#{'A' * pad}":3,"denominator":1})
  Oj.load(json, mode: :object) rescue next false
  true
end
```

598 of the 6001 lengths returned `Rational(3/1)` for a document that names no numerator. The first is 11 bytes of padding, and which ones hit depends only on what happens to sit after the name in memory.

The names of the built in odd classes are string literals, which ASAN leaves uninstrumented because they live in a mergeable section. `oj_reg_odd()` `strdup()`s the names of a registered class, and there the read is reported:

```ruby
Oj.register_odd(Thing, Thing, :create, :a)
Oj.load(%({"^O":"Thing","a\\u0000#{'A' * 2000}":1}), mode: :object)
```

```
==225066==ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 1 at 0x7bc105c754e2 thread T0
    #0 oj_odd_set_arg ext/oj/odd.c:198:53
    #1 hash_set_num ext/oj/object.c:511:22
    #7 oj_object_parse ext/oj/object.c:712:16
0x7bc105c754e2 is located 2000 bytes after 2-byte region [0x7bc105c74d10,0x7bc105c74d12)
allocated by thread T0 here:
    #1 oj_reg_odd ext/oj/odd.c:235:32
```

2000 bytes after the two byte name is exactly the padding the document asked for.

## After

The same sweep accepts none of the 6001 lengths, and ASAN reports nothing for the registered class. `Rational`, `Date`, `DateTime` and `Range` still round trip, and a key that really is `numerator` is still matched.

```c
if (klen == strlen(*np) && 0 == memcmp(key, *np, klen)) {
```

Comparing the lengths first keeps the read inside the name, and `memcmp()` compares the whole key instead of stopping at the NUL it carries, so a key that merely starts with a registered name no longer matches it.

## A leak the test exposed

The memcheck lane went red on the first push of this branch, with 88,088 bytes in 1,001 blocks lost from `oj_odd_alloc_args()` by way of `hat_cstr()` — one per iteration of the new test.

It is not caused by the change above. `oj_odd_alloc_args()` allocates the argument block when an odd class is recognized and `end_hash()` frees it once the object is built, so a parse that raises before the hash ends never frees it. It needs no NUL, just a key that is not an attribute:

```ruby
Oj.load(%({"^O":"Rational","nope":3,"denominator":1}), mode: :object)
```

100 of those leak 100 blocks on `d0d84b8` under valgrind. The new test runs 1001 parses that all raise, which is what made it visible.

`stack_cleanup()` now frees whatever an abandoned stack still holds, which covers both `oj_pi_parse()` and `oj_pi_sparse()`. With that in place valgrind reports nothing rooted in `oj_odd_alloc_args()`.

## Tests

`test/test_object.rb` gets `test_odd_key_with_an_embedded_nul`, which sweeps the padding from 0 to 1000 bytes and requires every one to be rejected, then checks the plain `numerator` key still works. Before the change it fails at 11 bytes of padding. Full `test/tests.rb` passes: 557 runs, 2457 assertions, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
