### PR TITLE
Fix the custom mode dump of an unraised exception opening with "{,"

### DIFF
--- a/ext/oj/custom.c
+++ b/ext/oj/custom.c
@@ -640,7 +640,9 @@ static void dump_obj_attrs(VALUE obj, VALUE clas, slot_t id, int depth, Out out)
     if (rb_obj_is_kind_of(obj, rb_eException)) {
         volatile VALUE rv;
 
-        if (',' != *(out->cur - 1)) {
+        // An exception that was never raised has no instance variables, so
+        // without the class name nothing has been written since the '{'.
+        if (',' != *(out->cur - 1) && '{' != *(out->cur - 1)) {
             *out->cur++ = ',';
         }
         // message

--- a/test/test_custom.rb
+++ b/test/test_custom.rb
@@ -567,6 +567,21 @@ class CustomJuice < Minitest::Test
     assert_equal(%({"a":1}), Thread.new { Oj.dump(hash, :mode => :custom, :except => [key]) }.value)
   end
 
+  # An exception that was never raised has no instance variables, so with no
+  # class name written either there was nothing between the '{' and the comma
+  # that separates the attributes from the message.
+  def test_dump_exception_never_raised
+    assert_equal(%({"~mesg":"boom","~bt":null}), Oj.dump(StandardError.new('boom'), :mode => :custom))
+    assert_equal(%({"~mesg":"boom","~bt":null}), Oj.dump(Exception.new('boom'), :mode => :custom))
+
+    err = StandardError.new('boom')
+    err.instance_variable_set(:@a, 1)
+    assert_equal(%({"a":1,"~mesg":"boom","~bt":null}), Oj.dump(err, :mode => :custom))
+
+    json = Oj.dump(StandardError.new('boom'), :mode => :custom, :create_additions => true)
+    assert_equal(%({"json_class":"StandardError","~mesg":"boom","~bt":null}), json)
+  end
+
   def dump_and_load(obj, trace=false, options={})
     options = options.merge(:indent => 2, :mode => :custom)
     json = Oj.dump(obj, options)


### PR DESCRIPTION
```ruby
Oj.dump(StandardError.new('boom'), mode: :custom)
# => {,"~mesg":"boom","~bt":null}

JSON.parse(Oj.dump(StandardError.new('boom'), mode: :custom))
# => JSON::ParserError: expected object key, got ',"~mesg":"boom","~bt":null}'
```

`dump_obj_attrs()` writes the separator before an exception's `~mesg` with

```c
if (',' != *(out->cur - 1)) {
    *out->cur++ = ',';
}
```

so it also writes it when what came before is the `'{'` the object was opened with. An exception that was never raised has no instance variables, and the class name is only written when `:create_additions` is on, so in that case nothing has been written since the `'{'`.

`:indent` does not help, because the comma goes in before the newline:

```
{,
  "~mesg":"boom",
  "~bt":null
}
```

Reaching it needs nothing but `:mode => :custom` and an exception that has not been raised. A raised one carries `~bt_locations`, and one that was given an instance variable carries that, so either way something is written first and the output is fine.

## After

```c
// An exception that was never raised has no instance variables, so
// without the class name nothing has been written since the '{'.
if (',' != *(out->cur - 1) && '{' != *(out->cur - 1)) {
    *out->cur++ = ',';
}
```

```
{"~mesg":"boom","~bt":null}
```

## Nothing else changes

Dumping 19 objects in `:custom` mode under 12 option sets, 228 outputs in all, the only lines that differ are the 21 that opened with `{,`. The objects cover exceptions raised and not, with and without instance variables, the base `Exception`, exceptions inside an array and inside a hash, plus plain objects, an Enumerable, hashes, arrays, a Struct, a Range, a BigDecimal and a Date. The options cover three indents, four `:create_id` values, `:create_additions`, `:circular`, `:omit_nil` and the space separators.

The same shape is in `dump_object.c:548`, but object mode writes its `^o` before it, so there is nothing to fix there. Sweeping `:object`, `:custom`, `:compat`, `:rails` and `:null` for output `JSON.parse` rejects finds 21 combinations before this change and none after, all of them `:custom`. `:compat` and `:rails` dump an exception as its message.

## Tests

`test/test_custom.rb` gets `test_dump_exception_never_raised`, which pins the output for an exception that was never raised, for the base `Exception`, for one carrying an instance variable, and for `:create_additions`. Before the change it fails on the first. Full `test/tests.rb` passes: 562 runs, 2469 assertions, 0 failures, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
