### PR TITLE
Fix the stack overflow from a long key with :only or :except

### DIFF
--- a/ext/oj/dump.c
+++ b/ext/oj/dump.c
@@ -1748,6 +1748,21 @@ size_t oj_dump_float_printf(char *buf, size_t blen, VALUE obj, double d, const c
     return cnt;
 }
 
+// The only and except lists are the keys joined with a ':' and wrapped in one
+// at each end, so a key is in a list when ":key:" is in it. Matching in place
+// finds what searching the list for a copy of the key with the colons on it
+// found, without a buffer sized by the key.
+static bool key_listed(const char *list, const char *key, size_t klen) {
+    const char *s;
+
+    for (s = list; NULL != (s = strchr(s, ':')); s++) {
+        if (0 == strncmp(s + 1, key, klen) && ':' == s[klen + 1]) {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool oj_key_skip(VALUE key, const char *only, const char *except) {
     const char *skey;
 
@@ -1757,15 +1772,9 @@ bool oj_key_skip(VALUE key, const char *only, const char *except) {
     default: skey = NULL; break;
     }
     if (NULL != skey && '\0' != *skey) {
-        size_t size = strlen(skey);
-        char  *buf  = alloca(size + 3);
+        size_t klen = strlen(skey);
 
-        buf[0] = ':';
-        strcpy(buf + 1, skey);
-        buf[size + 1] = ':';
-        buf[size + 2] = '\0';
-
-        return ((NULL != only && NULL == strstr(only, buf)) || (NULL != except && NULL != strstr(except, buf)));
+        return ((NULL != only && !key_listed(only, skey, klen)) || (NULL != except && key_listed(except, skey, klen)));
     }
     return NULL != only;
 }

--- a/test/test_custom.rb
+++ b/test/test_custom.rb
@@ -556,6 +556,17 @@ class CustomJuice < Minitest::Test
     assert_equal(String, Oj.load('"aaa"').class)
   end
 
+  # oj_key_skip() sized an alloca() from the key it was given, so a long key
+  # moved the stack pointer past the end of the stack. A thread gets a smaller
+  # one than the main thread, which is where a request is usually served.
+  def test_only_and_except_with_a_long_key
+    key = 'x' * (4 * 1024 * 1024)
+    hash = {'a' => 1, key => 2}
+
+    assert_equal(%({"a":1}), Thread.new { Oj.dump(hash, :mode => :custom, :only => ['a']) }.value)
+    assert_equal(%({"a":1}), Thread.new { Oj.dump(hash, :mode => :custom, :except => [key]) }.value)
+  end
+
   def dump_and_load(obj, trace=false, options={})
     options = options.merge(:indent => 2, :mode => :custom)
     json = Oj.dump(obj, options)


### PR DESCRIPTION
`oj_key_skip()` decides whether a hash key survives the `:only` and `:except` filters. It builds `":key:"` and looks for it in the lists, and it sizes the buffer it builds it in with `alloca()`:

```c
if (NULL != skey && '\0' != *skey) {
    size_t size = strlen(skey);
    char  *buf  = alloca(size + 3);

    buf[0] = ':';
    strcpy(buf + 1, skey);
    buf[size + 1] = ':';
    buf[size + 2] = '\0';

    return ((NULL != only && NULL == strstr(only, buf)) || (NULL != except && NULL != strstr(except, buf)));
}
```

`skey` is whatever the hash being dumped holds, so the length comes from the data. `alloca()` moves the stack pointer by it, and `buf[0] = ':'` writes at the far end of the move.

## Measured

`ulimit -s` is 16384 KB here. Dumping `{'x' * n => 1}` with `only: ['a']`:

| key | main thread | in a `Thread` |
| --- | --- | --- |
| 256 KB | ok | ok |
| 1 MB | ok | `SystemStackError` |
| 8 MB | ok | `SystemStackError` |
| 16 MB | `SystemStackError` | `SystemStackError` |
| 2 GB | `SystemStackError` | `SystemStackError` |

A `Fiber` behaves like the `Thread`, and 1 MB is the size that matters, because that is where a request is usually served:

```ruby
Thread.new { Oj.dump({'x' * (1 << 20) => 1}, mode: :compat, only: ['a']) }.value
=> SystemStackError
```

The `SystemStackError` carries no backtrace, which is what Ruby produces when its handler turns a machine stack overflow into an exception rather than the fault reaching the process. It is catchable, so on this platform and these sizes the effect is that the dump does not complete. What decides whether the write lands in the guard page or past it is the size and the layout, neither of which the process controls once the key length is attacker supplied, so it is worth not sizing the allocation from the key at all.

Reaching it needs `:only` or `:except` to be set, because that is the only time `oj_key_skip()` is called. It is called from `dump_compat.c`, `dump_object.c`, `dump_strict.c`, `custom.c` and `rails.c`, so every mode is affected.

## After

The lists are the keys joined with a `':'` and wrapped in one at each end, so a key is in a list when `":key:"` is in it. Looking for that in place finds what searching for the copy found:

```c
static bool key_listed(const char *list, const char *key, size_t klen) {
    const char *s;

    for (s = list; NULL != (s = strchr(s, ':')); s++) {
        if (0 == strncmp(s + 1, key, klen) && ':' == s[klen + 1]) {
            return true;
        }
    }
    return false;
}
```

`strncmp()` returning 0 means `s + 1` through `s + klen` matched the key, and the key holds no NUL, so `s[klen + 1]` is within the list. Nothing is sized by the key any more and there is no allocation at all.

Every size in the table above now returns, up to and including the 2 GB key, on the main thread and in a `Thread`.

## Output is unchanged

Dumping `{key => 1}` for every combination of 23 keys, 11 `:only` lists and 11 `:except` lists in `:strict`, `:null`, `:compat`, `:object`, `:custom` and `:rails`, 16560 in all, gives byte identical output before and after. The keys include symbols, strings, an empty string, non string keys, keys that are prefixes and suffixes of a listed key, and keys holding a `':'`, which is the one case where the two forms could have parted ways. An ASAN build reports nothing over the same 16560.

## Tests

`test/test_custom.rb` gets `test_only_and_except_with_a_long_key`, which dumps a 4 MB key with `:only` and with `:except` on a `Thread`. Before the change it does not fail, it errors with `SystemStackError`. Full `test/tests.rb` passes: 562 runs, 2467 assertions, 0 failures, 0 errors. `test/test_various.rb`, which holds the existing `:only` and `:except` tests, passes as well: 71 runs, 8213 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
