### PR TITLE
Fix the SEGV reading a truncated document with Oj::Parser#file and the descriptor it leaks

### DIFF
--- a/ext/oj/parser.c
+++ b/ext/oj/parser.c
@@ -1524,6 +1524,39 @@ static VALUE parser_load(VALUE self, VALUE reader) {
     return p->result(p);
 }
 
+struct _fileParse {
+    ojParser    p;
+    const char *path;
+    int         fd;
+};
+
+static VALUE file_parse(VALUE x) {
+    struct _fileParse *fp = (struct _fileParse *)x;
+    byte               buf[16385];
+    size_t             size = sizeof(buf) - 1;
+    ssize_t            rsize;
+
+    while (true) {
+        if (0 > (rsize = read(fp->fd, buf, size))) {
+            rb_raise(rb_eIOError, "error reading from %s", fp->path);
+        }
+        if (0 == rsize) {
+            break;
+        }
+        buf[rsize] = '\0';
+        parse(fp->p, buf, rsize, true);
+    }
+    validate_document_end(fp->p);
+
+    return fp->p->result(fp->p);
+}
+
+static VALUE file_close(VALUE x) {
+    close(((struct _fileParse *)x)->fd);
+
+    return Qnil;
+}
+
 /* Document-method: file(filename)
  * call-seq: file(filename)
  *
@@ -1532,9 +1565,10 @@ static VALUE parser_load(VALUE self, VALUE reader) {
  * Returns the result according to the delegate of the parser.
  */
 static VALUE parser_file(VALUE self, VALUE filename) {
-    ojParser    p;
-    const char *path;
-    int         fd;
+    struct _fileParse fp;
+    ojParser          p;
+    const char       *path;
+    int               fd;
 
     TypedData_Get_Struct(self, struct _ojParser, &oj_parser_type, p);
 
@@ -1553,26 +1587,15 @@ static VALUE parser_file(VALUE self, VALUE filename) {
         // Use threaded version.
         // TBD only if has pthreads
         // TBD parse_large(p, fd);
+        close(fd);
         return p->result(p);
     }
 #endif
-    byte    buf[16385];
-    size_t  size = sizeof(buf) - 1;
-    ssize_t rsize;
+    fp.p    = p;
+    fp.path = path;
+    fp.fd   = fd;
 
-    while (true) {
-        if (0 > (rsize = read(fd, buf, size))) {
-            rb_raise(rb_eIOError, "error reading from %s", path);
-        }
-        if (0 == rsize) {
-            break;
-        }
-        buf[rsize] = '\0';
-        parse(p, buf, rsize, true);
-    }
-    validate_document_end(p);
-
-    return p->result(p);
+    return rb_ensure(file_parse, (VALUE)&fp, file_close, (VALUE)&fp);
 }
 
 /* Document-method: just_one

--- a/ext/oj/parser.c
+++ b/ext/oj/parser.c
@@ -1570,6 +1570,8 @@ static VALUE parser_file(VALUE self, VALUE filename) {
         buf[rsize] = '\0';
         parse(p, buf, rsize, true);
     }
+    validate_document_end(p);
+
     return p->result(p);
 }
 

--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -288,6 +288,19 @@ class FileJuice < Minitest::Test
     assert_raises(IOError) { Oj::Parser.new(:usual).file(__dir__) }
   end
 
+  # Without validate_document_end() the Qundef the delegate uses as a place
+  # holder was handed back to Ruby.
+  def test_parser_file_on_a_truncated_document
+    ['{', '{"a":', '{"a":1', '[', '[1,', '[1,2', 'nul', 'tru', 'fals'].each do |json|
+      Tempfile.create('file_test_truncated.json') do |f|
+        f.write(json)
+        f.close
+
+        assert_raises(EncodingError, json) { Oj::Parser.new(:usual).file(f.path) }
+      end
+    end
+  end
+
   def dump_and_load(obj, trace=false)
     filename = File.join(__dir__, 'file_test.json')
     File.open(filename, 'w') { |f|


### PR DESCRIPTION
`parser_parse()` validates that the document ended where a document may end before it hands the result back:

```c
parse(p, ptr, (size_t)RSTRING_LEN(json), false);
validate_document_end(p);

return p->result(p);
```

`parser_file()` does not. A file that stops part way through a document reaches `p->result(p)` with the parse still open.

The usual delegate pushes `Qundef` as a place holder when a container is opened — `usual.c:228` for the key of an object member, `usual.c:262` for the array itself — and drops it when the container closes. With the parse abandoned the place holder is still on the value stack, so `result()` (`usual.c:579`) either returns it directly, when it is the only entry, or pushes it into the Array it builds from the rest.

`Qundef` is an internal value that must not reach Ruby, and the VM goes down the first time the value is used.

## Measured

On `ce28234`, writing each of these to a file and calling `Oj::Parser.usual.file` on it:

| document | result |
| --- | --- |
| `{` `{"a":` `{"a":1` | `[BUG] Stack consistency error` / `Segmentation fault` |
| `[` `[1,` `[1,2` | `[BUG] Segmentation fault` |
| `nul` `tru` `fals` | `nil` |

The array case is the clearest. `Oj::Parser.usual.file` on a file holding `[1,` returns an Array whose `size` is 2 and whose elements answer `NilClass` and `Integer` to `class`, but `inspect` takes the process down:

```
[BUG] Segmentation fault at 0x0000000000000034
-- Control frame information ---
c:0004 p:---- s:0017 e:000016 l:y b:0001 CFUNC  :to_s
c:0003 p:---- s:0014 e:000013 l:y b:0001 CFUNC  :inspect
-- Machine register context ---
 RDI: 0x0000000000000024
```

`RDI` is the receiver of `to_s` and `0x24` is `RUBY_Qundef` on this build, so the place holder is what dispatch was handed. The fault address is `0x10` past it.

Reaching it needs no control over the path or the content, only a file that was cut short — an interrupted write, a full disk, a truncated transfer. Nothing but `#file` is affected: `Oj.load_file` and `Oj.load` on an IO raise `Oj::ParseError` for every one of these, and `Oj::Parser#load` raises for the containers.

## After

```c
        buf[rsize] = '\0';
        parse(fp->p, buf, rsize, true);
    }
    validate_document_end(fp->p);

    return fp->p->result(fp->p);
```

`#file` now gives what `#parse` gives:

```
"{"        file  => EncodingError: Object is not closed at 1:-1
           parse => EncodingError: Object is not closed at 1:-1
"{\"a\":"  file  => EncodingError: Object is not closed at 1:-1
           parse => EncodingError: Object is not closed at 1:-1
"["        file  => EncodingError: Array is not closed at 1:-1
           parse => EncodingError: Array is not closed at 1:-1
"[1,"      file  => EncodingError: Array is not closed at 1:-1
           parse => EncodingError: Array is not closed at 1:-1
"nul"      file  => EncodingError: expected null at 1:-1
           parse => EncodingError: expected null at 1:-1
```

One difference remains. An unterminated string returns `nil` rather than raising:

```
"\"abc"    file  => nil
           parse => EncodingError: quoted string not terminated at 1:-1
           load  => nil
```

That is the streaming path rather than this check. `#file` and `#load` both call `parse()` with `more` set, so neither reaches the error `#parse` produces. It looks like a separate issue.

## A descriptor leak the test exposed

The first push of this branch went red on all five Windows lanes, with the assertions passing and the cleanup failing:

```
1) Error:
FileJuice#test_parser_file_on_a_truncated_document:
Errno::EACCES: Permission denied @ apply2files - D:/a/_temp/file_test_truncated.json...
    tempfile.rb:588:in 'File.unlink'
562 runs, 2454 assertions, 0 failures, 1 errors, 4 skips
```

`parser_file()` opens the path and never closes it, on any path out. The descriptor is a raw one rather than a Ruby IO, so the GC does not take it back either. Windows will not unlink a file that still has an open handle, which is what `Tempfile.create` tries to do on the way out of the block. The existing tests in `test/test_file.rb` that use `Tempfile` go through `Oj.load_file`, which closes, so this is the first one to pair a temporary file with `#file`.

200 calls leak 200 descriptors on every path:

```
complete document      6 ->  206 (grew 200)
truncated document   206 ->  406 (grew 200)
read error (dir)     406 ->  606 (grew 200)
directory (IOError)  606 ->  806 (grew 200)
```

The read loop now runs under `rb_ensure()`, which closes the descriptor on the normal return, on the `rb_raise()` from a read error and on anything `parse()` or `validate_document_end()` raises. `oj_pi_sparse()` (`sparse.c:920`) does the same thing with a CLEANUP label. After the change all four grow by 0.

A process that keeps calling `#file` would otherwise fail every `open` in it with `EMFILE` eventually, so this is worth having on its own.

## Tests

`test/test_file.rb` gets `test_parser_file_on_a_truncated_document`, which requires each of the nine truncations above to raise. Before the change it does not fail, it takes the runner down at the first one:

```
test/test_file.rb:299: [BUG] Stack consistency error (sp: 143, bp: 144)
```

Full `test/tests.rb` passes: 562 runs, 2474 assertions, 0 failures, 0 errors.

`test/test_parser_saj.rb` has one pre-existing error, `IOError: error opening saj_test.json`. The fixture is not in the repository and the file is not part of `test/tests.rb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
