### PR TITLE
Fix an options hash Oj knows no key of detaching a Rails encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 3.17.6 - unreleased
+
+- Fixed the encoder ActiveSupport 8.1 caches with `escape: false` freezing the options as they stood before `set_encoder` wrote `time_precision` into them, so `to_json(escape: false)` emitted 9 fractional digits. An options hash that names no option Oj knows no longer detaches an encoder from the defaults. (#1092)
+
 ## 3.17.5 - 2026-07-31
 
 Most of this release comes out of a security review of the C extension. There are no API changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.17.6 - unreleased
 
-- Fixed the encoder ActiveSupport 8.1 caches with `escape: false` freezing the options as they stood before `set_encoder` wrote `time_precision` into them, so `to_json(escape: false)` emitted 9 fractional digits. An options hash that names no option Oj knows no longer detaches an encoder from the defaults. (#1092)
+- Fixed issue #1092, where the encoder ActiveSupport 8.1 caches with `escape: false` froze the options as they stood before `set_encoder` wrote `time_precision` into them, so `to_json(escape: false)` emitted 9 fractional digits. An options hash that names no option Oj knows no longer detaches an encoder from the defaults. (#1093)
 
 ## 3.17.5 - 2026-07-31
 

--- a/ext/oj/oj.c
+++ b/ext/oj/oj.c
@@ -836,12 +836,14 @@ static const char *make_only_value(VALUE v) {
     return NULL;
 }
 
-static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
-    Options copts = (Options)opts;
-    size_t  len;
+// Apply one key and value to copts. Returns true if the key named an option Oj
+// knows and false if it did not. An unrecognized key is still ignored rather
+// than an error; the return only lets a caller tell the two cases apart.
+static bool parse_one_option(VALUE k, VALUE v, Options copts) {
+    size_t len;
 
     if (set_yesno_options(k, v, copts)) {
-        return ST_CONTINUE;
+        return true;
     }
     if (oj_indent_sym == k) {
         switch (rb_type(v)) {
@@ -967,7 +969,7 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
         }
     } else if (bigdecimal_load_sym == k) {
         if (Qnil == v) {
-            return ST_CONTINUE;
+            return true;
         }
 
         if (bigdecimal_sym == v || Qtrue == v) {
@@ -983,7 +985,7 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
         }
     } else if (compat_bigdecimal_sym == k) {
         if (Qnil == v) {
-            return ST_CONTINUE;
+            return true;
         }
         copts->compat_bigdec = (Qtrue == v);
     } else if (oj_decimal_class_sym == k) {
@@ -1078,7 +1080,7 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
         }
     } else if (nan_sym == k) {
         if (Qnil == v) {
-            return ST_CONTINUE;
+            return true;
         }
         if (null_sym == v) {
             copts->dump_opts.nan_dump = NullNan;
@@ -1095,7 +1097,7 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
         }
     } else if (omit_nil_sym == k) {
         if (Qnil == v) {
-            return ST_CONTINUE;
+            return true;
         }
         if (Qtrue == v) {
             copts->dump_opts.omit_nil = true;
@@ -1106,7 +1108,7 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
         }
     } else if (omit_null_byte_sym == k) {
         if (Qnil == v) {
-            return ST_CONTINUE;
+            return true;
         }
         if (Qtrue == v) {
             copts->dump_opts.omit_null_byte = true;
@@ -1167,7 +1169,7 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
         }
     } else if (integer_range_sym == k) {
         if (Qnil == v) {
-            return ST_CONTINUE;
+            return true;
         }
         if (rb_obj_class(v) == rb_cRange) {
             VALUE min = rb_funcall(v, oj_begin_id, 0);
@@ -1198,7 +1200,7 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
         }
     } else if (symbol_keys_sym == k || oj_symbolize_names_sym == k) {
         if (Qnil == v) {
-            return ST_CONTINUE;
+            return true;
         }
         copts->sym_key = (Qtrue == v) ? Yes : No;
 
@@ -1233,21 +1235,51 @@ static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
             OJ_R_FREE((void *)copts->dump_opts.except);
         }
         copts->dump_opts.except = make_only_value(v);
+    } else {
+        return false;
+    }
+    return true;
+}
+
+// Collects the return of parse_one_option() over every key in a hash.
+struct _optsParse {
+    Options copts;
+    bool    consumed;
+};
+
+static int parse_options_cb(VALUE k, VALUE v, VALUE opts) {
+    struct _optsParse *op = (struct _optsParse *)opts;
+
+    if (parse_one_option(k, v, op->copts)) {
+        op->consumed = true;
     }
     return ST_CONTINUE;
 }
 
-void oj_parse_options(VALUE ropts, Options copts) {
+// Apply the options in ropts to copts and report whether any key was
+// recognized. A hash of nothing but unknown keys leaves copts untouched and
+// returns false.
+bool oj_parse_options_consumed(VALUE ropts, Options copts) {
+    struct _optsParse op = {copts, false};
+
     if (T_HASH != rb_type(ropts)) {
-        return;
+        return false;
     }
-    rb_hash_foreach(ropts, parse_options_cb, (VALUE)copts);
+    rb_hash_foreach(ropts, parse_options_cb, (VALUE)&op);
+    if (Qnil != rb_hash_lookup(ropts, match_string_sym)) {
+        op.consumed = true;
+    }
     oj_parse_opt_match_string(&copts->str_rx, ropts);
 
     copts->dump_opts.use = (0 < copts->dump_opts.indent_size || 0 < copts->dump_opts.after_size ||
                             0 < copts->dump_opts.before_size || 0 < copts->dump_opts.hash_size ||
                             0 < copts->dump_opts.array_size);
-    return;
+
+    return op.consumed;
+}
+
+void oj_parse_options(VALUE ropts, Options copts) {
+    oj_parse_options_consumed(ropts, copts);
 }
 
 // Free the option buffers that oj_parse_options() allocated for a single call.

--- a/ext/oj/oj.h
+++ b/ext/oj/oj.h
@@ -257,6 +257,7 @@ extern VALUE oj_custom_parse_cstr(int argc, VALUE *argv, char *json, size_t len)
 
 extern bool oj_hash_has_key(VALUE hash, VALUE key);
 extern void oj_parse_options(VALUE ropts, Options copts);
+extern bool oj_parse_options_consumed(VALUE ropts, Options copts);
 extern void oj_free_call_options(Options copts);
 extern void oj_options_take_ownership(Options copts);
 extern void oj_options_release(Options copts);

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -765,11 +765,15 @@ static VALUE encoder_new(int argc, VALUE *argv, VALUE self) {
         e->arg = rb_hash_new();
     }
     // An encoder given no options of its own reads oj_default_options at encode
-    // time rather than copying it here. ActiveSupport keeps one option-less
-    // encoder for the life of the process, so a copy taken now would freeze
-    // every later Oj.default_options and ActiveSupport::JSON::Encoding change
-    // out of it - including the time_precision that set_encoder itself writes
-    // after ActiveSupport has already built and cached that encoder.
+    // time rather than copying it here. ActiveSupport keeps such an encoder for
+    // the life of the process, so a copy taken now would freeze every later
+    // Oj.default_options and ActiveSupport::JSON::Encoding change out of it -
+    // including the time_precision that set_encoder itself writes after
+    // ActiveSupport has already built and cached that encoder.
+    //
+    // A hash counts as options only if at least one key names an option Oj
+    // knows. Non-empty is not enough: ActiveSupport 8.1 caches a second encoder
+    // built with {escape: false}, a key Oj has never had.
     e->own_opts = T_HASH == rb_type(e->arg) && 0 < RHASH_SIZE(e->arg);
     if (e->own_opts) {
         e->opts = oj_default_options;
@@ -778,9 +782,13 @@ static VALUE encoder_new(int argc, VALUE *argv, VALUE self) {
         // its own that is freed with the encoder.
         e->opts.str_rx.head = NULL;
         e->opts.str_rx.tail = NULL;
-        oj_parse_options(e->arg, &e->opts);
+        e->own_opts         = oj_parse_options_consumed(e->arg, &e->opts);
+    }
+    if (e->own_opts) {
         oj_options_take_ownership(&e->opts);
     } else {
+        // Nothing to free: every option that allocates is reached through a
+        // recognized key, and ownership is not taken until after that check.
         memset(&e->opts, 0, sizeof(e->opts));
     }
 

--- a/ext/oj/rails.c
+++ b/ext/oj/rails.c
@@ -1184,8 +1184,6 @@ static VALUE rails_set_encoder(VALUE self) {
     } else {
         rb_raise(rb_eStandardError, "ActiveSupport not loaded.");
     }
-    rb_funcall(active, rb_intern("json_encoder="), 1, encoder_class);
-
     json     = rb_const_get_at(active, rb_intern("JSON"));
     encoding = rb_const_get_at(json, rb_intern("Encoding"));
 
@@ -1211,6 +1209,12 @@ static VALUE rails_set_encoder(VALUE self) {
     rb_undef_method(encoding, "time_precision=");
     rb_define_module_function(encoding, "time_precision=", rails_time_precision, 1);
     rb_gv_set("$VERBOSE", verbose);
+
+    // Last, because ActiveSupport builds and caches encoders inside
+    // json_encoder= and they should see the settings above already in the
+    // defaults. escape_html and xml_time are read ahead of it for the same
+    // reason.
+    rb_funcall(active, rb_intern("json_encoder="), 1, encoder_class);
 
     return Qnil;
 }

--- a/pages/Rails.md
+++ b/pages/Rails.md
@@ -91,6 +91,10 @@ The classes that can be put in optimized mode and are optimized when
 
 Both `Oj::Rails` and each `Oj::Rails::Encoder` have `optimize()`, `deoptimize()`, and `optimized?()` methods. The module level methods change the setting for the whole process. An encoder follows those process wide settings until `optimize()` or `deoptimize()` is called on the encoder itself. From then on the encoder keeps a set of its own and later module level changes do not reach it.
 
+Options work the same way. An encoder reads `Oj.default_options` when it encodes, so later changes to the defaults reach it, unless it was given options of its own, in which case it keeps the copy it took when it was created. An encoder counts as having options of its own only if the hash it was built with names at least one option Oj knows. A hash of nothing but keys Oj does not have, such as the `escape: false` ActiveSupport 8.1 builds one of its cached encoders with, leaves the encoder on the defaults.
+
+Once a class is optimized its `as_json()` method is no longer called, so an application that defines its own `as_json()` on an optimized class, `BigDecimal` for example, will not see it used. Call `Oj::Rails.deoptimize(BigDecimal)` after `Oj.optimize_rails` to put that one class back on the `as_json()` path and leave the rest optimized.
+
 The ActiveSupport decoder is the `JSON.parse()` method. Calling the
 `Oj::Rails.set_decoder()` method replaces that method with the Oj equivalent.
 

--- a/test/activesupport8.1/encoding_test.rb
+++ b/test/activesupport8.1/encoding_test.rb
@@ -40,6 +40,26 @@ class TestJSONEncoding < ActiveSupport::TestCase
     Oj.default_options = {bigdecimal_as_decimal: prev}
   end
 
+  # #1092. ActiveSupport 8.1 caches a second encoder next to that one, built
+  # with {escape: false}. The hash is not empty but names no option Oj has, and
+  # taking it for options of its own detached that encoder from the defaults,
+  # freezing them as they stood before set_encoder wrote time_precision into
+  # them. Timestamps then came out with 9 fractional digits on the escape: false
+  # path and the configured precision on every other one.
+  def test_1092_escape_false_encoder_tracks_time_precision
+    with_standard_json_time_format(true) do
+      with_time_precision(3) do
+        assert_equal '{"time":"2000-01-01T00:00:00.000Z"}', {time: Time.utc(2000)}.to_json(escape: false)
+      end
+
+      # Both cached encoders follow a later change, so they stay in step.
+      with_time_precision(0) do
+        payload = {time: Time.utc(2000)}
+        assert_equal payload.to_json, payload.to_json(escape: false)
+      end
+    end
+  end
+
   def sorted_json(json)
     if json.start_with?("{") && json.end_with?("}")
       "{" + json[1..-2].split(",").sort.join(",") + "}"

--- a/test/test_rails.rb
+++ b/test/test_rails.rb
@@ -295,6 +295,55 @@ class RailsJuice < Minitest::Test
     Oj.default_options = orig
   end
 
+  # Only a hash that names at least one option Oj knows counts as options of its
+  # own. ActiveSupport 8.1 caches an encoder built with {escape: false}, a key Oj
+  # has never had, and treating that as options froze the defaults as they were
+  # before set_encoder wrote time_precision into them.
+  def test_encoder_with_no_known_options_follows_later_default_options
+    orig = Oj.default_options
+    e = Oj::Rails::Encoder.new(escape: false)
+    Oj.default_options = {indent: 2}
+
+    assert_equal(%|{\n  "a":1\n}\n|, e.encode({'a' => 1}))
+  ensure
+    Oj.default_options = orig
+  end
+
+  def test_encoder_with_no_known_options_follows_a_later_global_optimize
+    e = Oj::Rails::Encoder.new(escape: false)
+    Oj::Rails.optimize(Range)
+
+    assert(e.optimized?(Range))
+  ensure
+    Oj::Rails.deoptimize(Range)
+  end
+
+  # The same pair for :second_precision, which is what time_precision= writes and
+  # so the option #1092 saw frozen at 9 digits.
+  def test_encoder_with_no_known_options_follows_a_later_second_precision
+    orig = Oj.default_options
+    Oj::Rails.optimize(Time)
+    e = Oj::Rails::Encoder.new(escape: false)
+    Oj.default_options = {second_precision: 3}
+
+    assert_equal('"2026-08-01T15:00:00.000Z"', e.encode(Time.utc(2026, 8, 1, 15)))
+  ensure
+    Oj::Rails.deoptimize(Time)
+    Oj.default_options = orig
+  end
+
+  def test_encoder_with_a_known_option_keeps_its_own_second_precision
+    orig = Oj.default_options
+    Oj::Rails.optimize(Time)
+    e = Oj::Rails::Encoder.new(second_precision: 6)
+    Oj.default_options = {second_precision: 3}
+
+    assert_equal('"2026-08-01T15:00:00.000000Z"', e.encode(Time.utc(2026, 8, 1, 15)))
+  ensure
+    Oj::Rails.deoptimize(Time)
+    Oj.default_options = orig
+  end
+
   # A String :indent forces the numeric one to zero, but dump_array sized the
   # closing indent from the numeric one, so a deeply nested array wrote past
   # the end of the output buffer.


### PR DESCRIPTION

## Problem

Reported in #1092. With `Oj.optimize_rails` and ActiveSupport 8.1, `to_json(escape: false)` dumps timestamps with 9 fractional digits while every other path uses the configured `ActiveSupport::JSON::Encoding.time_precision`.

ActiveSupport 8.1 caches two encoders inside `json_encoder=`:

```ruby
@encoder_without_options = encoder.new
@encoder_without_escape  = encoder.new(escape: false)
```

`encoder_new()` took a non-empty options hash as reason enough to snapshot `oj_default_options` into the encoder, and `rails_set_encoder()` calls `json_encoder=` before it writes `time_precision` into those defaults. So the `escape: false` encoder froze `sec_prec` at 9, while the option-less one, made lazy in #1049, went on reading the live defaults. Both read the same optimized class table after #1049, so the frozen one dumped optimized timestamps at the stale precision rather than falling back to ActiveSupport's own encoding.

Oj has never had an `:escape` option. `parse_options_cb()` ignores a key it does not recognize, so the only effect `{escape: false}` ever had on an Oj encoder was to detach it from the defaults. Rails mode escaping is decided by the process wide flag `escape_html_entities_in_json` writes.

## Change

`parse_options_cb()`'s key chain moves into `parse_one_option()`, which returns whether the key named an option Oj knows, and `oj_parse_options_consumed()` reports whether any key in a hash did. `encoder_new()` keeps the copy of the defaults only when that is true and discards it otherwise.

Nothing leaks on the discard path: every option that allocates into the copy - `create_id`, `ignore`, `only`, `except`, `match_string` - is reached through a key that makes `oj_parse_options_consumed()` return true, and `oj_options_take_ownership()` is deferred until after the answer is in.

A second commit moves the `use_standard_json_time_format` / `escape_html_entities_in_json` / `time_precision` block in `rails_set_encoder()` ahead of the `json_encoder=` call, so anything ActiveSupport caches in there sees settings that are already in the defaults. `escape_html` and `xml_time` were already read ahead of it. With the first commit in place neither cached encoder takes a copy, so this changes nothing observable today; it matters again the moment ActiveSupport caches an encoder built with options Oj does know.

## Behavior change

An options hash that names no option Oj knows no longer detaches an encoder from the defaults. Such an encoder now follows later `Oj.default_options` and `ActiveSupport::JSON::Encoding` changes, the way an encoder built with no options at all does.

`oj_parse_options()` keeps its signature and its behavior. An unrecognized key is still silently ignored rather than an error.

## Before and after

`repro_1092.rb`, run as `BUNDLE_GEMFILE=gemfiles/rails_8.1.gemfile bundle exec ruby -Ilib repro_1092.rb`:

```ruby
require "active_support"
require "active_support/json"
require "bigdecimal"
require "oj"

class BigDecimal
  def as_json(*) = to_f
end

ActiveSupport::JSON::Encoding.time_precision = 3
Oj.optimize_rails

payload = { time: Time.utc(2026, 8, 1, 15), decimal: BigDecimal("55.799489") }
puts Oj::VERSION
puts payload.to_json
puts payload.to_json(escape: false)
```

Before:

```
3.17.5
{"time":"2026-08-01T15:00:00.000Z","decimal":"55.799489"}
{"time":"2026-08-01T15:00:00.000000000Z","decimal":"55.799489"}
```

After:

```
3.17.5
{"time":"2026-08-01T15:00:00.000Z","decimal":"55.799489"}
{"time":"2026-08-01T15:00:00.000Z","decimal":"55.799489"}
```

The `decimal` being a String is the intended behavior of #985 and is not touched here. #1092 also reports it as a regression; the answer is in the issue.

## Tests

`test/test_rails.rb` gets four instance level tests next to the ones #1049 added. An encoder built with `escape: false` follows a later `Oj.default_options` change, both for `:indent` and for `:second_precision`, and follows a later module level `Oj::Rails.optimize`. An encoder built with `second_precision: 6` still keeps the copy it took, which pins the existing semantics for a hash that does name an option.

`test/activesupport8.1/encoding_test.rb` gets `test_1092_escape_false_encoder_tracks_time_precision`, next to the #985 test #1051 added. It asserts the fractional digits `to_json(escape: false)` produces under `time_precision 3`, and that the two cached encoders stay in step across a later change.

Both new C paths were checked to fail before the change: the ActiveSupport test and the two `escape: false` default-following tests fail on `develop` with the C changes stashed.

`ruby test/tests.rb` is 574 runs 0 failures. The ActiveSupport 7.2, 8.0 and 8.1 suites are 0 failures with the same skip counts as `develop`. `rake test:valgrind` is 697 runs 0 failures with no leaks and no invalid access reported.

The vendored `:escape` and `escape_js_separators_in_json` skips stay skipped. Oj still has no `:escape` option and this does not add one.

## Docs

`pages/Rails.md` gets the rule that only a hash naming an option Oj knows counts as options of its own, next to the paragraph #1049 added about the optimization table, and a paragraph on `as_json` not being called for an optimized class with `Oj::Rails.deoptimize(Klass)` as the per class way out.

`CHANGELOG.md` gets a `3.17.6 - unreleased` section.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
