### PR TITLE
Fix Oj::Doc dropping the exponent of a number with no decimal point

### DIFF
--- a/ext/oj/fast.c
+++ b/ext/oj/fast.c
@@ -498,6 +498,10 @@ static Leaf read_num(ParseInfo pi) {
         }
     }
     if ('e' == *pi->s || 'E' == *pi->s) {
+        // An exponent makes it a float whether or not a '.' was seen. Without
+        // this leaf_fixnum_value() stops reading at the 'e' and the exponent is
+        // dropped.
+        type = T_FLOAT;
         pi->s++;
         if ('-' == *pi->s || '+' == *pi->s) {
             pi->s++;

--- a/test/test_fast.rb
+++ b/test/test_fast.rb
@@ -112,6 +112,32 @@ class DocTest < Minitest::Test
     end
   end
 
+  # read_num() only made a leaf a float when it saw a '.', so an exponent on an
+  # integer mantissa was left to leaf_fixnum_value(), which stops reading at the
+  # 'e' and dropped it.
+  def test_exponent_on_an_integer_mantissa
+    [['1e5', 100_000.0], ['1E5', 100_000.0], ['1e+5', 100_000.0], ['1e-5', 0.000_01],
+     ['-1e5', -100_000.0], ['0e0', 0.0], ['12e2', 1200.0], ['1e0', 1.0]].each do |json, expected|
+      Oj::Doc.open(json) do |doc|
+        assert_equal(Float, doc.type, json)
+        assert_in_delta(expected, doc.fetch, expected.abs / 1_000_000_000.0, json)
+      end
+      assert_in_delta(expected, Oj::Doc.open("[#{json}]") { |doc| doc.fetch }.first, expected.abs / 1_000_000_000.0, json)
+    end
+
+    assert_predicate(Oj::Doc.open('1e400') { |doc| doc.fetch }, :infinite?)
+    assert_in_delta(0.0, Oj::Doc.open('1e-400') { |doc| doc.fetch })
+  end
+
+  # An exponent with no digits is not a number. Before it was taken as a fixnum
+  # that ended at the 'e'.
+  def test_exponent_without_digits
+    ['1e', '1E', '1e+', '1e-'].each do |json|
+      assert_raises(Oj::ParseError, json) { Oj::Doc.open(json) { |doc| doc.fetch } }
+      assert_raises(Oj::ParseError, json) { Oj::Doc.open("[#{json}]") { |doc| doc.fetch } }
+    end
+  end
+
   # read_num() took any token that started like a number, and
   # leaf_float_value() handed what it collected to rb_cstr_to_dbl().
   def test_malformed_number


### PR DESCRIPTION
This is the last defect I currently know of, so this should be the end of the run of fixes.

## What it is

`read_num` (`ext/oj/fast.c`) only makes a leaf a float when it sees a `.`, so a number written with an exponent but an integer mantissa stays a fixnum. `leaf_fixnum_value` then stops reading at the `e` and the exponent is gone. There is no exception and no warning, just the wrong number:

```ruby
Oj::Doc.open('[1e5]') { |doc| doc.fetch }   # => [1]
Oj.load('[1e5]')                            # => [100000.0]
```

`1.5e3` is right because of the `.`; `12e2`, `1E5`, `1e+5`, `1e-5`, `-1e5` and `0e0` are all wrong.

The same gap makes an exponent with no digits pass. `1e` and `1e+` were read as the fixnum `1` and the rest thrown away, where `Oj.load` rejects them.

## The fix

Set the leaf type to float when the exponent is read, not only when a `.` is seen. The check that `read_num` already does for floats then covers the digitless exponent as well, so `1e` raises `Oj::ParseError` like the other malformed numbers do.

## What changes

Every case that was wrong now matches `Oj.load`:

| document | before | after | `Oj.load` |
| --- | --- | --- | --- |
| `[1e5]` | `[1]` | `[100000.0]` | `[100000.0]` |
| `[1E5]` | `[1]` | `[100000.0]` | `[100000.0]` |
| `[1e+5]` | `[1]` | `[100000.0]` | `[100000.0]` |
| `[1e-5]` | `[1]` | `[1.0e-05]` | `[1.0e-05]` |
| `[-1e5]` | `[-1]` | `[-100000.0]` | `[-100000.0]` |
| `[0e0]` | `[0]` | `[0.0]` | `[0.0]` |
| `[12e2]` | `[12]` | `[1200.0]` | `[1200.0]` |
| `[1e400]` | `[1]` | `[Infinity]` | `[Infinity]` |
| `[1e]` | `[1]` | `Oj::ParseError` | `Oj::ParseError` |
| `[1e+]` | `[1]` | `Oj::ParseError` | `Oj::ParseError` |
| `[1.5e3]` | `[1500.0]` | `[1500.0]` | `[1500.0]` |
| `[123]` | `[123]` | `[123]` | `[123]` |

`Oj::Doc#type` reports `Float` rather than `Integer` for these, which is what the value now is. `Oj::Doc#dump` is unaffected: it writes the text of the document.

Sweeping every token of four characters or less over `0 1 . e E + -`, at the top level and inside an array and an object, is 8,400 documents. 998 of them change: 832 from a value to `Oj::ParseError` (the digitless exponents, which `Oj.load` also rejects) and 166 from one value to another (the dropped exponents). Nothing that used to be rejected is now accepted.

After the fix `Oj::Doc` and `Oj.load` agree on accepting or rejecting 5,596 of the 5,600 nested cases in that sweep. The four left are `[+.]` and `[-.]` in an array and an object, which `Oj.load` takes as `0` and `Oj::Doc` rejects. That difference came from #1077 and is not touched here.

## What is still different

`Oj::Doc` has no BigDecimal path: `leaf_float_value` hands the text to `rb_cstr_to_dbl`, so the result is always a Float. `Oj.load` switches to BigDecimal for values a double cannot hold, so `[10000000000000000000e2]` is `[1.0e+21]` from `Oj::Doc` and `[0.1e22]` from `Oj.load`. That is not new and not specific to exponents — `[123456789012345678901234567890.0]` differs the same way today. This PR only stops the exponent from being dropped; it moves those numbers onto the float path `Oj::Doc` already has.

## Tests

`test/test_fast.rb` gets `test_exponent_on_an_integer_mantissa` (eight forms, checked at the top level and in an array, plus the overflow and underflow ends) and `test_exponent_without_digits`. Both fail before the fix and pass after.

`rake test` is green, and so is `rake test:valgrind`.

## Notes

Found while building the behaviour matrix for #1077. Reported there as the part that returns a wrong value rather than taking the process down, which is why it was left for its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
