### PR TITLE
Fix the claim that no methods are called on a loaded Object

### DIFF
--- a/pages/Security.md
+++ b/pages/Security.md
@@ -11,10 +11,24 @@ auto defined is used with an untrusted source. The `Oj.safe_load()` method
 sets and uses the most strict and safest options. It should be used by
 developers who find it difficult to understand the options available in Oj.
 
-The options in Oj are designed to provide flexibility to the developer. This
-flexibility allows Objects to be serialized and deserialized. No methods are
-ever called on these created Objects but that does not stop the developer from
-calling methods on them. As in any system, check your inputs before working with
-them. Taking an arbitrary `String` from a user and evaluating it is never a good
-idea from an unsecure source. The same is true for `Object` attributes as they
-are not more than `String`s. Always check inputs from untrusted sources.
+The options in Oj are designed to provide flexibility to the developer. This flexibility allows Objects to be serialized and deserialized. An Object is deserialized by allocating it without calling its initializer and then setting its instance variables. A few methods are called on what that builds: `exception` and `set_backtrace` on an `Exception`, and `replace` on a subclass of `Hash`, `Array` or `String` for a `self` key. As in any system, check your inputs before working with them. Taking an arbitrary `String` from a user and evaluating it is never a good idea from an unsecure source. The same is true for `Object` attributes as they are not more than `String`s. Always check inputs from untrusted sources.
+
+## The mode a document is loaded in
+
+`Oj.load()` uses the `:object` mode unless the mode is changed. That mode takes the class of an Object from the document, so the document decides which of the classes already loaded in the process is allocated and what its instance variables are. Classes are looked up and not created unless `:auto_define` is turned on.
+
+For a document from an untrusted source, ask for a mode that does not do that:
+
+```ruby
+Oj.load(json, mode: :strict)
+Oj.strict_load(json)
+Oj.safe_load(json)
+```
+
+or set it for the process:
+
+```ruby
+Oj.default_options = {mode: :strict}
+```
+
+`Oj.object_load()` is the explicit form of the current default and stays in `:object` mode whatever the default is set to.


### PR DESCRIPTION
`pages/Security.md` says

> No methods are ever called on these created Objects

Three are.

`oj_set_obj_ivar()` (`object.c:391`) calls `exception` and `set_backtrace` for the `~mesg` and `~bt` keys when what is being built is an `Exception`, and `hash_set_value()` and `hash_set_cstr()` call `replace` for a `self` key when it is a subclass of `Hash`, `Array` or `String`:

```ruby
Oj.load(%({"^o":"RuntimeError","~mesg":"pwned","~bt":["frame"]}))
# => #<RuntimeError: pwned>, backtrace ["frame"]

class SubString < String
  def replace(v) = super("replace called with #{v}")
end

Oj.load(%({"^o":"SubString","self":"x"}))
# => "replace called with x"
```

Both guards are narrow, and nothing else is called. An Object is allocated with `rb_obj_alloc()`, which does not run its initializer, and then its instance variables are set. So the point the paragraph is making still holds. It now says what does happen instead of claiming nothing does.

## The mode is worth saying out loud

The page did not say which mode `Oj.load()` uses. It uses `:object`, so the class of an Object comes from the document, which is the thing a reader arrives at this page wanting to know. A section now says so, notes that classes are looked up rather than created unless `:auto_define` is on, and lists the ways to ask for a mode that does not do it:

```ruby
Oj.load(json, mode: :strict)
Oj.strict_load(json)
Oj.safe_load(json)
```

```ruby
Oj.default_options = {mode: :strict}
```

and that `Oj.object_load()` stays in `:object` mode whatever that default is set to. Each of those was checked against `ce28234` rather than taken from the option docs.

Documentation only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
