### PR TITLE
Fix the pre-1970 time tests being skipped on Windows for a limit that no longer applies

### DIFF
--- a/test/test_file.rb
+++ b/test/test_file.rb
@@ -125,8 +125,6 @@ class FileJuice < Minitest::Test
   end
 
   def test_time_object_early
-    skip 'Windows does not support dates before 1970.' if RbConfig::CONFIG['host_os'] =~ /(mingw|mswin)/
-
     t = Time.xmlschema('1954-01-05T00:00:00.123456')
     Oj.default_options = { :mode => :object, :time_format => :unix_zone }
     dump_and_load(t, false)

--- a/test/test_object.rb
+++ b/test/test_object.rb
@@ -598,9 +598,6 @@ class ObjectJuice < Minitest::Test
   end
 
   def test_time_early
-    # Windows does not support dates before 1970.
-    return if RbConfig::CONFIG['host_os'] =~ /(mingw|mswin)/
-
     t = Time.new(1954, 1, 5, 21, 37, 7.123456789, -8 * 3600)
     # The fractional seconds are not always recreated exactly which causes a
     # mismatch so instead the seconds, nsecs, and gmt_offset are checked


### PR DESCRIPTION
`test_object.rb`'s `test_time_early` returned early and `test_file.rb`'s `test_time_object_early` skipped, both saying "Windows does not support dates before 1970." The skip in `test_file.rb` came in with b8ac875 in 2017, when Appveyor built against a 32 bit Ruby.

The limit was `rb_time_timespec()` and `rb_time_timeval()` raising for a time before the epoch on 32 bit systems, which `oj_dump_time()` still describes and still avoids by checking `sizeof(struct timespec)`:

```c
// rb_time_timespec as well as rb_time_timeeval have a bug that causes an
// exception to be raised if a time is before 1970 on 32 bit systems so
// check the timespec size and use the ruby calls if a 32 bit system.
if (16 <= sizeof(struct timespec)) {
```

Neither path calls a libc time function: dump uses `rb_time_timespec()` with `Time#utc_offset` and `Time#utc?`, load passes a fixed offset to `rb_time_timespec_new()`, and `sec_as_time()` is integer arithmetic. On a 64 bit Ruby the 32 bit branch is not taken and there is nothing left for the tests to avoid.

Checked on Windows 11 with ruby 3.3.12 (x64-mingw-ucrt) in JST, where both tests pass:

```
--- test_object.rb#test_time_early ---
dump   = {"^t":-504469372.876543212e-28800}
loaded = 1954-01-05 21:37:07.123456788 -0800
  tv_sec -504469373, tv_nsec 123456788, utc? false, utc_offset -28800   all match

--- test_file.rb#test_time_object_early ---
file   = {"^t":-504608399.876544000e32400}
loaded = 1954-01-05 00:00:00.123456 +0900
  tv_sec -504608400, tv_nsec 123456000, utc? false, utc_offset 32400    all match
```

A sweep of seven dates, each built as UTC, at an explicit -08:00 offset and in the local zone, round trips `tv_sec`, `tv_nsec`, `utc?` and `utc_offset` for all 21 combinations:

| date | utc | offset | local |
| --- | --- | --- | --- |
| 1854-01-05 | PASS | PASS | PASS |
| 1900-01-01 | PASS | PASS | PASS |
| 1954-01-05 | PASS | PASS | PASS |
| 1969-12-31 | PASS | PASS | PASS |
| 1970-01-01 | PASS | PASS | PASS |
| 1970-01-02 | PASS | PASS | PASS |
| 2026-07-31 | PASS | PASS | PASS |

The local zone cases are the ones the skips could still plausibly have been protecting, since the Windows CRT carries no historical timezone data, and a negative epoch second keeps its +32400 offset there.

Pre-epoch times were already covered on Windows without a skip elsewhere: `test_various.rb`'s `test_time_neg` and `test_time_years`, and `test_wab.rb`'s `test_time_before_epoch` from #1088.

Both files pass in full on Windows: `test_object.rb` 92 runs / 1495 assertions, `test_file.rb` 26 runs / 76 assertions, no failures, errors or skips.