### PR TITLE
Fix memory leak of the parser create_id when it is set again

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -29,10 +29,13 @@ if RUBY_PLATFORM.include?('linux')
     # test_*.rb files mutate global state (Oj.default_options, mimic_JSON, ...)
     # or fork, and upstream runs those in their own processes. Mirror the
     # tests.rb set here, minus test_scp which forks and talks over a socket.
+    # test_parser_usual is not in tests.rb but coexists with the rest and is
+    # the only coverage of the Oj::Parser options.
     memcheck_test_files = %w[
       test_compat test_custom test_fast test_file test_gc test_hash
       test_integer_range test_long_strings test_max_integer_digits test_null
-      test_object test_rails test_saj test_strict test_wab test_writer
+      test_object test_parser_usual test_rails test_saj test_strict test_wab
+      test_writer
     ].map { |name| "test/#{name}.rb" }
 
     namespace :test do

--- a/ext/oj/usual.c
+++ b/ext/oj/usual.c
@@ -831,6 +831,7 @@ static VALUE opt_create_id_set(ojParser p, VALUE value) {
     Usual d = (Usual)p->ctx;
 
     if (Qnil == value) {
+        OJ_R_FREE(d->create_id);
         d->create_id                 = NULL;
         d->create_id_len             = 0;
         p->funcs[OBJECT_FUN].add_str = add_str_key;
@@ -850,12 +851,15 @@ static VALUE opt_create_id_set(ojParser p, VALUE value) {
         if (1 << (8 * sizeof(d->create_id_len)) <= len) {
             rb_raise(rb_eArgError, "The create_id values is limited to %d bytes.", 1 << (8 * sizeof(d->create_id_len)));
         }
-        d->create_id_len                  = (uint8_t)len;
+        char *prev = d->create_id;
+
         d->create_id                      = str_dup(RSTRING_PTR(value), len);
+        d->create_id_len                  = (uint8_t)len;
         p->funcs[OBJECT_FUN].add_str      = add_str_key_create;
         p->funcs[TOP_FUN].close_object    = close_object_create;
         p->funcs[ARRAY_FUN].close_object  = close_object_create;
         p->funcs[OBJECT_FUN].close_object = close_object_create;
+        OJ_R_FREE(prev);
     }
     return opt_create_id(p, value);
 }

--- a/test/test_parser_usual.rb
+++ b/test/test_parser_usual.rb
@@ -289,6 +289,25 @@ class UsualTest < Minitest::Test
     assert_equal('UsualTest::MyClass{a: true b: false}', doc.to_s)
   end
 
+  # The delegate keeps its own copy of create_id, and setting it again replaced
+  # that copy without freeing the previous one. Setting it to nil dropped it as
+  # well. rake test:valgrind is what catches the leak.
+  def test_create_id_set_again
+    p = Oj::Parser.new(:usual)
+
+    100.times do |i|
+      p.create_id = "id#{i}"
+      assert_equal("id#{i}", p.create_id)
+
+      p.create_id = nil
+      assert_nil(p.create_id)
+    end
+
+    p.create_id = '^'
+    doc = p.parse('{"a":true,"^":"UsualTest::MyClass","b":false}')
+    assert_equal('UsualTest::MyClass{a: true b: false}', doc.to_s)
+  end
+
   def test_missing_class
     p = Oj::Parser.new(:usual, create_id: '^')
     json = '{"a":true,"^":"Auto","b":false}'


### PR DESCRIPTION
## What it is

The usual delegate keeps its own copy of `create_id`, and `opt_create_id_set` (`ext/oj/usual.c`) replaced that copy without freeing the previous one:

```c
d->create_id_len = (uint8_t)len;
d->create_id     = str_dup(RSTRING_PTR(value), len);
```

`str_dup` is `OJ_R_ALLOC_N(char, len + 1)`, so every set after the first loses `len + 1` bytes. Setting `create_id` to nil drops the copy the same way, since that branch only assigns `NULL`. The one free that does exist is in the delegate's cleanup (`usual.c:628`), so a parser that is used for the life of the process never gives the earlier values back.

Both `parser.create_id = value` and the `create_id:` entry of an option Hash land here, the latter through `parser_missing` (`ext/oj/parser.c:1423`).

## Measured

Setting a 9 byte value 1000 times on one parser, and setting a 9 byte value then nil 1000 times, under `valgrind --leak-check=full --show-leak-kinds=definite`:

| | before | after |
| --- | --- | --- |
| `p.create_id = format('%09d', i)` × 1000 | 9,990 bytes in 999 blocks definitely lost | none |
| `p.create_id = ...; p.create_id = nil` × 1000 | 10,000 bytes in 1,000 blocks definitely lost | none |

The leaked blocks are reported at `str_dup (usual.c:39)` under `opt_create_id_set`, one per set, exactly `len + 1` bytes each. The last value set is not among them because the delegate's cleanup frees it.

## The fix

Free the previous copy in both branches. In the branch that allocates, the previous pointer is kept until the new copy exists so that a raise from the allocation cannot leave `create_id` dangling, and `create_id_len` is assigned after the copy so that the two never disagree. The length check still runs before anything is freed.

## Test

`test/test_parser_usual.rb` gets `test_create_id_set_again`, which alternates a value and nil 100 times on one parser and checks the reported value each time, then parses with the last value set to show the surviving copy is the live one. A leak is not visible from Ruby, so what catches it is `rake test:valgrind`.

That lane did not run this file before. `test/test_parser_usual.rb` is not part of `test/tests.rb`, which the memcheck list mirrors, and it is the only coverage of the `Oj::Parser` options, so it is added to the list. Run on that one file, the new test reports `492 bytes in 101 blocks are definitely lost` before the fix and nothing after it. The whole lane with the file included is `555 runs, 2930 assertions, 0 failures` and no Valgrind errors.

## Notes

Found while widening the set of test files that `rake` runs (#1084). This is not the `create_id` defect fixed in #1074: that one is `parse_options_cb` in `oj.c` freeing the global default's buffer and leaving it dangling for the next call, on the `Oj.dump` side. This one is the parser delegate never freeing at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
