### PR TITLE
Fix the odd module match being decided by uninitialized memory

### DIFF
--- a/ext/oj/odd.c
+++ b/ext/oj/odd.c
@@ -166,7 +166,11 @@ Odd oj_get_oddc(const char *classname, size_t len) {
         if (len == odd->clen && 0 == strncmp(classname, odd->classname, len)) {
             return odd;
         }
-        if (odd->is_module && 0 == strncmp(odd->classname, classname, odd->clen) && ':' == classname[odd->clen]) {
+        // The module test needs a "::" after the module name, so the name has
+        // to be shorter than what it is compared against. Without that the
+        // comparison and the character after it both run past len.
+        if (odd->is_module && odd->clen < len && 0 == strncmp(odd->classname, classname, odd->clen) &&
+            ':' == classname[odd->clen]) {
             return odd;
         }
     }

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -5,6 +5,15 @@ $LOAD_PATH << __dir__
 
 require 'helper'
 
+# Registered as an odd class by test_odd_mod_shorter_than_the_module_name. It
+# has to be at the top level for its name to be short enough for a value that
+# is a prefix of it to fit in a document.
+module OddMod
+  def self.direct(h)
+    h
+  end
+end
+
 class ObjectJuice < Minitest::Test
   class Jeez
     attr_accessor :x, :y, :_z
@@ -1187,6 +1196,25 @@ class ObjectJuice < Minitest::Test
     assert_equal(%|{"^O":"ObjectJuice::Ichi::Ni::San::Shi","dump":{"a":1}}|, json)
     h = Oj.load(json, :mode => :object)
     assert_equal({'a' => 1}, h)
+  end
+
+  # oj_get_oddc() compared odd->clen bytes of the class name against the value
+  # and then looked at the byte after them, neither of which is bounded by the
+  # length it was given. An escaped value is decoded into a buffer on the stack,
+  # so the bytes after it are what the string before it left there, and a value
+  # of "M" was built as the registered module.
+  def test_odd_mod_shorter_than_the_module_name
+    Oj.register_odd(OddMod, OddMod, :direct, :dump)
+
+    # The first string is decoded into the buffer read_escaped_str() keeps on
+    # its stack, leaving "ddMod:" sitting where the second one, which decodes to
+    # a single "O", does not reach.
+    (0..200).each do |pad|
+      json = %([{"p":"O\\u0064dMod:#{'Z' * pad}"},{"^O":"\\u004f","dump":{"a":1}}])
+      obj = Oj.load(json, :mode => :object)
+
+      assert_equal({'^O' => 'O', 'dump' => {'a' => 1}}, obj[1], "padded with #{pad} bytes")
+    end
   end
 
   # oj_odd_set_arg() compared the key with strncmp(), which stops at the NUL the


### PR DESCRIPTION
`oj_get_oddc()` is handed a name and a length. Its module test uses neither of them as a bound:

```c
Odd oj_get_oddc(const char *classname, size_t len) {
    Odd odd;

    for (odd = odds; NULL != odd; odd = odd->next) {
        if (len == odd->clen && 0 == strncmp(classname, odd->classname, len)) {
            return odd;
        }
        if (odd->is_module && 0 == strncmp(odd->classname, classname, odd->clen) && ':' == classname[odd->clen]) {
            return odd;
        }
    }
    return NULL;
}
```

`odd->clen` is the length of the registered name, so when a registered module has a longer name than the value, the comparison and the `classname[odd->clen]` after it both run past the end of the value.

Its one caller is `hat_cstr()` (`object.c:224`), which passes the `^O` value of a document. Neither parser terminates that value: `read_str()` passes `pi->cur - str` with `pi->cur` on the closing quote (`parse.c:573`), and the sparse one passes `pi->rd.tail - pi->rd.str - 1` (`sparse.c:372`).

## What is past the end decides the match

This is not a read outside a buffer. A value parsed in place is followed by its own closing quote, and no module name can hold a `"`, so the comparison stops one byte past the value and nothing comes of it. An escaped value is decoded into a `struct _buf` whose `base` is a 1024 byte array on `read_escaped_str()`'s own stack, and the reads stay inside that array. ASAN reports nothing over 11104 documents covering module names of 3 to 4000 bytes against every prefix length, because the comparison stops at the first byte that does not match.

What it reads is memory that was never written for this value. Printing the bytes `oj_get_oddc()` compares, for a one character value with a module named `ObjectJuice::Ichi::Ni` registered:

```
name=ObjectJuice::Ichi::Ni clen=21 len=1 bytes=4f 62 6a 65 63 74 4a 75 58 90 40 f9 88 7f 00 00 ...
                                                O  b  j  e  c  t  J  u  <- left by the string before it
```

Only the first byte, `4f`, is the value. The next seven are what the previous decode left in the array, and the eight after those are a pointer.

## A document can put what it wants there

```ruby
module Mod
  def self.direct(h) = h
end
Oj.register_odd(Mod, Mod, :direct, :dump)

Oj.load(%([{"p":"Mod:ZZZ"},{"^O":"M","dump":{"a":1}}]), mode: :object)
```

With both strings escaped they go through `read_escaped_str()` at the same depth and get the same array. The first decodes to `Mod:ZZZ`, the second to `M`. `oj_get_oddc("M", 1)` then compares `Mod` against the `M` plus the `od` and the `:` still sitting behind it, and `Mod.direct` is called for a document that never names `Mod`.

Run over 401 paddings, that built `Mod` **4010 times out of 4010**. A single run in a fresh process does it only sometimes, which is what a decision taken on uninitialized memory looks like.

The reach is narrow. `is_module` is only set for something registered with `Oj.register_odd`, and none of the four built in odd classes is a module. What it gives a document is a choice of which registered odd class is built, with a value that does not name it.

## After

```c
// The module test needs a "::" after the module name, so the name has
// to be shorter than what it is compared against. Without that the
// comparison and the character after it both run past len.
if (odd->is_module && odd->clen < len && 0 == strncmp(odd->classname, classname, odd->clen) &&
    ':' == classname[odd->clen]) {
```

The test wants a `"::"` after the module name, so there has to be something after it. Requiring that keeps both reads inside the value.

The same loop now builds `Mod` 0 times out of 4010.

## Output is unchanged

Loading `{"^O":"<name>","dump":{"a":1},"a":1}` for 34 names against a registered module (`Ichi::Ni`) and a registered class (`Plain`), each name both plain and escaped, gives identical results before and after. The names cover every prefix of the module name, the name with one and with two trailing colons, `Ichi::Ni::San::Shi`, names one character longer or different, the four built in odd classes, and names that are only colons.

`Ichi::Ni::San::Shi` still resolves to the `Ichi::Ni` module, which is what `test_odd_mod` checks.

## Tests

`test/test_object.rb` gets `test_odd_mod_shorter_than_the_module_name`, which registers a top level `OddMod` and requires all 201 paddings of the document above to stay a plain Hash. Before the change it fails at 1 byte of padding. Full `test/tests.rb` passes: 562 runs, 2666 assertions, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
