### PR TITLE
Fix the wab mode time load being an offset out on Windows

### DIFF
--- a/ext/oj/util.c
+++ b/ext/oj/util.c
@@ -134,3 +134,30 @@ void sec_as_time(int64_t secs, TimeInfo ti) {
     secs     = secs - (int64_t)ti->min * 60LL;
     ti->sec  = (int)secs;
 }
+
+// The inverse of sec_as_time(). The days are counted with the civil calendar
+// algorithm from Howard Hinnant's date library so that no libc call is needed.
+// timegm() is not available on Windows and the mktime() based replacement that
+// was used there returned the wrong value in any timezone east of UTC.
+int64_t time_as_sec(TimeInfo ti) {
+    int64_t year = (int64_t)ti->year;
+    int64_t mon  = (int64_t)ti->mon;
+    int64_t era;
+    int64_t yoe;   // year of the era, [0, 399]
+    int64_t doy;   // day of the year, [0, 365]
+    int64_t doe;   // day of the era, [0, 146096]
+    int64_t days;  // days since 1970-01-01
+
+    // Start the year on March 1st so that a leap day falls on the last day of
+    // the year and the day of the year is a simple expression.
+    if (mon <= 2) {
+        year--;
+    }
+    era  = (0 <= year ? year : year - 399) / 400;
+    yoe  = year - era * 400;
+    doy  = (153 * (mon + (2 < mon ? -3 : 9)) + 2) / 5 + (int64_t)ti->day - 1;
+    doe  = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    days = era * 146097 + doe - 719468;
+
+    return days * SECS_PER_DAY + (int64_t)ti->hour * 3600LL + (int64_t)ti->min * 60LL + (int64_t)ti->sec;
+}

--- a/ext/oj/util.h
+++ b/ext/oj/util.h
@@ -15,6 +15,7 @@ typedef struct _timeInfo {
     int year;
 }* TimeInfo;
 
-extern void sec_as_time(int64_t secs, TimeInfo ti);
+extern void    sec_as_time(int64_t secs, TimeInfo ti);
+extern int64_t time_as_sec(TimeInfo ti);
 
 #endif /* OJ_UTIL_H */

--- a/ext/oj/wab.c
+++ b/ext/oj/wab.c
@@ -375,44 +375,41 @@ static const char *read_num(const char *s, int len, int *vp) {
 }
 
 static VALUE time_parse(const char *s, int len) {
-    struct tm tm;
-    bool      neg   = false;
-    long      nsecs = 0;
-    int       i;
-    time_t    secs;
+    struct _timeInfo ti;
+    bool             neg   = false;
+    long             nsecs = 0;
+    int              i;
 
-    memset(&tm, 0, sizeof(tm));
+    memset(&ti, 0, sizeof(ti));
     if ('-' == *s) {
         s++;
         neg = true;
     }
-    if (NULL == (s = read_num(s, 4, &tm.tm_year))) {
+    if (NULL == (s = read_num(s, 4, &ti.year))) {
         return Qnil;
     }
     if (neg) {
-        tm.tm_year = -tm.tm_year;
-        neg        = false;
+        ti.year = -ti.year;
+        neg     = false;
     }
-    tm.tm_year -= 1900;
     s++;
-    if (NULL == (s = read_num(s, 2, &tm.tm_mon))) {
-        return Qnil;
-    }
-    tm.tm_mon--;
-    s++;
-    if (NULL == (s = read_num(s, 2, &tm.tm_mday))) {
+    if (NULL == (s = read_num(s, 2, &ti.mon))) {
         return Qnil;
     }
     s++;
-    if (NULL == (s = read_num(s, 2, &tm.tm_hour))) {
+    if (NULL == (s = read_num(s, 2, &ti.day))) {
         return Qnil;
     }
     s++;
-    if (NULL == (s = read_num(s, 2, &tm.tm_min))) {
+    if (NULL == (s = read_num(s, 2, &ti.hour))) {
         return Qnil;
     }
     s++;
-    if (NULL == (s = read_num(s, 2, &tm.tm_sec))) {
+    if (NULL == (s = read_num(s, 2, &ti.min))) {
+        return Qnil;
+    }
+    s++;
+    if (NULL == (s = read_num(s, 2, &ti.sec))) {
         return Qnil;
     }
     s++;
@@ -424,16 +421,7 @@ static VALUE time_parse(const char *s, int len) {
             return Qnil;
         }
     }
-#if IS_WINDOWS
-    secs = (time_t)mktime(&tm);
-    memset(&tm, 0, sizeof(tm));
-    tm.tm_year = 70;
-    tm.tm_mday = 1;
-    secs -= (time_t)mktime(&tm);
-#else
-    secs = (time_t)timegm(&tm);
-#endif
-    return rb_funcall(rb_time_nano_new(secs, nsecs), oj_utc_id, 0);
+    return rb_funcall(rb_time_nano_new((time_t)time_as_sec(&ti), nsecs), oj_utc_id, 0);
 }
 
 static VALUE protect_uri(VALUE rstr) {

--- a/test/test_wab.rb
+++ b/test/test_wab.rb
@@ -216,6 +216,20 @@ class WabJuice < Minitest::Test
     assert_equal(json, Oj.dump(loaded, mode: :wab), 'json mismatch after load')
   end
 
+  def test_time_before_epoch
+    # Loading used to go through a mktime() based replacement for timegm() on
+    # Windows. That replacement returned -1 for any time before the epoch no
+    # matter what the timezone was, so these fail on Windows without the fix
+    # even when the machine is set to UTC.
+    [Time.gm(1969, 7, 20, 20, 17, 40),
+     Time.gm(1900, 1, 1, 0, 0, 0),
+     Time.gm(1, 1, 1, 0, 0, 0)].each do |t|
+      json = Oj.dump(t, mode: :wab)
+      loaded = Oj.wab_load(json)
+      assert_equal(json, Oj.dump(loaded, mode: :wab), 'json mismatch after load')
+    end
+  end
+
   def test_uuid
     u = ::WAB::UUID.new('123e4567-e89b-12d3-a456-426655440000')
     json = Oj.dump(u, mode: :wab)


### PR DESCRIPTION
In `:wab` mode `Oj.wab_load` returns the wrong time on Windows in any timezone
east of UTC. On a machine set to JST the existing `test_wab.rb` test fails:

```
1) Failure:
WabJuice#test_time [test/test_wab.rb:216]:
json mismatch after load.
--- expected
+++ actual
@@ -1 +1 @@
-"\"2017-01-05T23:58:07.123456789Z\""
+"\"2017-01-05T14:58:08.123456789Z\""
```

```ruby
t = Time.gm(2017, 1, 5, 23, 58, 7, 123_456.789)
j = Oj.dump(t, mode: :wab)     #=> "2017-01-05T23:58:07.123456789Z"   dump is fine
Oj.wab_load(j)                 #=> 2017-01-05 14:58:08.123456789 UTC  load is not
```

The result is out by 9 hours (the JST offset) and by 1 second. Dumping goes
through `sec_as_time()` and does not depend on the timezone, so only loading is
affected. CI runs in UTC where the offset is zero, which is why this was never
caught.

## Cause

`ext/oj/wab.c` stood in for `timegm()`, which Windows does not have, with
`mktime()`:

```c
#if IS_WINDOWS
    secs = (time_t)mktime(&tm);
    memset(&tm, 0, sizeof(tm));
    tm.tm_year = 70;
    tm.tm_mday = 1;
    secs -= (time_t)mktime(&tm);
#else
    secs = (time_t)timegm(&tm);
#endif
```

`mktime()` reads the `struct tm` as local time, so the epoch expressed in local
time is subtracted to cancel the offset out. That relies on `mktime()` returning
the offset for 1970-01-01 00:00 local, but the Microsoft CRT returns -1 for any
time before the epoch. East of UTC the local 1970-01-01 00:00 is itself before
the epoch, so the correction term becomes `-(-1)`, that is +1 second, and the
offset is never cancelled at all.

Measured on Windows 11, machine set to JST:

```
mktime(1970-01-01 00:00 local)    = -1            (a POSIX mktime returns -32400)
mktime(2017-01-05 23:58:07 local) = 1483628287

1483628287 - (-1)     = 1483628288 = 2017-01-05T14:58:08Z   what was returned
1483628287 - (-32400) = 1483660687 = 2017-01-05T23:58:07Z   correct
```

Both the 9 hour shift and the 1 second shift come out of that single line.

| local timezone | `mktime(1970-01-01 00:00 local)` | result |
| --- | --- | --- |
| east of UTC (JST, CET, ...) | -1, an error, as it is before the epoch | broken |
| UTC | 0 | correct |
| west of UTC (EST, ...) | positive, 18000 for EST | correct |

The same expression has a second problem that does not depend on the timezone.
`mktime()` also returns -1 for the date being parsed whenever that date is
before the epoch, so every pre-1970 time loaded wrong on Windows in every
timezone, including UTC:

```
TZ=UTC0  "1900-01-01T00:00:00.000000000Z" -> "1969-12-31T23:59:59.000000000Z"
TZ=UTC0  "1969-07-20T20:17:40.000000000Z" -> "1969-12-31T23:59:59.000000000Z"
JST      "1900-01-01T00:00:00.000000000Z" -> "1970-01-01T00:00:00.000000000Z"
JST      "1969-07-20T20:17:40.000000000Z" -> "1970-01-01T00:00:00.000000000Z"
```

## Fix

`_mkgmtime()` is available on Windows and is a one line replacement, but it also
returns -1 before the epoch, so it would fix the offset while leaving Windows
disagreeing with Linux for pre-1970 times. The days are computed directly
instead, which lets the `#if IS_WINDOWS` branch go away entirely so that both
platforms run the same code and this class of difference cannot come back.

`time_as_sec()` is added to `util.c` alongside `sec_as_time()`, which is its
inverse and is already what the dump side of `wab.c` uses.

## Verification

Windows 11, Ruby 3.3.12 (x64-mingw-ucrt), machine set to JST.

- `test/test_wab.rb` passes in JST and under `TZ=UTC0`; the full `rake test` run
  is clean.
- Round trips were compared against `Time.gm`, which has `timegm()` semantics
  and does not depend on the platform, over 562,177 dates: every day from 1600
  to 2400, the first and last day of every month for years 1 through 9999, the
  February 28 / February 29 / March 1 boundary for every year, and the epoch,
  2038, year 1 and year 9999 edges. All of them match, so the non-Windows
  behaviour is unchanged.
- Times before the epoch now round trip and agree with Linux:

```
"1969-07-20T20:17:40.000000000Z" -> "1969-07-20T20:17:40.000000000Z"
"1900-01-01T00:00:00.000000000Z" -> "1900-01-01T00:00:00.000000000Z"
"0001-01-01T00:00:00.000000000Z" -> "0001-01-01T00:00:00.000000000Z"
```

For a malformed string with an out of range field the value still normalizes
exactly the way `timegm()` did for the day, hour, minute and second, and for
months 0 through 14. Months of 15 and over differ, for example
`"2017-99-05T..."` now gives 2025-03-21 where it used to give 2025-03-05. Both
are meaningless values for a meaningless input.

## About the test

`test_time_before_epoch` is added rather than a test that switches the
timezone. Setting `ENV['TZ']` from Ruby does not reach the CRT, which caches the
zone until `_tzset()` is called: with the unfixed extension launched under
`TZ=UTC0`, setting `ENV['TZ'] = 'JST-9'` and then loading still produced the
correct 2017 value, so a test written that way would pass either way.

A time before the epoch needs no timezone manipulation because it is wrong on
Windows in every zone, so it catches this on the Windows CI lane as it is.
Against the unfixed extension under `TZ=UTC0`, `test_time` passes and
`test_time_before_epoch` fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
