### PR TITLE
Add a job timeout to the workflows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,6 +49,7 @@ jobs:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
       MAKE: make -j 2
     runs-on: ${{ matrix.os }}-latest
+    timeout-minutes: 30
     continue-on-error: ${{ matrix.ruby == 'head'}}
     name: Ruby ${{ matrix.ruby }} (${{ matrix.os }}${{ matrix.gemfile != 'no_rails' && ', ' || '' }}${{ matrix.gemfile != 'no_rails' && matrix.gemfile || '' }})
     steps:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -22,6 +22,7 @@ jobs:
     name: Formatting Check
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     steps:
     - uses: actions/checkout@v7

--- a/.github/workflows/valgrind.yml
+++ b/.github/workflows/valgrind.yml
@@ -13,6 +13,7 @@ jobs:
   valgrind:
     name: memcheck (ubuntu, ruby ${{ matrix.ruby }})
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Without `timeout-minutes` a job that stops making progress runs until the GitHub default of **6 hours** before it is cut off, holding a runner the whole time and giving no signal that anything is wrong.

30 minutes leaves room for a slow runner while still catching a job that is stuck. Recent runs finish well inside it:

| job | longest recent run |
|---|---|
| `Build` (Windows, the slowest of the matrix) | 2m45s |
| `memcheck (ubuntu, ruby 4.0)` | 6m06s |
| `Formatting Check` | 13s |

The value is on the job rather than on a step so that it covers the whole job, including `bundle install` and the extension build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
