### PR TITLE
Fix :float_format taking directives it has no argument for

### DIFF
--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -299,7 +299,8 @@ static VALUE only_array_from_string(const char *str) {
  *   floats, 0 indicates use Ruby
  * - *:float_format* [_String_] the C printf format string for printing floats.
  *   Default follows the float_precision and will be changed if float_precision is
- *   changed. The string can be no more than 6 bytes.
+ *   changed. The string can be no more than 6 bytes and can hold at most one
+ *   directive, which must be one of aAeEfgG and take no argument of its own.
  * - *:use_to_json* [_Boolean_|_nil_] call to_json() methods on dump, default is false
  * - *:use_as_json* [_Boolean_|_nil_] call as_json() methods on dump, default is false
  * - *:use_raw_json* [_Boolean_|_nil_] call raw_json() methods on dump, default is false
@@ -574,7 +575,8 @@ static VALUE get_def_opts(VALUE self) {
  *     when dumping the seconds portion of time.
  *   - *:float_format* [_String_] the C printf format string for printing floats.
  *     Default follows the float_precision and will be changed if float_precision
- *     is changed. The string can be no more than 6 bytes.
+ *     is changed. The string can be no more than 6 bytes and can hold at most one
+ *     directive, which must be one of aAeEfgG and take no argument of its own.
  *   - *:float_precision* [_Fixnum_|_nil_] number of digits of precision when dumping floats, 0 indicates use Ruby.
  *   - *:use_to_json* [_Boolean_|_nil_] call to_json() methods on dump, default is false.
  *   - *:use_as_json* [_Boolean_|_nil_] call as_json() methods on dump, default is false.
@@ -703,6 +705,46 @@ bool set_yesno_options(VALUE key, VALUE value, Options copts) {
         }
     }
     return false;
+}
+
+inline static bool in_set(const char *set, char c) {
+    return '\0' != c && NULL != strchr(set, c);
+}
+
+// The format is used with one double and nothing else, so a directive that
+// asks for anything more takes it from whatever is left in the argument
+// registers. %s reads it as a pointer and %n writes through it.
+static void validate_float_format(const char *str, size_t len) {
+    const char *s   = str;
+    const char *end = str + len;
+    int         cnt = 0;
+
+    for (; s < end; s++) {
+        if ('%' != *s) {
+            continue;
+        }
+        s++;
+        if (s < end && '%' == *s) {
+            continue;
+        }
+        if (1 < ++cnt) {
+            rb_raise(rb_eArgError, ":float_format must not have more than one directive.");
+        }
+        for (; s < end && in_set("-+ #0", *s); s++) {
+        }
+        for (; s < end && '0' <= *s && *s <= '9'; s++) {
+        }
+        if (s < end && '.' == *s) {
+            for (s++; s < end && '0' <= *s && *s <= '9'; s++) {
+            }
+        }
+        if (s < end && 'l' == *s) {
+            s++;
+        }
+        if (end <= s || !in_set("aAeEfgG", *s)) {
+            rb_raise(rb_eArgError, ":float_format directive must be one of aAeEfgG and take no argument of its own.");
+        }
+    }
 }
 
 static const char *make_only_value(VALUE v) {
@@ -1176,6 +1218,7 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
         if (6 < RSTRING_LEN(v)) {
             rb_raise(rb_eArgError, ":float_format must be 6 bytes or less.");
         }
+        validate_float_format(RSTRING_PTR(v), (size_t)RSTRING_LEN(v));
         strncpy(copts->float_fmt, RSTRING_PTR(v), (size_t)RSTRING_LEN(v));
         copts->float_fmt[RSTRING_LEN(v)] = '\0';
     } else if (only_sym == k) {

--- a/test/test_strict.rb
+++ b/test/test_strict.rb
@@ -466,6 +466,33 @@ class StrictJuice < Minitest::Test
     end
   end
 
+  # The format is handed to snprintf() with one double and nothing else, so a
+  # directive asking for anything more took it from whatever was left in the
+  # argument registers. %s read it as a pointer, %n wrote through it, and %p
+  # and %x printed it.
+  def test_float_format_directives
+    ['%0.15g', '%.3f', '%e', '%E', '%g', '%G', '%a', '%A', '%lf', '%+f', '% f', '%#f',
+     '%-9f', '%09f', '%.f', '%99f', '%9999f', 'x%fy', '%f%%', '%%f', '', 'plain'].each do |fmt|
+      Oj.dump(1.5, :mode => :strict, :float_format => fmt)
+    end
+
+    ['%s', '%n', '%p', '%d', '%i', '%x', '%c', '%hn', '%Lf', '%1$f', '%*f', '%f%f', '%', "%\0f"].each do |fmt|
+      assert_raises(ArgumentError, fmt) { Oj.dump(1.5, :mode => :strict, :float_format => fmt) }
+    end
+  end
+
+  # :float_precision of 0 leaves :float_format empty, and Oj.default_options is
+  # commonly saved and put back.
+  def test_float_format_default_options_round_trip
+    Oj.default_options = {:float_precision => 0}
+    assert_equal('', Oj.default_options[:float_format])
+    Oj.default_options = Oj.default_options
+
+    Oj.default_options = {:float_precision => 16}
+    assert_equal('%0.16g', Oj.default_options[:float_format])
+    Oj.default_options = Oj.default_options
+  end
+
   def dump_and_load(obj, trace=false)
     json = Oj.dump(obj, :indent => 2)
     puts json if trace


### PR DESCRIPTION
The string set with `:float_format` is handed to `snprintf()` with one double and nothing else:

```c
size_t oj_dump_float_printf(char *buf, size_t blen, VALUE obj, double d, const char *format) {
    size_t cnt = snprintf(buf, blen, format, d);
```

A directive that wants anything more takes it from whatever is left in the argument registers. Only the length was checked, so on `ce28234`:

```ruby
Oj.dump(1.5, mode: :strict, float_format: '%p')   # => "0x7ffe5ed2902d"
Oj.dump(1.5, mode: :strict, float_format: '%x')   # => "e404bc6d"
Oj.dump(1.5, mode: :strict, float_format: '%d')   # => "1094399341"
Oj.dump(1.5, mode: :strict, float_format: '%s')   # reads it as a char *
Oj.dump(1.5, mode: :strict, float_format: '%n')   # writes through it
```

`%n` is not caught by the glibc check for it, because that only fires when the format itself is in writable memory, and this one is a `char[7]` in the options. `%f%f` and `%*f` reach past the one argument the same way, and `%Lf` reads it as a wider type and gives `nan`.

`:float_format` is settable from a per call option Hash, from `Oj.default_options=` and from the options of an `Oj::StringWriter` or an `Oj::StreamWriter`. `:strict`, `:null`, `:object` and `:custom` use it; `:compat` and `:rails` do not.

## After

The format is checked where it is set. It may hold at most one directive, and that one has to be a conversion `snprintf()` will take the double for:

```
%[-+ #0][width][.precision][l][aAeEfgG]
```

`%%` and text around a directive are still fine, and so is a format with no directive at all.

That last part matters more than it looks. `:float_precision => 0` leaves `:float_format` empty, and `Oj.default_options` is commonly saved and put back, including by the setup and teardown of Oj's own tests, so an empty format has to keep being accepted.

## What still works and what does not

Checked against `ce28234` and this branch, dumping `1.5` in `:strict` mode:

| format | before | after |
| --- | --- | --- |
| `%0.15g` | `1.5` | `1.5` |
| `%.3f` | `1.500` | `1.500` |
| `%e` `%E` | `1.500000e+00` | same |
| `%g` `%G` `%a` `%A` | `1.5`, `0x1.8p+0` | same |
| `%lf` `%+f` `% f` `%#f` `%-9f` `%09f` `%.f` | as printf | same |
| `%99f` `%9999f` | padded, clamped to the buffer | same |
| `x%fy` `%f%%` `%%f` | `x1.500000y`, `1.500000%`, `%f` | same |
| `''` `plain` | `''`, `plain` | same |
| `%s` | reads a register as a `char *` | `ArgumentError` |
| `%n` | writes through a register | `ArgumentError` |
| `%p` | `0x7ffe5ed2902d` | `ArgumentError` |
| `%d` `%i` `%x` `%c` | register contents | `ArgumentError` |
| `%hn` `%Lf` `%1$f` `%*f` `%f%f` `%` | garbage or worse | `ArgumentError` |

Nothing that could produce a number stopped working. Everything that stopped working could not produce one.

This does narrow what the option accepts, and the RDoc for it says "the C printf format string for printing floats", so it is a visible change. The two RDoc comments now say the rest of the sentence: at most one directive, one of `aAeEfgG`, taking no argument of its own.

## Tests

`test/test_strict.rb` gets `test_float_format_directives`, which requires all 22 formats in the top half of the table to be accepted and all 14 in the bottom half to raise, and `test_float_format_default_options_round_trip`, which covers the empty format that `:float_precision => 0` leaves. Before the change the first fails on `%s`.

Full `test/tests.rb` passes: 563 runs, 2481 assertions, 0 failures, 0 errors. `test/test_various.rb` and `test/test_writer.rb`, which are where the existing `:float_format` uses live, pass as well.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
