### PR TITLE
Fix the SEGV from a malformed number in Oj::Doc

### DIFF
--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -105,6 +105,22 @@ inline static void next_non_white(ParseInfo pi) {
     }
 }
 
+inline static bool is_value_end(char c) {
+    switch (c) {
+    case '\0':
+    case ' ':
+    case '\t':
+    case '\f':
+    case '\n':
+    case '\r':
+    case '/':
+    case ',':
+    case ']':
+    case '}': return true;
+    default: return false;
+    }
+}
+
 inline static char *ulong_fill(char *s, size_t num) {
     char  buf[32];
     char *b = buf + sizeof(buf) - 1;
@@ -463,17 +479,22 @@ static Leaf read_num(ParseInfo pi) {
     char *start = pi->s;
     int   type  = T_FIXNUM;
     Leaf  leaf;
+    int   dcnt = 0;
+    int   ecnt = 1;
 
-    if ('-' == *pi->s) {
+    // read_next() sends a leading '+' here as well, and Oj.load() takes one.
+    if ('-' == *pi->s || '+' == *pi->s) {
         pi->s++;
     }
     // digits
     for (; '0' <= *pi->s && *pi->s <= '9'; pi->s++) {
+        dcnt++;
     }
     if ('.' == *pi->s) {
         type = T_FLOAT;
         pi->s++;
         for (; '0' <= *pi->s && *pi->s <= '9'; pi->s++) {
+            dcnt++;
         }
     }
     if ('e' == *pi->s || 'E' == *pi->s) {
@@ -481,8 +502,14 @@ static Leaf read_num(ParseInfo pi) {
         if ('-' == *pi->s || '+' == *pi->s) {
             pi->s++;
         }
-        for (; '0' <= *pi->s && *pi->s <= '9'; pi->s++) {
+        for (ecnt = 0; '0' <= *pi->s && *pi->s <= '9'; pi->s++) {
+            ecnt++;
         }
+    }
+    // A float is converted with rb_cstr_to_dbl(), which has to be given
+    // something it can convert.
+    if (T_FLOAT == type && (0 == dcnt || 0 == ecnt || !is_value_end(*pi->s))) {
+        raise_error("invalid number", pi->str, pi->s);
     }
     leaf      = leaf_new(pi->doc, type);
     leaf->str = start;
@@ -670,7 +697,11 @@ static void doc_free(Doc doc) {
 static VALUE protect_open_proc(VALUE x) {
     ParseInfo pi = (ParseInfo)x;
 
-    pi->doc->data   = read_next(pi);  // parse
+    pi->doc->data = read_next(pi);  // parse
+    // read_obj() and read_array() terminate each value where it ends. The top
+    // level value has no closing delimiter to do that on, so a number leaf runs
+    // to the end of the document unless it is terminated here.
+    *pi->s          = '\0';
     *pi->doc->where = pi->doc->data;
     pi->doc->where  = pi->doc->where_path;
     if (rb_block_given_p()) {

--- a/test/test_fast.rb
+++ b/test/test_fast.rb
@@ -112,6 +112,24 @@ class DocTest < Minitest::Test
     end
   end
 
+  # read_num() took any token that started like a number, and
+  # leaf_float_value() handed what it collected to rb_cstr_to_dbl().
+  def test_malformed_number
+    ['-.', '0.0.0', '0.0e', '00.0x', '1.2.3.4', '1.5.', '1.0e+', '1.0E'].each do |json|
+      assert_raises(Oj::ParseError, json) { Oj::Doc.open(json) { |doc| doc.fetch } }
+      assert_raises(Oj::ParseError, json) { Oj::Doc.open("[#{json}]") { |doc| doc.fetch } }
+      assert_raises(Oj::ParseError, json) { Oj::Doc.open(%({"a":#{json}})) { |doc| doc.fetch } }
+    end
+  end
+
+  # An element of an array or a member of an object is terminated where it
+  # ends. The top level value has no closing delimiter to be terminated on, so
+  # the leaf for a number ran to the end of the document.
+  def test_top_level_number_is_terminated
+    Oj::Doc.open('1.5 x') { |doc| assert_in_delta(1.5, doc.fetch) }
+    Oj::Doc.open('1.5') { |doc| assert_in_delta(1.5, doc.fetch) }
+  end
+
   def test_array_empty
     json = %{[]}
     Oj::Doc.open(json) do |doc|


### PR DESCRIPTION
```ruby
Oj::Doc.open('0.0.0') { |doc| doc.fetch }
```

```
[BUG] Segmentation fault at 0x0000000000000014
```

`-.` is enough, at two bytes, as are `0.0e`, `00.0x`, `1.0 x` and `1.2.3.4`.

## Why

`read_num()` takes whatever follows a character that can start a number and never checks that what it collected is one. `read_next()` dispatches `+`, `-` and `0` to `9` here, and from there the loops just stop at the first character they do not want:

```c
if ('-' == *pi->s) {
    pi->s++;
}
// digits
for (; '0' <= *pi->s && *pi->s <= '9'; pi->s++) {
}
if ('.' == *pi->s) {
    type = T_FLOAT;
    pi->s++;
    for (; '0' <= *pi->s && *pi->s <= '9'; pi->s++) {
    }
}
```

Nothing terminates the top level value either. `read_obj()` and `read_array()` write a NUL where each value they hold ends, but the value at the top of the document has no closing delimiter to do that on, so `leaf->str` runs to the end of the document.

`leaf_float_value()` then hands that text to Ruby:

```c
leaf->value = rb_float_new(rb_cstr_to_dbl(leaf->str, 1));
```

With `badcheck` set Ruby raises `ArgumentError` for text it cannot convert, and building that error calls `rb_enc_str_new_cstr(p, enc)` with the `enc` `rb_cstr_to_dbl()` passes, which is NULL. `rb_enc_str_new_cstr()` reads `min_enc_len` off it before doing anything else:

```
-- C level backtrace ---
rb_enc_str_new_cstr    string.c:1156
rb_cstr_to_dbl_raise   object.c:3655
leaf_float_value       fast.c:298
leaf_value             fast.c:190
-- Machine register context ---
 RSI: 0x0000000000000000
```

`RSI` is the `enc` argument and `0x14` is the offset of `min_enc_len` in `OnigEncodingTypeST`, so the fault address is exactly that field on a NULL encoding. The value has to be materialized to get there: `each_leaf`, `each_child`, `size` and `dump` return normally on the same document because they never call `leaf_value()`.

Two separate things have to be wrong for a document to reach `rb_cstr_to_dbl()` with text it cannot convert, and both are here:

| document | what `read_num()` collects | why it is not a number |
| --- | --- | --- |
| `-.` | `-.` | no digits |
| `0.0e` | `0.0e` | no exponent digits |
| `0.0.0` | `0.0` | does not end where a value may end |
| `1.0 x` | `1.0` | ends at a space, but the leaf is not terminated so `rb_cstr_to_dbl()` sees `1.0 x` |

## Measured

Sweeping the 7380 tokens of up to four characters over `0 1 . e E + - x "`, each one at the top level, inside an array and as an object member, through `fetch`, `each_value` and `dump`:

| | faults |
| --- | --- |
| `ce28234` | 41, in the first 13% of the tokens, at which point I stopped |
| with this change | 0, over all 7380 |

Nesting does not save the ones that have no digits at all. `Oj::Doc.open('[-.]')` and `Oj::Doc.open('[0.0e]')` take the process down on `ce28234` as well, because the token does end at the `]` and the delimiter check the array path performs is satisfied.

## After

`read_num()` requires a digit in the mantissa and, when an exponent is written, a digit in the exponent, and requires a float to end where a value may end. `protect_open_proc()` terminates the top level value the way the nested paths terminate the values they hold.

```
TOKEN      TOP                              NESTED
-.         Oj::ParseError: invalid number   Oj::ParseError: invalid number
0.0.0      Oj::ParseError: invalid number   Oj::ParseError: invalid number
0.0e       Oj::ParseError: invalid number   Oj::ParseError: invalid number
00.0x      Oj::ParseError: invalid number   Oj::ParseError: invalid number
1.2.3.4    Oj::ParseError: invalid number   Oj::ParseError: invalid number
1.5.       Oj::ParseError: invalid number   Oj::ParseError: invalid number
1.0 x      1.0                              Oj::ParseError: invalid format, expected , or ] while in an array
```

Everything that parsed before still parses to the same value: `0`, `1.5`, `-1`, `-1.5`, `1.5e3`, `1.5e-3`, `5.`, `01`, `-`, `1 2`, `1e`, `1e+`, and `.5` and `e5` still return nil.

One deliberate change beyond that. A leading `+` is now consumed as a sign rather than left for the caller, so `Oj::Doc.open('[+1]')` gives `1` where it used to raise. `read_next()` already routes `+` to `read_num()`, and `Oj.load('[+1]')` gives `[1]`, so this makes `Oj::Doc` agree with both. Without it the top level `+1`, which does parse today, would start failing.

## Tests

`test/test_fast.rb` gets `test_malformed_number`, which requires eight malformed tokens to raise at the top level, in an array and in an object, and `test_top_level_number_is_terminated`. Before the change neither fails, they take the runner down:

```
test/test_fast.rb:119: [BUG] Segmentation fault at 0x0000000000000014
```

Full `test/tests.rb` passes: 563 runs, 2491 assertions, 0 failures, 0 errors.

## Noticed while here, not touched

`Oj::Doc` drops the exponent of an integer mantissa. `read_num()` only sets `T_FLOAT` on a `.`, so `1e5` stays a `T_FIXNUM` and `leaf_fixnum_value()` stops at the `e`:

```ruby
Oj::Doc.open('[1e5]') { |doc| doc.fetch }   # => [1]
Oj.load('[1e5]')                            # => [100000.0]
```

That is a wrong value rather than a fault, and fixing it changes what documents that parse today return, so it seems better as its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
